### PR TITLE
init metadatatable, when schema has existed.

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/command/DbSchemas.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/command/DbSchemas.java
@@ -67,13 +67,13 @@ public class DbSchemas {
                 for (Schema schema : schemas) {
                     if (schema.exists()) {
                         LOG.debug("Schema " + schema + " already exists. Skipping schema creation.");
-                        return null;
+                        if (!schema.empty()) {
+                            return null;
+                        }
+                    } else {
+                        LOG.info("Creating schema " + schema + " ...");
+                        schema.create();
                     }
-                }
-
-                for (Schema schema : schemas) {
-                    LOG.info("Creating schema " + schema + " ...");
-                    schema.create();
                 }
 
                 metaDataTable.addSchemasMarker(schemas);


### PR DESCRIPTION
I used hsqldb for demostration.
But initOnMigrate=true option only create metadataTable, it didn't insert init version record.

I did some dig, and found out that, if the schema existed, the flyway won't insert the init version record. actually, the DbSchema.create() didn't create metadataTable either. The metadataTable is created in migrate step.

So I think the normal flow is:
1. check schema existed,
2. check schema is empty.

if both of conditions is true, don't return null immediatelly, just skip create and continue to create metadataTable and insert init version record.

Please review.  Thank you very much. :)
