### PR TITLE
fix issue 684 by allowing convenient running of custom init SQL statemen...

### DIFF
--- a/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
+++ b/flyway-core/src/main/java/com/googlecode/flyway/core/Flyway.java
@@ -690,6 +690,18 @@ public class Flyway {
     }
 
     /**
+     * Sets the datasource to use. Must have the necessary privileges to execute ddl.
+     *
+     * @param url      The JDBC URL of the database.
+     * @param user     The user of the database.
+     * @param password The password of the database.
+     * @param initSqls    The (optional) sql statements to execute to initialize a connection immediately after obtaining it.
+     */
+    public void setDataSource(String url, String user, String password, String... initSqls) {
+        this.dataSource = new DriverDataSource(null, url, user, password, initSqls);
+    }
+
+    /**
      * Sets the version to tag an existing schema with when executing init. (default: 1)
      *
      * @param initialVersion The version to tag an existing schema with when executing init. (default: 1)


### PR DESCRIPTION
...ts during connection acquisition. Just added a new version of setDataSource which passes the initialization statements to DriverDataSource which already contains the functionality to run custom init statements.

Without the code in this pull request the functionality can be accessed by creating a DriverDataSource instance with the extra parameters and passing this instance to Flyway. I have used this method to test that the code in DriverDataSource works, but this was not an exhaustive test. 
