### PR TITLE
Support for migrating multiple schemas at once

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -95,8 +95,7 @@ public class Flyway {
     private String[] schemaNames = new String[0];
     
     /**
-     * 
-     * 
+     * Will allow multiple schemas to be migrated at once
      */
     private boolean multipleDbMode = false;
 
@@ -296,8 +295,8 @@ public class Flyway {
     }
 
     /**
-     * 
-     * @return
+     * Get whether or not the multiple db mode is active or not  
+     * @return {@code true} if multiple db mode is active {@code false} if it is not enabled (default: {@code false})
      */
     public boolean isMultipleDbMode() {
     	return multipleDbMode;
@@ -585,8 +584,8 @@ public class Flyway {
     }
 
     /**
-     * 
-     * @param multipleDbMode
+     * Set whether the multiple db mode is active or not
+     * @param multipleDbMode {@code true} to enable multiple db mode {@code false} to disable
      */
     public void setMultipleDbMode(boolean multipleDbMode) {
     	this.multipleDbMode = multipleDbMode;

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
@@ -41,6 +41,9 @@ public class FlywayExtension {
     /** The case-sensitive list of schemas managed by Flyway */
     String[] schemas
 
+	/** Whether single schema mode is on or not */
+	Boolean singleSchemaMode
+
     /** The initial version to put in the database */
     String initVersion
 

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
@@ -41,8 +41,8 @@ public class FlywayExtension {
     /** The case-sensitive list of schemas managed by Flyway */
     String[] schemas
 
-	/** Whether single schema mode is on or not */
-	Boolean singleSchemaMode
+	/** Whether multiple db mode is on or not */
+	Boolean multipleDbMode
 
     /** The initial version to put in the database */
     String initVersion

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
@@ -96,6 +96,7 @@ abstract class AbstractFlywayTask extends DefaultTask {
         propSet(flyway, 'placeholderPrefix')
         propSet(flyway, 'placeholderSuffix')
         propSet(flyway, 'target')
+        propSetAsBoolean(flyway, 'singleSchemaMode')
         propSetAsBoolean(flyway, 'outOfOrder')
         propSetAsBoolean(flyway, 'validateOnMigrate')
         propSetAsBoolean(flyway, 'cleanOnValidationError')

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
@@ -96,7 +96,7 @@ abstract class AbstractFlywayTask extends DefaultTask {
         propSet(flyway, 'placeholderPrefix')
         propSet(flyway, 'placeholderSuffix')
         propSet(flyway, 'target')
-        propSetAsBoolean(flyway, 'singleSchemaMode')
+        propSetAsBoolean(flyway, 'multipleDbMode')
         propSetAsBoolean(flyway, 'outOfOrder')
         propSetAsBoolean(flyway, 'validateOnMigrate')
         propSetAsBoolean(flyway, 'cleanOnValidationError')

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -116,6 +116,13 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private String[] schemas;
 
     /**
+     * Whether the multiple db mode option is enabled or not 
+     * 
+     * @parameter property="flyway.multipleDbMode"
+     */
+    private boolean multipleDbMode = flyway.isMultipleDbMode();
+    
+    /**
      * <p>The name of the metadata table that will be used by Flyway. (default: schema_version)</p>
      * <p> By default (single-schema mode) the
      * metadata table is placed in the default schema for the connection provided by the datasource. <br/> When the
@@ -398,6 +405,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
 
             flyway.setClassLoader(Thread.currentThread().getContextClassLoader());
             flyway.setSchemas(schemas);
+            flyway.setMultipleDbMode(multipleDbMode);
             flyway.setTable(table);
             flyway.setInitVersion(initVersion);
             flyway.setInitDescription(initDescription);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -15,6 +15,13 @@
  */
 package org.flywaydb.maven;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -32,13 +39,6 @@ import org.sonatype.plexus.components.cipher.PlexusCipherException;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Map;
-import java.util.Properties;
 
 /**
  * Common base class for all mojos with all common attributes.<br>


### PR DESCRIPTION

Current codebase did not support migrating multiple db's in a single maven command.  The use case for this is multi-tenant systems that have data isolation based on the database schema. Running maven once per tenant is not feasible. 

The implementation provided may need some work, but I wanted to keep the current implementation in-tact and allow for the option to run migrations over the entire flyway.schemas list. 

To accomplish this, I added a property (flyway.multipleDbMode), defaulted to false.  When true, this will migrate every schema in the list provided to flyway.schemas.  When false, this will migrate just the first of the list, as was in place in the current codebase. Both the gradle and maven plugins have been updated to set the property appropriately as well.