### PR TITLE
Fix for issue #456. 

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlStatementBuilder.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/SqlStatementBuilder.java
@@ -301,7 +301,7 @@ public class SqlStatementBuilder {
     private List<TokenType> extractStringLiteralDelimitingTokens(String[] tokens) {
         List<TokenType> delimitingTokens = new ArrayList<TokenType>();
         for (String token : tokens) {
-            String cleanToken = removeEscapedQuotes(token);
+            String cleanToken = removeCharsetCasting(removeEscapedQuotes(token));
 
             if (alternateQuote == null) {
                 String alternateQuoteFromToken = extractAlternateOpenQuote(cleanToken);
@@ -354,6 +354,16 @@ public class SqlStatementBuilder {
      */
     protected String removeEscapedQuotes(String token) {
         return StringUtils.replaceAll(token, "''", "");
+    }
+
+    /**
+     * Removes charset casting that prefixes string literals.
+     * Must be implemented in dialect specific sub classes.
+     * @param token The token to parse.
+     * @return The cleaned token.
+     */
+    protected String removeCharsetCasting(String token) {
+        return token;
     }
 
     /**

--- a/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilder.java
@@ -29,6 +29,11 @@ public class MySQLSqlStatementBuilder extends SqlStatementBuilder {
      * The keyword that indicates a change in delimiter.
      */
     private static final String DELIMITER_KEYWORD = "DELIMITER";
+    private final String[] charSets = {
+            "ARMSCII8","ASCII","BIG5","BINARY","CP1250","CP1251","CP1256","CP1257","CP850","CP852","CP866","CP932",
+            "DEC8","EUCJPMS","EUCKR","GB2312","GBK","GEOSTD8","GREEK","HEBREW","HP8","KEYBCS2","KOI8R","KOI8U","LATIN1",
+            "LATIN2","LATIN5","LATIN7","MACCE","MACROMAN","SJIS","SWE7","TIS620","UCS2","UJIS","UTF8"
+    };
 
     @Override
     public Delimiter extractNewDelimiterFromLine(String line) {
@@ -63,6 +68,20 @@ public class MySQLSqlStatementBuilder extends SqlStatementBuilder {
         String noEscapedBackslashes = StringUtils.replaceAll(token, "\\\\","");
         String noBackslashEscapes = StringUtils.replaceAll(StringUtils.replaceAll(noEscapedBackslashes, "\\'", ""), "\\\"", "");
         return StringUtils.replaceAll(noBackslashEscapes, "''", "");
+    }
+
+    @Override
+    protected String removeCharsetCasting(String token) {
+        if(token.startsWith("_")) {
+            for(String charSet: charSets) {
+                String cast = "_" + charSet;
+                if(token.startsWith(cast)) {
+                    return token.substring(cast.length());
+                }
+            }
+        }
+        // If now matches are found for charset casting then return token
+        return token;
     }
 
     @Override

--- a/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/com/googlecode/flyway/core/dbsupport/mysql/MySQLSqlStatementBuilderSmallTest.java
@@ -72,6 +72,27 @@ public class MySQLSqlStatementBuilderSmallTest {
     }
 
     @Test
+    public void charsetCastedString() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES (_utf8'hello');");
+
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void charsetCastedComplexString() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES (_utf8'text with spaces and \" and pretend casts _utf8\\'hello\\' here _utf8');");
+
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void stringEndingInCastPrefix() throws Exception {
+        builder.addLine("INSERT INTO Tablename (id) VALUES ('text goes here _utf8');");
+
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
     public void hexLiteral() throws Exception {
         builder.addLine("INSERT INTO Tablename (id) VALUES (x'5B1A5933964C4AA59F3013D3B3F3414D');");
 

--- a/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1.1__Add_function.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1.1__Add_function.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2010-2013 Axel Fontaine and the many contributors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 CREATE FUNCTION CHECK_AGE( @AGE INT ) RETURNS bigint
 AS
 BEGIN

--- a/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1.2__Chech_constraint_addition.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1.2__Chech_constraint_addition.sql
@@ -1,2 +1,18 @@
+--
+-- Copyright 2010-2013 Axel Fontaine and the many contributors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 ALTER TABLE
     USERS ADD CONSTRAINT NO_OLDER_THAN_100_CONSTRAINT CHECK (dbo.CHECK_AGE(AGE)=1)

--- a/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1__Base_version.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/sqlserver/sql/checkConstraint/V1__Base_version.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2010-2013 Axel Fontaine and the many contributors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
   CREATE TABLE USERS
   (
     ID int identity( 100000000, 1 ),


### PR DESCRIPTION
Fix for issue #456. Flyway is unable to correctly find the quote delimiter when there is an inline charset cast on the string literal. I added a new method to the `SqlStatementBuilder.java` that can be overridden in the dialect specific subclasses if other dialects need similar behavior. For the `MySQLStatementBuilder.java`, I added a list of the supported charsets and check to make sure the tokens do not contain a charset cast prefix. If so, then I remove the cast reference so the token can be evaluated properly for quotes.
