### PR TITLE
fix issue 682

### DIFF
--- a/flyway-maven-plugin/pom.xml
+++ b/flyway-maven-plugin/pom.xml
@@ -59,6 +59,12 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <parallel>none</parallel>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-maven-plugin</artifactId>
                 <executions>

--- a/flyway-maven-plugin/src/main/java/com/googlecode/flyway/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/com/googlecode/flyway/maven/AbstractFlywayMojo.java
@@ -407,10 +407,10 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
      * @param mavenPropertyValue The value of the Maven property.
      * @return The value to use.
      */
-    private boolean getBooleanProperty(String systemPropertyName, boolean mavenPropertyValue) {
+    protected boolean getBooleanProperty(String systemPropertyName, boolean mavenPropertyValue) {
         String systemPropertyValue = System.getProperty(systemPropertyName);
         if (systemPropertyValue != null) {
-            return Boolean.getBoolean(systemPropertyValue);
+            return Boolean.getBoolean(systemPropertyName);
         }
         return mavenPropertyValue;
     }

--- a/flyway-maven-plugin/src/test/java/com/googlecode/flyway/maven/AbstractFlywayMojoSmallTest.java
+++ b/flyway-maven-plugin/src/test/java/com/googlecode/flyway/maven/AbstractFlywayMojoSmallTest.java
@@ -18,7 +18,10 @@ package com.googlecode.flyway.maven;
 import com.googlecode.flyway.core.Flyway;
 import org.apache.maven.project.MavenProject;
 import org.h2.Driver;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -27,6 +30,14 @@ import static org.junit.Assert.assertNull;
  * Test for AbstractFlywayMojo.
  */
 public class AbstractFlywayMojoSmallTest {
+
+    public static final String FLYWAY_MY_PROPERTY = "flyway.myProperty";
+
+    @Before
+    public void cleanCustomSystemProperty(){
+        System.clearProperty(FLYWAY_MY_PROPERTY);
+    }
+
     @Test
     public void execute() throws Exception {
         AbstractFlywayMojo mojo = new AbstractFlywayMojo() {
@@ -59,5 +70,30 @@ public class AbstractFlywayMojoSmallTest {
         mojo.url = "jdbc:h2:mem:dummy";
         mojo.mavenProject = new MavenProject();
         mojo.execute();
+    }
+
+    @Test
+    public void shouldHaveABooleanPropertyWithTrue() throws Exception {
+        System.setProperty(FLYWAY_MY_PROPERTY, "true");
+        AbstractFlywayMojo mojo = new AbstractFlywayMojo() {
+            @Override
+            protected void doExecute(Flyway flyway) throws Exception {
+            }
+        };
+
+        boolean booleanProperty = mojo.getBooleanProperty(FLYWAY_MY_PROPERTY, false);
+        assertEquals(true, booleanProperty);
+    }
+
+    @Test
+    public void shouldHaveTheMavenPropertyWithFalse() throws Exception {
+        AbstractFlywayMojo mojo = new AbstractFlywayMojo() {
+            @Override
+            protected void doExecute(Flyway flyway) throws Exception {
+            }
+        };
+
+        boolean booleanProperty = mojo.getBooleanProperty(FLYWAY_MY_PROPERTY, false);
+        assertEquals(false, booleanProperty);
     }
 }


### PR DESCRIPTION
I discover a big issue in the maven plugin in flyway 2.3.1, you cannot set any boolean property with a java system property in command line (like -Dflyway.outOfOrder=true).

i did some debuging and the method getBooleanProperty got a very small bug.
Boolean.getBoolean(systemPropertyValue) should be  Boolean.getBoolean(systemPropertyName)

PS: i try with flyway 2.1.1 and its working,
i had a unit test
