### PR TITLE
NumberFormatException with file names like V1..1__desc.sql

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/api/MigrationVersion.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/api/MigrationVersion.java
@@ -102,9 +102,7 @@ public final class MigrationVersion implements Comparable<MigrationVersion> {
 
     @Override
     public int hashCode() {
-        int result = version != null ? version.hashCode() : 0;
-        result = 31 * result + displayText.hashCode();
-        return result;
+        return version == null ? 0 : version.hashCode();
     }
 
     public int compareTo(MigrationVersion o) {
@@ -162,6 +160,10 @@ public final class MigrationVersion implements Comparable<MigrationVersion> {
                     "Invalid version containing non-numeric characters. Only 0..9 and . are allowed. Invalid version: "
                     + str);
             }
+        }
+        for (int i = numbers.size() - 1; i > 0; i--) {
+            if (numbers.get(i) != 0) break;
+            numbers.remove(i);
         }
         return numbers;
     }

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/api/MigrationVersionSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/api/MigrationVersionSmallTest.java
@@ -59,6 +59,7 @@ public class MigrationVersionSmallTest {
         final MigrationVersion a1 = new MigrationVersion("1.2.3.3");
         final MigrationVersion a2 = new MigrationVersion("1.2.3.3");
         assertTrue(a1.compareTo(a2) == 0);
+        assertEquals(a1.hashCode(), a2.hashCode());
     }
 
     @Test
@@ -88,6 +89,7 @@ public class MigrationVersionSmallTest {
         final MigrationVersion v2 = new MigrationVersion("001.0");
         assertTrue(v1.compareTo(v2) == 0);
         assertTrue(v1.equals(v2));
+        assertEquals(v1.hashCode(), v2.hashCode());
     }
 
     @Test
@@ -96,6 +98,7 @@ public class MigrationVersionSmallTest {
         final MigrationVersion v2 = new MigrationVersion("1");
         assertTrue(v1.compareTo(v2) == 0);
         assertTrue(v1.equals(v2));
+        assertEquals(v1.hashCode(), v2.hashCode());
     }
 
     @Test
@@ -116,6 +119,7 @@ public class MigrationVersionSmallTest {
         final MigrationVersion v2 = new MigrationVersion("0");
         assertTrue(v1.compareTo(v2) == 0);
         assertTrue(v1.equals(v2));
+        assertEquals(v1.hashCode(), v2.hashCode());
     }
 
     @Test(expected = FlywayException.class)


### PR DESCRIPTION
Fixes https://github.com/flyway/flyway/issues/572

As part of the fix I also fixed the compareTo implementation for MigrationVersion.EMPTY and MigrationVersion.LATEST and simplified the code a bit.
