### PR TITLE
fixed bug #718

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/dbsupport/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/dbsupport/JdbcTemplate.java
@@ -227,7 +227,10 @@ public class JdbcTemplate {
         Statement statement = null;
         try {
             statement = connection.createStatement();
-            statement.execute(sql);
+            for(String batchElement : sql.split("[;|GO]((\\r\\n|\\r|\\n)+)")) {
+                statement.addBatch(batchElement);
+            }
+            statement.executeBatch();
         } finally {
             JdbcUtils.closeStatement(statement);
         }


### PR DESCRIPTION
If one of the commands sent to the database fails to execute properly flyway doesn't throw any exception as if patch was executed successfully
