### PR TITLE
Add skip support

### DIFF
--- a/flyway-ant-largetest/src/test/java/com/googlecode/flyway/ant/AntLargeTest.java
+++ b/flyway-ant-largetest/src/test/java/com/googlecode/flyway/ant/AntLargeTest.java
@@ -95,14 +95,6 @@ public abstract class AntLargeTest {
     protected String runAnt(int expectedReturnCode, String dir, String... extraArgs) throws Exception {
         String antHome = System.getenv("ANT_HOME");
 
-        if (antHome == null) {
-            // On a typical Linux system, Ant is installed to /usr/bin
-            // using a package management system, and setting ANT_HOME to /usr
-            // breaks lots of things. So, if ANT_HOME is null, we'll try /usr directory
-            // here without touching the ANT_HOME.
-            antHome = "/usr";
-        }
-        
         String extension = "";
         if (System.getProperty("os.name").startsWith("Windows")) {
             extension = ".bat";

--- a/flyway-maven-plugin-largetest/src/test/java/com/googlecode/flyway/maven/largetest/MavenLargeTest.java
+++ b/flyway-maven-plugin-largetest/src/test/java/com/googlecode/flyway/maven/largetest/MavenLargeTest.java
@@ -97,14 +97,6 @@ public class MavenLargeTest {
         String m2Home = System.getenv("M2_HOME");
         String flywayVersion = System.getProperty("flywayVersion", getPomVersion());
 
-        if (m2Home == null) {
-            // On a typical Linux system, Maven is installed to /usr/bin
-            // using a package management system, and setting M2_HOME to /usr
-            // breaks lots of things. So, if M2_HOME is null, we'll try /usr directory
-            // here without touching the M2_HOME.
-            m2Home = "/usr";
-        }
-        
         String extension = "";
         if (System.getProperty("os.name").startsWith("Windows")) {
             extension = ".bat";


### PR DESCRIPTION
Added support for skip flag in the plug-in configuration to skip the execution of the plug-in in multi-module projects, where we typically want to configure the plug-in in the root level, but skip the execution by default so that only one sub-module executes the plug-in only once.
