### PR TITLE
Fixed javadoc for core/dbSupport/SqlScript.java

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlScript.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlScript.java
@@ -48,7 +48,7 @@ public class SqlScript {
     /**
      * Creates a new sql script from this source with these placeholders to replace.
      *
-     * @param sqlScriptSource The sql script as a text block with all placeholders still present.
+     * @param sqlScriptSource The sql script as a text block with all placeholders already replaced.
      * @param dbSupport       The database-specific support.
      */
     public SqlScript(String sqlScriptSource, DbSupport dbSupport) {


### PR DESCRIPTION
As seen in com.googlecode.flyway.core.resolver.sql.PlaceholderReplacer, line [62](https://github.com/flyway/flyway/blob/master/flyway-core/src/main/java/com/googlecode/flyway/core/resolver/sql/SqlMigrationExecutor.java#L62), the placeholders are already replaced when calling SqlScript's constructor.
