### PR TITLE
Fixed OSGi metadata table create script loading 

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
@@ -91,7 +91,7 @@ public class MetaDataTableImpl implements MetaDataTable {
         LOG.info("Creating Metadata table: " + table);
 
         String resourceName = "org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/createMetaDataTable.sql";
-        String source = new ClassPathResource(resourceName, classLoader).loadAsString("UTF-8");
+        String source = new ClassPathResource(resourceName, getClass().getClassLoader()).loadAsString("UTF-8");
 
         Map<String, String> placeholders = new HashMap<String, String>();
         placeholders.put("schema", table.getSchema().getName());


### PR DESCRIPTION
This is useful incase the schema table sql migrations aren't available on the user provided classpath, for example in certain osgi configurations.

OSGi Ex:

```
MyBundle (uses flyway)                                  Flyway
------------------------------------------------------------------------------------------------------------------
Flyway flyway = new Flyway();
// set the ClassLoader so that flyway
// can find the jdbc drivers and the 
// internal migrations
flyway.setClassLoader(
    MyClass.class.getClassLoader());
flyway.setDataSource( ... );
flyway.migrate(); -----------------------------------------> Finds empty db
                                                          Needs to create the schema_version table
                                                          Tries to load classpath resource 
("org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/createMetaDataTable.sql")
                                                          ... never resolved because MyBundle doesn't have 
                                                              that resource on its class path.
                                                          But, if we use the class loader OSGi gives flyway
                                                          (eg getClass().getClassLoader()), then flyway can
                                                          successfully load the sql it needs.
```

Let me know your thoughts, and I'm happy to modify this in any way if you see problems with it, and thanks again for the sharp tool.
