### PR TITLE
Drop oracle database links

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSchema.java
@@ -300,7 +300,7 @@ public class OracleSchema extends Schema {
 
         List<String> linkNames = jdbcTemplate.queryForStringList("SELECT db_link FROM user_db_links");
         for (String linkName : linkNames) {
-            dropStatements.add("DROP DATABASE LINK " + dbSupport.quote(name, linkName));
+            dropStatements.add("DROP DATABASE LINK \"" + linkName + "\"");
         }
         return dropStatements;
     }


### PR DESCRIPTION
I'm using flyway on a very large Oracle schema.  One of the issues I found was that a clean didn't remove existing DB links; this pull request fixes it.  Let me know if there's anything you'd like me to add in order to get this in to 3.1.
