### PR TITLE
Fixed improper handling of escaped backslaches

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
@@ -60,7 +60,8 @@ public class MySQLSqlStatementBuilder extends SqlStatementBuilder {
 
     @Override
     protected String removeEscapedQuotes(String token) {
-        String noBackslashEscapes = StringUtils.replaceAll(StringUtils.replaceAll(token, "\\'", ""), "\\\"", "");
+        String noEscapedBackslashes = StringUtils.replaceAll(token, "\\\\","");
+        String noBackslashEscapes = StringUtils.replaceAll(StringUtils.replaceAll(noEscapedBackslashes, "\\'", ""), "\\\"", "");
         return StringUtils.replaceAll(noBackslashEscapes, "''", "");
     }
 

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
@@ -70,4 +70,11 @@ public class MySQLSqlStatementBuilderSmallTest {
 
         assertTrue(builder.isTerminated());
     }
+
+    @Test
+    public void trailingEscapedBackSlash() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES ('\\\\');");
+
+        assertTrue(builder.isTerminated());
+    }
 }


### PR DESCRIPTION
Fix for Issue #594. Removed escaped backslashes from from token string prior to removing escaped quotes so as not to confuse flyway with situations were a string literal ends with an \'.

-- Also added test to `MySQLSqlStatementBuilderSmallTest` to test for improper termination of strings that end with \'
