### PR TITLE
Consider colons as a token separator

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlStatementBuilder.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlStatementBuilder.java
@@ -262,7 +262,7 @@ public class SqlStatementBuilder {
      */
     protected boolean endsWithOpenMultilineStringLiteral(String line) {
         //Ignore all special characters that naturally occur in SQL, but are not opening or closing string literals
-        String[] tokens = StringUtils.tokenizeToStringArray(line, " <>;=|(),");
+        String[] tokens = StringUtils.tokenizeToStringArray(line, " <>;=|(),:");
 
         List<TokenType> delimitingTokens = extractStringLiteralDelimitingTokens(tokens);
 


### PR DESCRIPTION
I bumped into tokenization problems on PostgreSQL with statements of the form:
CREATE TABLE base_table (
    base_table_id integer DEFAULT nextval('base_table_seq'::regclass) NOT NULL
);
The parser considers "'base_table_seq'::regclass" to be a full token, but it should be considered as 2 tokens:
"'base_catalog_table_seq'" and "regclass"

Now I haven't tested this with other rdbms and I'm not sure this should be applied to all of them.
