### PR TITLE
 flyway#754 fix bug on quote after comment start

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlStatementBuilder.java
@@ -336,20 +336,25 @@ public class SqlStatementBuilder {
                 //Skip '', 'abc', ...
                 continue;
             }
-            if (cleanToken.startsWith("'") || cleanToken.endsWith("'")) {
-                delimitingTokens.add(TokenType.QUOTE);
+            if ((cleanToken.length() >= 4) && cleanToken.startsWith("/*") && cleanToken.endsWith("*/")) {
+                //Skip /**/, /*comment*/, ...
+                continue;
             }
 
             if (isSingleLineComment(cleanToken)) {
                 delimitingTokens.add(TokenType.SINGLE_LINE_COMMENT);
             }
 
-            if ((cleanToken.length() >= 4) && cleanToken.startsWith("/*") && cleanToken.endsWith("*/")) {
-                //Skip /**/, /*comment*/, ...
-                continue;
-            }
-            if (cleanToken.startsWith("/*") || cleanToken.endsWith("*/")) {
+            if (cleanToken.startsWith("/*")) {
                 delimitingTokens.add(TokenType.MULTI_LINE_COMMENT);
+            } else if (cleanToken.startsWith("'")) {
+                delimitingTokens.add(TokenType.QUOTE);
+            }
+
+            if (!cleanToken.startsWith("/*") && cleanToken.endsWith("*/")) {
+                delimitingTokens.add(TokenType.MULTI_LINE_COMMENT);
+            } else if (!cleanToken.startsWith("'") && cleanToken.endsWith("'")) {
+                delimitingTokens.add(TokenType.QUOTE);
             }
         }
 

--- a/flyway-core/src/test/resources/migration/comment/V1__Comment.sql
+++ b/flyway-core/src/test/resources/migration/comment/V1__Comment.sql
@@ -37,3 +37,16 @@ CREATE TABLE table1 (
   name VARCHAR(25) NOT NULL,
   PRIMARY KEY(name)
 );
+
+CREATE TABLE table2 (
+/*'
+  sixth
+ '*/
+  name VARCHAR(25) NOT NULL,
+  PRIMARY KEY(name)
+);
+
+CREATE TABLE table3 (
+  name VARCHAR(25) NOT NULL, --' seventh
+  PRIMARY KEY(name)
+);


### PR DESCRIPTION
This bug is common for all databases. It occurs when quote follows the comment start or precedes the comment end without whitespaces.
I add sql statements for testing this bug into common V1__Comment.sql script.
