### PR TITLE
Fix: missing location for db.migration

### DIFF
--- a/flyway-sample/src/main/java/com/googlecode/flyway/sample/Main.java
+++ b/flyway-sample/src/main/java/com/googlecode/flyway/sample/Main.java
@@ -37,7 +37,7 @@ public class Main {
                 new SimpleDriverDataSource(new org.hsqldb.jdbcDriver(), "jdbc:hsqldb:file:db/flyway_sample;shutdown=true", "SA", "");
         Flyway flyway = new Flyway();
         flyway.setDataSource(dataSource);
-        flyway.setLocations("com.googlecode.flyway.sample.migration");
+        flyway.setLocations("db.migration", "com.googlecode.flyway.sample.migration");
         flyway.migrate();
 
         SimpleJdbcTemplate jdbcTemplate = new SimpleJdbcTemplate(dataSource);


### PR DESCRIPTION
The flyway-sample project would fail running because the locations were overriden with the Java migration path, and the default db.migration path was missing. This fixes the issue.
