### PR TITLE
fix problem of running command line under cygwin 

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -43,7 +43,11 @@ else
 fi
 
 # Detect the width of the console
-CONSOLE_WIDTH=`tput cols`
+if command -v tput 2>/dev/null; then
+	CONSOLE_WIDTH=`tput cols`
+else
+	CONSOLE_WIDTH=80
+fi
 
 "$JAVA_CMD" -cp ./bin/flyway-commandline-${project.version}.jar:./bin/flyway-core-${project.version}.jar com.googlecode.flyway.commandline.Main $@ -consoleWidth=$CONSOLE_WIDTH
 


### PR DESCRIPTION
cygwin is complaining about paths and it requires . as current path
additionally I fixed problem when JAVA_HOME has some spaces.

I made also conditional call of tput so it does not complain on cygwin when it is missing

It solves issue https://github.com/flyway/flyway/issues/562
