### PR TITLE
Feature placeholder optional strict enforcement

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
@@ -106,6 +106,12 @@ public class Flyway {
     private Map<String, String> placeholders = new HashMap<String, String>();
 
     /**
+     * Sets strict enforcement of unmatched placeholder checks.
+     * If false Flyway will not throw error for unmatched placeholders found in sql
+     */
+    private boolean placeholderStrict = false;
+
+    /**
      * The prefix of every placeholder. (default: ${ )
      */
     private String placeholderPrefix = "${";
@@ -638,6 +644,15 @@ public class Flyway {
      *
      * @param placeholderPrefix The prefix of every placeholder. (default: ${ )
      */
+    public void setPlaceholderStrict(boolean placeholderStrict) {
+        this.placeholderStrict = placeholderStrict;
+    }
+
+    /**
+     * Sets the prefix of every placeholder.
+     *
+     * @param placeholderPrefix The prefix of every placeholder. (default: ${ )
+     */
     public void setPlaceholderPrefix(String placeholderPrefix) {
         this.placeholderPrefix = placeholderPrefix;
     }
@@ -1032,7 +1047,7 @@ public class Flyway {
      * @return A new, fully configured, MigrationResolver instance.
      */
     private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
-        return new CompositeMigrationResolver(dbSupport, locations, encoding, sqlMigrationPrefix, sqlMigrationSuffix, placeholders, placeholderPrefix, placeholderSuffix);
+        return new CompositeMigrationResolver(dbSupport, locations, encoding, sqlMigrationPrefix, sqlMigrationSuffix, placeholders, placeholderPrefix, placeholderSuffix, placeholderStrict);
     }
 
     /**
@@ -1058,6 +1073,10 @@ public class Flyway {
         String locationsProp = properties.getProperty("flyway.locations");
         if (locationsProp != null) {
             setLocations(StringUtils.tokenizeToStringArray(locationsProp, ","));
+        }
+        String placeholderStrictProp = properties.getProperty("flyway.placeholderStrict");
+        if (placeholderStrictProp != null) {
+            setPlaceholderStrict(new Boolean(placeholderStrictProp));
         }
         String placeholderPrefixProp = properties.getProperty("flyway.placeholderPrefix");
         if (placeholderPrefixProp != null) {

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
@@ -640,9 +640,9 @@ public class Flyway {
     }
 
     /**
-     * Sets the prefix of every placeholder.
+     * Sets strict validation on unmatched placeholders.
      *
-     * @param placeholderPrefix The prefix of every placeholder. (default: ${ )
+     * @param placeholderStrict The flag for checking unmatched placeholders. (default: false )
      */
     public void setPlaceholderStrict(boolean placeholderStrict) {
         this.placeholderStrict = placeholderStrict;

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
@@ -642,7 +642,7 @@ public class Flyway {
     /**
      * Sets strict validation on unmatched placeholders.
      *
-     * @param placeholderStrict The flag for checking unmatched placeholders. (default: false )
+     * @param placeholderStrict Flag for checking for unmatched placeholders. (default: false )
      */
     public void setPlaceholderStrict(boolean placeholderStrict) {
         this.placeholderStrict = placeholderStrict;

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableImpl.java
@@ -108,7 +108,7 @@ public class MetaDataTableImpl implements MetaDataTable {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", table.getSchema().getName());
         placeholders.put("table", table.getName());
-        final String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+        final String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}", true).replacePlaceholders(source);
 
         SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
         sqlScript.execute(jdbcTemplate);

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo202FormatUpgrader.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo202FormatUpgrader.java
@@ -92,7 +92,7 @@ public class MetaDataTableTo202FormatUpgrader {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", table.getSchema().getName());
         placeholders.put("table", table.getName());
-        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}", true).replacePlaceholders(source);
 
         SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
         sqlScript.execute(jdbcTemplate);

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo20FormatUpgrader.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo20FormatUpgrader.java
@@ -142,7 +142,7 @@ public class MetaDataTableTo20FormatUpgrader {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", table.getSchema().getName());
         placeholders.put("table", table.getName());
-        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}", true).replacePlaceholders(source);
 
         SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
         sqlScript.execute(jdbcTemplate);

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo21FormatUpgrader.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/metadatatable/MetaDataTableTo21FormatUpgrader.java
@@ -92,7 +92,7 @@ public class MetaDataTableTo21FormatUpgrader {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", table.getSchema().getName());
         placeholders.put("table", table.getName());
-        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+        String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}", true).replacePlaceholders(source);
 
         SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
         sqlScript.execute(jdbcTemplate);

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/resolver/CompositeMigrationResolver.java
@@ -80,6 +80,11 @@ public class CompositeMigrationResolver implements MigrationResolver {
     private final String placeholderSuffix;
 
     /**
+     * Flag for enforcing unmatched placeholder checking.
+     */
+    private final boolean placeholderStrict;
+
+    /**
      * The available migrations, sorted by version, newest first. An empty list is returned when no migrations can be
      * found.
      */
@@ -96,8 +101,9 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param placeholders       A map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
      * @param placeholderPrefix  The prefix of every placeholder.
      * @param placeholderSuffix  The suffix of every placeholder.
+     * @param placeholderStrict  Enforces unmatched placeholder checking.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, Locations locations, String encoding, String sqlMigrationPrefix, String sqlMigrationSuffix, Map<String, String> placeholders, String placeholderPrefix, String placeholderSuffix) {
+    public CompositeMigrationResolver(DbSupport dbSupport, Locations locations, String encoding, String sqlMigrationPrefix, String sqlMigrationSuffix, Map<String, String> placeholders, String placeholderPrefix, String placeholderSuffix, boolean placeholderStrict) {
         this.dbSupport = dbSupport;
         this.locations = locations;
         this.encoding = encoding;
@@ -106,6 +112,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
         this.placeholders = placeholders;
         this.placeholderPrefix = placeholderPrefix;
         this.placeholderSuffix = placeholderSuffix;
+        this.placeholderStrict = placeholderStrict;
     }
 
     /**
@@ -131,7 +138,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @throws FlywayException when the available migrations have overlapping versions.
      */
     private List<ResolvedMigration> doFindAvailableMigrations() throws FlywayException {
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, placeholderPrefix, placeholderSuffix);
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, placeholderPrefix, placeholderSuffix, placeholderStrict);
 
         Collection<MigrationResolver> migrationResolvers = new ArrayList<MigrationResolver>();
 

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
@@ -16,6 +16,8 @@
 package com.googlecode.flyway.core.util;
 
 import com.googlecode.flyway.core.api.FlywayException;
+import com.googlecode.flyway.core.util.logging.Log;
+import com.googlecode.flyway.core.util.logging.LogFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +30,8 @@ import java.util.regex.Pattern;
  * Tool for replacing placeholders.
  */
 public class PlaceholderReplacer {
+    private static final Log LOG = LogFactory.getLog(PlaceholderReplacer.class);
+
     /**
      * PlaceholderReplacer that doesn't replace any placeholders.
      */
@@ -59,20 +63,6 @@ public class PlaceholderReplacer {
      * @param placeholders      A map of <placeholder, replacementValue> to apply to sql migration scripts.
      * @param placeholderPrefix The prefix of every placeholder. Usually ${
      * @param placeholderSuffix The suffix of every placeholder. Usually }
-     */
-    public PlaceholderReplacer(Map<String, String> placeholders, String placeholderPrefix, String placeholderSuffix) {
-        this.placeholders = placeholders;
-        this.placeholderPrefix = placeholderPrefix;
-        this.placeholderSuffix = placeholderSuffix;
-        this.placeholderStrict = true; // default to true (this constructor primarily used in metadata impl classes)
-    }
-
-    /**
-     * Creates a new PlaceholderReplacer.
-     *
-     * @param placeholders      A map of <placeholder, replacementValue> to apply to sql migration scripts.
-     * @param placeholderPrefix The prefix of every placeholder. Usually ${
-     * @param placeholderSuffix The suffix of every placeholder. Usually }
      * @param placeholderStrict Enforce unmatched placeholder checks.
      */
     public PlaceholderReplacer(Map<String, String> placeholders, String placeholderPrefix, String placeholderSuffix, boolean placeholderStrict) {
@@ -95,10 +85,8 @@ public class PlaceholderReplacer {
             String searchTerm = placeholderPrefix + placeholder + placeholderSuffix;
             noPlaceholders = StringUtils.replaceAll(noPlaceholders, searchTerm, placeholders.get(placeholder));
         }
-        
-        if(placeholderStrict) {
-            checkForUnmatchedPlaceholderExpression(noPlaceholders);
-        }
+
+        checkForUnmatchedPlaceholderExpression(noPlaceholders);
         
         return noPlaceholders;
     }
@@ -120,9 +108,13 @@ public class PlaceholderReplacer {
         }
 
         if (!unmatchedPlaceHolderExpressions.isEmpty()) {
-            throw new FlywayException("No value provided for placeholder expressions: "
-                    + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions)
-                    + ".  Check your configuration!");
+            if(placeholderStrict) {
+                throw new FlywayException("No value provided for placeholder expressions: "
+                        + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions)
+                        + ".  Check your configuration!");
+            } else {
+                LOG.debug("Unmached placeholders found: " + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions));
+            }
         }
     }
 }

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
@@ -113,7 +113,7 @@ public class PlaceholderReplacer {
                         + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions)
                         + ".  Check your configuration!");
             } else {
-                LOG.debug("Unmached placeholders found: " + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions));
+                LOG.debug("Unmatched placeholders found: " + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions));
             }
         }
     }

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/util/PlaceholderReplacer.java
@@ -31,7 +31,12 @@ public class PlaceholderReplacer {
     /**
      * PlaceholderReplacer that doesn't replace any placeholders.
      */
-    public static final PlaceholderReplacer NO_PLACEHOLDERS = new PlaceholderReplacer(new HashMap<String, String>(), "", "");
+    public static final PlaceholderReplacer NO_PLACEHOLDERS = new PlaceholderReplacer(new HashMap<String, String>(), "", "", false);
+
+    /**
+     * Enforce check for unmatched placeholders.
+     */
+    private boolean placeholderStrict;
 
     /**
      * A map of <placeholder, replacementValue> to apply to sql migration scripts.
@@ -59,6 +64,22 @@ public class PlaceholderReplacer {
         this.placeholders = placeholders;
         this.placeholderPrefix = placeholderPrefix;
         this.placeholderSuffix = placeholderSuffix;
+        this.placeholderStrict = true; // default to true (this constructor primarily used in metadata impl classes)
+    }
+
+    /**
+     * Creates a new PlaceholderReplacer.
+     *
+     * @param placeholders      A map of <placeholder, replacementValue> to apply to sql migration scripts.
+     * @param placeholderPrefix The prefix of every placeholder. Usually ${
+     * @param placeholderSuffix The suffix of every placeholder. Usually }
+     * @param placeholderStrict Enforce unmatched placeholder checks.
+     */
+    public PlaceholderReplacer(Map<String, String> placeholders, String placeholderPrefix, String placeholderSuffix, boolean placeholderStrict) {
+        this.placeholders = placeholders;
+        this.placeholderPrefix = placeholderPrefix;
+        this.placeholderSuffix = placeholderSuffix;
+        this.placeholderStrict = placeholderStrict;
     }
 
     /**
@@ -74,8 +95,11 @@ public class PlaceholderReplacer {
             String searchTerm = placeholderPrefix + placeholder + placeholderSuffix;
             noPlaceholders = StringUtils.replaceAll(noPlaceholders, searchTerm, placeholders.get(placeholder));
         }
-        checkForUnmatchedPlaceholderExpression(noPlaceholders);
-
+        
+        if(placeholderStrict) {
+            checkForUnmatchedPlaceholderExpression(noPlaceholders);
+        }
+        
         return noPlaceholders;
     }
 

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/SqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/SqlScriptSmallTest.java
@@ -226,7 +226,7 @@ public class SqlScriptSmallTest {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("drop_view", "--");
         placeholders.put("or_replace", "OR REPLACE");
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", true);
 
         List<SqlStatement> sqlStatements = sqlScript.parse(placeholderReplacer.replacePlaceholders(source));
         assertNotNull(sqlStatements);

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/migration/MigrationTestCase.java
@@ -646,7 +646,7 @@ public abstract class MigrationTestCase {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", dbSupport.getCurrentSchema().getName());
         placeholders.put("table", flyway.getTable());
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", true);
 
         SqlScript sqlScript = new SqlScript(placeholderReplacer.replacePlaceholders(source), dbSupport);
         sqlScript.execute(jdbcTemplate);
@@ -667,7 +667,7 @@ public abstract class MigrationTestCase {
      * Upgrade a Flyway 1.7 format metadata table to the Flyway 2.0 format.
      */
     private void upgradeMetaDataTableTo20Format() throws Exception {
-        CompositeMigrationResolver migrationResolver = new CompositeMigrationResolver(dbSupport, new Locations(BASEDIR), "UTF-8", "V", ".sql", new HashMap<String, String>(), "${", "}");
+        CompositeMigrationResolver migrationResolver = new CompositeMigrationResolver(dbSupport, new Locations(BASEDIR), "UTF-8", "V", ".sql", new HashMap<String, String>(), "${", "}", true);
 
         MetaDataTableTo20FormatUpgrader upgrader = new MetaDataTableTo20FormatUpgrader(dbSupport, dbSupport.getCurrentSchema().getTable(flyway.getTable()), migrationResolver);
         upgrader.upgrade();

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/resolver/CompositeMigrationResolverSmallTest.java
@@ -37,7 +37,7 @@ public class CompositeMigrationResolverSmallTest {
     public void resolveMigrationsMultipleLocations() {
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", ".sql", new HashMap<String, String>(), "${", "}");
+                "UTF-8", "V", ".sql", new HashMap<String, String>(), "${", "}", true);
 
         List<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/util/PlaceholderReplacerSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/util/PlaceholderReplacerSmallTest.java
@@ -45,7 +45,7 @@ public class PlaceholderReplacerSmallTest {
         placeholders.put("placeholder", "value");
         placeholders.put("replace", "be replaced");
         placeholders.put("dummy", "shouldNotAppear");
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", true);
 
         assertEquals("No value #[left] to be replaced", placeholderReplacer.replacePlaceholders(TEST_STR));
     }
@@ -54,28 +54,52 @@ public class PlaceholderReplacerSmallTest {
     public void exoticPlaceholders() {
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("left", "right");
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "#[", "]");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "#[", "]", true);
 
         assertEquals("No ${placeholder} right to ${replace}", placeholderReplacer.replacePlaceholders(TEST_STR));
     }
 
+    @Test
+    public void unmatchedPlaceholdersNotStrict() {
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put("placeholder", "value");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", false);
 
+        assertEquals("No value #[left] to ${replace}", placeholderReplacer.replacePlaceholders(TEST_STR));
+    }
 
     @Test
-    public void unmatchedPlaceholders() throws FlywayException {
+    public void unmatchedPlaceholdersStrict() throws FlywayException {
         thrown.expect(FlywayException.class);
         thrown.expectMessage("No value provided for placeholder expressions: #[left].  Check your configuration!");
         Map<String, String> placeholders = new HashMap<String, String>();
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "#[", "]");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "#[", "]", true);
         placeholderReplacer.replacePlaceholders(TEST_STR);
     }
 
     @Test
-    public void unmatchedPlaceholdersWithMultipleOccurences() throws FlywayException {
+    public void unmatchedPlaceholdersWithMultipleOccurencesNotStrict() {
+        Map<String, String> placeholders = new HashMap<String, String>();
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", false);
+
+        assertEquals("No ${placeholder} #[left] to ${replace}", placeholderReplacer.replacePlaceholders(TEST_STR));
+    }
+
+    @Test
+    public void unmatchedPlaceholdersWithMultipleOccurencesStrict() throws FlywayException {
         thrown.expect(FlywayException.class);
         thrown.expectMessage("No value provided for placeholder expressions: ${placeholder}, ${replace}.  Check your configuration!");
         Map<String, String> placeholders = new HashMap<String, String>();
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", true);
         placeholderReplacer.replacePlaceholders(TEST_STR + TEST_STR);
+    }
+
+    @Test
+    public void mixedUnmatchedPlaceholdersWithPlaceholdersNotStrict() {
+        Map<String, String> placeholders = new HashMap<String, String>();
+        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}", false);
+        placeholders.put("placeholder", "value");
+
+        assertEquals("No value #[left] to ${replace}", placeholderReplacer.replacePlaceholders(TEST_STR));
     }
 }


### PR DESCRIPTION
I have added the property `flyway.placeholderStrict` which tells flyway to enforce the unmatched placeholders exception or not.

We have several situations where we want to replace some placeholders but not others, this can change depending on the test environment we set up (sometimes other systems change the placeholders upstream or down stream). I saw a few other posts on unmatched placeholder exceptions in the forums and thought this may be a good approach to addressing the issue.

Note that the default is set to false which is not the current default behavior of Flyway but I think it fits better with the most general use case.

Look forward to your thoughts.
