### PR TITLE
Maven plugin: Expose new DB version in "flyway.current" property after migration

### DIFF
--- a/flyway-maven-plugin-largetest/src/test/java/org/flywaydb/maven/largetest/MavenTestCase.java
+++ b/flyway-maven-plugin-largetest/src/test/java/org/flywaydb/maven/largetest/MavenTestCase.java
@@ -59,6 +59,13 @@ public abstract class MavenTestCase {
     }
 
     @Test
+    public void executions() throws Exception {
+        String stdOut = runMaven(0, "executions", "clean", "install", "-Dflyway.user=SA");
+        assertTrue(stdOut.contains("[INFO] Cleaned schema \"PUBLIC\""));
+        assertTrue(stdOut.contains("[echo] Property: flyway.current = 1.1"));
+    }
+
+    @Test
     public void sample() throws Exception {
         String stdOut = runMaven(0, "sample", "clean", "compile", "flyway:clean", "flyway:migrate");
         assertTrue(stdOut.contains("Successfully applied 5 migrations"));

--- a/flyway-maven-plugin-largetest/src/test/resources/executions/pom.xml
+++ b/flyway-maven-plugin-largetest/src/test/resources/executions/pom.xml
@@ -1,0 +1,96 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.flywaydb.maven.largetest</groupId>
+    <artifactId>regular</artifactId>
+    <version>${flyway.version}</version>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>1.8.0.10</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>${flyway.version}</version>
+
+                <configuration>
+                    <driver>org.hsqldb.jdbcDriver</driver>
+                    <url>jdbc:hsqldb:file:${project.build.directory}/db/flyway_sample;shutdown=true</url>
+                    <user>overriddenBySystemProperty</user>
+                    <schemas>
+                        <schema>PUBLIC</schema>
+                    </schemas>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>clean-db</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                    </execution>
+                    <execution>
+                        <id>init-db</id>
+                        <goals>
+                            <goal>migrate</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>echo properties</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target name="echo props">
+                                <echo message="Property: flyway.current = ${flyway.current}"/>
+                                <echo message="Property: flyway.target = ${flyway.target}"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-maven-plugin-largetest/src/test/resources/executions/src/main/resources/db/migration/V1_1__Populate_table.sql
+++ b/flyway-maven-plugin-largetest/src/test/resources/executions/src/main/resources/db/migration/V1_1__Populate_table.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2014 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+INSERT INTO test_user (name) VALUES ('kuki');

--- a/flyway-maven-plugin-largetest/src/test/resources/executions/src/main/resources/db/migration/V1__First.sql
+++ b/flyway-maven-plugin-largetest/src/test/resources/executions/src/main/resources/db/migration/V1__First.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2010-2014 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  name VARCHAR(25) NOT NULL,
+  PRIMARY KEY(name)
+);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/MigrateMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/MigrateMojo.java
@@ -31,5 +31,7 @@ public class MigrateMojo extends AbstractFlywayMojo {
         }
 
         flyway.migrate();
+
+        mavenProject.getProperties().setProperty("flyway.current", flyway.info().current().getVersion().toString());
     }
 }


### PR DESCRIPTION
Hi,

I'm using flyway in my code and maven and its awesome.
Recently I needed to be able to get, in maven, the current version after migration - my build is automatically invoking the migrate goal during install.

So I've extended the maven-plugin so after migration it records the current DB version in the "flyway.current" property.

In order to test this, I've also extended the maven-plugin-largetest to test the "executions" section of the plugin.

Right now I'm using a local version that includes this patch - will be great if you can merge it into flyway.

Thanks,
M.

BTW, this is my first pull request... so please educate me if I'm doing it wrong :-)
