### PR TITLE
Fixed parsing issue  for MySQL where strings ending in a [space]x|b'

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
@@ -69,10 +69,12 @@ public class MySQLSqlStatementBuilder extends SqlStatementBuilder {
         if (token.startsWith("\"")) {
             return "\"";
         }
-        if (token.startsWith("B'")) {
+        // to be a valid bitfield or hex literal the token must be at leas three characters in length
+        // i.e. b'' otherwise token may be string literal ending in [space]b'
+        if (token.startsWith("B'") && token.length() > 2) {
             return "B'";
         }
-        if (token.startsWith("X'")) {
+        if (token.startsWith("X'") && token.length() > 2) {
             return "X'";
         }
         return null;

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
@@ -58,6 +58,20 @@ public class MySQLSqlStatementBuilderSmallTest {
     }
 
     @Test
+    public void stringEndingInX() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES (' x');");
+
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void stringEndingInB() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES (' b');");
+
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
     public void hexLiteral() throws Exception {
         builder.addLine("INSERT INTO Tablename (id) VALUES (x'5B1A5933964C4AA59F3013D3B3F3414D');");
 


### PR DESCRIPTION
Fixed parsing issue  for MySQL where strings ending in a [space]x|b' were not being terminated properly by the MySQLSqlStatementBuilder (see issue #593). Checked to see if token's length was greater than 2. Any bit or hex literal should at the minimum have a length of three (i.e. b'' or x'') but the case where a string ends with a [space]x|b' (i.e. ' x') then the length is only two. This seemed like the easiest way to determine if the token was truly a bit/hex literal or the ending sequence of a string. I also added two tests to test for the [space]x|b' case being improperly terminated.
