### PR TITLE
Implementation for #805: JdbcMigrations, Resolvers and FlywayCallbacks should have access to core configuration

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/ConfigurationAware.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/ConfigurationAware.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api;
+
+/**
+ * Marks a class as configuration aware (callbacks and migrations). Configuration aware classes
+ * get the flyway master configuration injected upon creation.
+ */
+public interface ConfigurationAware {
+
+    /**
+     * Sets the current configuration. This method should not be called directly, it is called by the Flyway.
+     *
+     * @param flywayConfiguration The current Flyway configuration.
+     */
+    void setFlywayConfiguration(FlywayConfiguration flywayConfiguration);
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api;
+
+import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+/**
+ * Readonly interface for main flyway configuration. Can be used to provide configuration data to migrations and callbacks.
+ */
+public interface FlywayConfiguration {
+
+    /**
+     * Gets the callbacks for lifecycle notifications.
+     *
+     * @return The callbacks for lifecycle notifications. An empty array if none. (default: none)
+     */
+    FlywayCallback[] getCallbacks();
+
+    /**
+     * Retrieves the ClassLoader to use for resolving migrations on the classpath.
+     *
+     * @return The ClassLoader to use for resolving migrations on the classpath.
+     * (default: Thread.currentThread().getContextClassLoader() )
+     */
+    ClassLoader getClassLoader();
+
+    /**
+     * Retrieves the dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     *
+     * @return The dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     */
+    DataSource getDataSource();
+
+    /**
+     * Retrieves the version to tag an existing schema with when executing baseline.
+     *
+     * @return The version to tag an existing schema with when executing baseline. (default: 1)
+     */
+    MigrationVersion getBaselineVersion();
+
+    /**
+     * Retrieves the description to tag an existing schema with when executing baseline.
+     *
+     * @return The description to tag an existing schema with when executing baseline. (default: &lt;&lt; Flyway Baseline &gt;&gt;)
+     */
+    String getBaselineDescription();
+
+    /**
+     * Retrieves the The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
+     *
+     * @return The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply. An empty array if none.
+     * (default: none)
+     */
+    MigrationResolver[] getResolvers();
+
+    /**
+     * Retrieves the file name suffix for sql migrations.
+     * <p/>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     *
+     * @return The file name suffix for sql migrations. (default: .sql)
+     */
+    String getSqlMigrationSuffix();
+
+    /**
+     * Retrieves the file name prefix for repeatable sql migrations.
+     * <p/>
+     * <p>Repeatable sql migrations have the following file name structure: prefixSeparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to R__My_description.sql</p>
+     *
+     * @return The file name prefix for repeatable sql migrations. (default: R)
+     */
+    String getRepeatableSqlMigrationPrefix();
+
+    /**
+     * Retrieves the file name separator for sql migrations.
+     * <p/>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     *
+     * @return The file name separator for sql migrations. (default: __)
+     */
+    String getSqlMigrationSeparator();
+
+    /**
+     * Retrieves the file name prefix for sql migrations.
+     * <p/>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     *
+     * @return The file name prefix for sql migrations. (default: V)
+     */
+    String getSqlMigrationPrefix();
+
+    /**
+     * Checks whether placeholders should be replaced.
+     *
+     * @return Whether placeholders should be replaced. (default: true)
+     */
+    boolean isPlaceholderReplacement();
+
+    /**
+     * Retrieves the suffix of every placeholder.
+     *
+     * @return The suffix of every placeholder. (default: } )
+     */
+    String getPlaceholderSuffix();
+
+    /**
+     * Retrieves the prefix of every placeholder.
+     *
+     * @return The prefix of every placeholder. (default: ${ )
+     */
+    String getPlaceholderPrefix();
+
+    /**
+     * Retrieves the map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
+     *
+     * @return The map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
+     */
+    Map<String, String> getPlaceholders();
+
+    /**
+     * Retrieves the target version up to which Flyway should consider migrations.
+     * Migrations with a higher version number will be ignored.
+     * The special value {@code current} designates the current version of the schema.
+     *
+     * @return The target version up to which Flyway should consider migrations. (default: the latest version)
+     */
+    MigrationVersion getTarget();
+
+    /**
+     * <p>Retrieves the name of the schema metadata table that will be used by Flyway.</p><p> By default (single-schema
+     * mode) the metadata table is placed in the default schema for the connection provided by the datasource. </p> <p>
+     * When the <i>flyway.schemas</i> property is set (multi-schema mode), the metadata table is placed in the first
+     * schema of the list. </p>
+     *
+     * @return The name of the schema metadata table that will be used by flyway. (default: schema_version)
+     */
+    String getTable();
+
+    /**
+     * Retrieves the schemas managed by Flyway.  These schema names are case-sensitive.
+     * <p>Consequences:</p>
+     * <ul>
+     * <li>The first schema in the list will be automatically set as the default one during the migration.</li>
+     * <li>The first schema in the list will also be the one containing the metadata table.</li>
+     * <li>The schemas will be cleaned in the order of this list.</li>
+     * </ul>
+     *
+     * @return The schemas managed by Flyway. (default: The default schema for the datasource connection)
+     */
+    String[] getSchemas();
+
+    /**
+     * Retrieves the encoding of Sql migrations.
+     *
+     * @return The encoding of Sql migrations. (default: UTF-8)
+     */
+    String getEncoding();
+
+    /**
+     * Retrieves the locations to scan recursively for migrations.
+     * <p/>
+     * <p>The location type is determined by its prefix.
+     * Unprefixed locations or locations starting with {@code classpath:} point to a package on the classpath and may
+     * contain both sql and java-based migrations.
+     * Locations starting with {@code filesystem:} point to a directory on the filesystem and may only contain sql
+     * migrations.</p>
+     *
+     * @return Locations to scan recursively for migrations. (default: db/migration)
+     */
+    String[] getLocations();
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
@@ -15,9 +15,9 @@
  */
 package org.flywaydb.core.api.callback;
 
-import org.flywaydb.core.api.MigrationInfo;
-
 import java.sql.Connection;
+
+import org.flywaydb.core.api.MigrationInfo;
 
 /**
  * This is the main callback interface that should be implemented to get access to flyway lifecycle notifications.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
@@ -21,7 +21,8 @@ import java.sql.Connection;
  * Interface to be implemented by Jdbc Java Migrations. By default the migration version and description will be extracted
  * from the class name. This can be overriden by also implementing the MigrationInfoProvider interface, in which
  * case it can be specified programmatically. The checksum of this migration (for validation) will also be null, unless
- * the migration also implements the MigrationChecksumProvider, in which case it can be returned programmatically.
+ * the migration also implements the MigrationChecksumProvider, in which case it can be returned programmatically. When
+ * the JdbcMigration implements ConfigurationAware, the master flyway configuration is automatically injected upon creation.
  */
 public interface JdbcMigration {
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
@@ -27,6 +28,7 @@ import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
 import org.flywaydb.core.internal.util.ClassUtils;
+import org.flywaydb.core.internal.util.InjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Pair;
 import org.flywaydb.core.internal.util.StringUtils;
@@ -52,14 +54,20 @@ public class JdbcMigrationResolver implements MigrationResolver {
     private Scanner scanner;
 
     /**
+     * The flyway master configuration.
+     */
+    private FlywayConfiguration configuration;
+
+    /**
      * Creates a new instance.
      *
      * @param location The base package on the classpath where to migrations are located.
      * @param scanner  The Scanner for loading migrations on the classpath.
      */
-    public JdbcMigrationResolver(Scanner scanner, Location location) {
+    public JdbcMigrationResolver(Scanner scanner, Location location, FlywayConfiguration configuration) {
         this.location = location;
         this.scanner = scanner;
+        this.configuration = configuration;
     }
 
     public List<ResolvedMigration> resolveMigrations() {
@@ -72,7 +80,7 @@ public class JdbcMigrationResolver implements MigrationResolver {
         try {
             Class<?>[] classes = scanner.scanForClasses(location, JdbcMigration.class);
             for (Class<?> clazz : classes) {
-                JdbcMigration jdbcMigration = ClassUtils.instantiate(clazz.getName(), scanner.getClassLoader());
+                JdbcMigration jdbcMigration = InjectionUtils.instantiateAndInjectConfiguration(clazz.getName(), scanner.getClassLoader(), configuration);
 
                 ResolvedMigrationImpl migrationInfo = extractMigrationInfo(jdbcMigration);
                 migrationInfo.setPhysicalLocation(ClassUtils.getLocationOnDisk(clazz));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
@@ -27,6 +28,7 @@ import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
 import org.flywaydb.core.internal.util.ClassUtils;
+import org.flywaydb.core.internal.util.InjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Pair;
 import org.flywaydb.core.internal.util.StringUtils;
@@ -52,17 +54,19 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      */
     private Scanner scanner;
 
+    private FlywayConfiguration configuration;
+
     /**
      * Creates a new instance.
      *
      * @param location The base package on the classpath where to migrations are located.
      * @param scanner  The Scanner for loading migrations on the classpath.
      */
-    public SpringJdbcMigrationResolver(Scanner scanner, Location location) {
+    public SpringJdbcMigrationResolver(Scanner scanner, Location location, FlywayConfiguration configuration) {
         this.location = location;
         this.scanner = scanner;
+        this.configuration = configuration;
     }
-
 
     public Collection<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
@@ -74,7 +78,7 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
         try {
             Class<?>[] classes = scanner.scanForClasses(location, SpringJdbcMigration.class);
             for (Class<?> clazz : classes) {
-                SpringJdbcMigration springJdbcMigration = ClassUtils.instantiate(clazz.getName(), scanner.getClassLoader());
+                SpringJdbcMigration springJdbcMigration = InjectionUtils.instantiateAndInjectConfiguration(clazz.getName(), scanner.getClassLoader(), configuration);
 
                 ResolvedMigrationImpl migrationInfo = extractMigrationInfo(springJdbcMigration);
                 migrationInfo.setPhysicalLocation(ClassUtils.getLocationOnDisk(clazz));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ClassUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ClassUtils.java
@@ -15,6 +15,8 @@
  */
 package org.flywaydb.core.internal.util;
 
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 
 import java.io.UnsupportedEncodingException;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/InjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/InjectionUtils.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.FlywayException;
+
+/**
+ * Utility class for interfaced based injection.
+ */
+public class InjectionUtils {
+
+    private InjectionUtils() {
+        // Utility class
+    }
+
+    /**
+     * Injects the given flyway configuration into the target object if target implements the
+     * {@link ConfigurationAware} interface. Does nothing if target is not configuration aware.
+     *
+     * @param target The object to inject the configuration into.
+     * @param configuration The configuration to inject.
+     */
+    public static void injectFlywayConfiguration(Object target, FlywayConfiguration configuration) {
+        if (target instanceof ConfigurationAware) {
+            ((ConfigurationAware) target).setFlywayConfiguration(configuration);
+        }
+    }
+
+    // Must be synchronized for the Maven Parallel Junit runner to work
+    public static synchronized <T> T instantiateAndInjectConfiguration(String className, ClassLoader classLoader, FlywayConfiguration config) throws Exception {
+        T result = ClassUtils.instantiate(className, classLoader);
+        injectFlywayConfiguration(result, config);
+        return result;
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackImpl.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackImpl.java
@@ -18,16 +18,21 @@ package org.flywaydb.core;
 import static org.junit.Assert.assertNotNull;
 
 import java.sql.Connection;
+
 import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.MigrationInfo;
 
 /**
  * Sample FlywayCallback implementation to test that the lifecycle
  * notifications are getting called correctly
- * 
+ *
  * @author Dan Bunker
  */
-public class FlywayCallbackImpl implements FlywayCallback {
+public class FlywayCallbackImpl implements FlywayCallback, ConfigurationAware {
+
+    private FlywayConfiguration flywayConfiguration;
 	private boolean beforeClean = false;
 	private boolean afterClean = false;
 	private boolean beforeMigrate = false;
@@ -129,6 +134,11 @@ public class FlywayCallbackImpl implements FlywayCallback {
         assertNotNull(dataConnection);
 	}
 
+	@Override
+	public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+	}
+
 	public boolean isBeforeClean() {
 		return beforeClean;
 	}
@@ -185,4 +195,7 @@ public class FlywayCallbackImpl implements FlywayCallback {
 		return afterInfo;
 	}
 
+	public void assertFlywayConfigurationSet() {
+		assertNotNull("Configuration must have been set", flywayConfiguration);
+	}
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackSmallTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
  * Tests for Flyway Callbacks
  */
 public class FlywayCallbackSmallTest {
+
     @Test
     public void cleanTest() {
         Properties properties = createProperties("clean");

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayResolverImpl.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayResolverImpl.java
@@ -13,35 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flywaydb.core.internal.resolver.jdbc.dummy;
+package org.flywaydb.core;
 
 import org.flywaydb.core.api.ConfigurationAware;
 import org.flywaydb.core.api.FlywayConfiguration;
-import org.flywaydb.core.api.FlywayException;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.junit.Assert;
 
-import java.sql.Connection;
+import java.util.Collection;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
- * Test migration. Doubles as test for {@link ConfigurationAware} migration.
+ * Dummy implementation for Resolvers to check configuration injection.
  */
-public class V2__InterfaceBasedMigration implements JdbcMigration, ConfigurationAware {
+public class FlywayResolverImpl implements MigrationResolver, ConfigurationAware {
 
     private FlywayConfiguration flywayConfiguration;
 
     @Override
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+
         this.flywayConfiguration = flywayConfiguration;
     }
 
-    public void migrate(Connection connection) throws Exception {
-        if (flywayConfiguration == null) {
-            throw new FlywayException("Flyway configuration has not been set on migration");
-        }
-        // Do nothing else
+    @Override
+    public Collection<ResolvedMigration> resolveMigrations() {
+        return null;
     }
 
-    public boolean isFlywayConfigurationSet() {
-        return flywayConfiguration != null;
+    public void assertFlywayConfigurationSet() {
+        assertNotNull("Configuration must have been set", flywayConfiguration);
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -19,11 +19,13 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.resolver.MyConfigurationAwareCustomMigrationResolver;
 import org.flywaydb.core.internal.resolver.MyCustomMigrationResolver;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.junit.Test;
 
 import javax.sql.DataSource;
+
 import java.sql.Connection;
 import java.util.Properties;
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -25,11 +25,7 @@ import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,9 +36,11 @@ import static org.junit.Assert.assertTrue;
 public class CompositeMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsMultipleLocations() {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()),
+                new Scanner(Thread.currentThread().getContextClassLoader()), config,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
                 "UTF-8", "V", "R", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.util.Locations;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Scanner;
+
+/**
+ * Dummy Implementation of {@link FlywayConfiguration} for unit tests.
+ */
+public class FlywayConfigurationForTests implements FlywayConfiguration {
+
+    private ClassLoader classLoader;
+    private String[] locations = new String[0];
+    private String encoding;
+    private String sqlMigrationPrefix;
+    private String repeatableSqlMigrationPrefix;
+    private String sqlMigrationSeparator;
+    private String sqlMigrationSuffix;
+    private MyCustomMigrationResolver[] migrationResolvers = new MyCustomMigrationResolver[0];
+
+    public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
+            String sqlMigrationPrefix, String repeatableSqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
+            MyCustomMigrationResolver... myCustomMigrationResolver) {
+        this.classLoader = contextClassLoader;
+        this.locations = locations;
+        this.encoding = encoding;
+        this.sqlMigrationPrefix = sqlMigrationPrefix;
+        this.repeatableSqlMigrationPrefix = repeatableSqlMigrationPrefix;
+        this.sqlMigrationSeparator = sqlMigrationSeparator;
+        this.sqlMigrationSuffix = sqlMigrationSuffix;
+        this.migrationResolvers = myCustomMigrationResolver;
+    }
+
+    public static FlywayConfigurationForTests create() {
+        return new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "V", "R", "__", ".sql");
+    }
+
+    public static FlywayConfigurationForTests createWithLocations(String... locations) {
+        return new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), locations, "UTF-8", "V", "R", "__", ".sql");
+    }
+
+    public static FlywayConfigurationForTests createWithPrefixAndLocations(String prefix, String... locations) {
+        return new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), locations, "UTF-8", prefix, "R", "__", ".sql");
+    }
+
+    @Override
+    public FlywayCallback[] getCallbacks() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    @Override
+    public DataSource getDataSource() {
+        return null;
+    }
+
+    @Override
+    public MigrationResolver[] getResolvers() {
+        return migrationResolvers;
+    }
+
+    @Override
+    public String getBaselineDescription() {
+        return null;
+    }
+
+    @Override
+    public MigrationVersion getBaselineVersion() {
+        return null;
+    }
+
+    @Override
+    public String getSqlMigrationSuffix() {
+        return sqlMigrationSuffix;
+    }
+
+    @Override
+    public String getRepeatableSqlMigrationPrefix() {
+        return repeatableSqlMigrationPrefix;
+    }
+
+    @Override
+    public String getSqlMigrationSeparator() {
+        return sqlMigrationSeparator;
+    }
+
+    @Override
+    public String getSqlMigrationPrefix() {
+        return sqlMigrationPrefix;
+    }
+
+    @Override
+    public boolean isPlaceholderReplacement() {
+        return false;
+    }
+
+    @Override
+    public String getPlaceholderSuffix() {
+        return null;
+    }
+
+    @Override
+    public String getPlaceholderPrefix() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getPlaceholders() {
+        return null;
+    }
+
+    @Override
+    public MigrationVersion getTarget() {
+        return null;
+    }
+
+    @Override
+    public String getTable() {
+        return null;
+    }
+
+    @Override
+    public String[] getSchemas() {
+        return null;
+    }
+
+    @Override
+    public String[] getLocations() {
+        return this.locations;
+    }
+
+    @Override
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+    public void setRepeatableSqlMigrationPrefix(String repeatableSqlMigrationPrefix) {
+        this.repeatableSqlMigrationPrefix = repeatableSqlMigrationPrefix;
+    }
+
+    public void setSqlMigrationPrefix(String sqlMigrationPrefix) {
+        this.sqlMigrationPrefix = sqlMigrationPrefix;
+    }
+
+    public void setResolvers(MyCustomMigrationResolver... myCustomMigrationResolver) {
+        this.migrationResolvers = myCustomMigrationResolver;
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
@@ -13,32 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flywaydb.core.internal.resolver.jdbc.dummy;
+package org.flywaydb.core.internal.resolver;
 
 import org.flywaydb.core.api.ConfigurationAware;
 import org.flywaydb.core.api.FlywayConfiguration;
-import org.flywaydb.core.api.FlywayException;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.MigrationType;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
 
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Test migration. Doubles as test for {@link ConfigurationAware} migration.
- */
-public class V2__InterfaceBasedMigration implements JdbcMigration, ConfigurationAware {
+* Created by Axel on 3/7/14.
+*/
+public class MyConfigurationAwareCustomMigrationResolver extends MyCustomMigrationResolver implements ConfigurationAware {
 
     private FlywayConfiguration flywayConfiguration;
 
     @Override
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
         this.flywayConfiguration = flywayConfiguration;
-    }
-
-    public void migrate(Connection connection) throws Exception {
-        if (flywayConfiguration == null) {
-            throw new FlywayException("Flyway configuration has not been set on migration");
-        }
-        // Do nothing else
     }
 
     public boolean isFlywayConfigurationSet() {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -15,7 +15,9 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
@@ -34,11 +36,12 @@ import static org.junit.Assert.assertNull;
  */
 public class SpringJdbcMigrationResolverSmallTest {
     private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
+    private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/spring/dummy"));
+                new SpringJdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -57,7 +60,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -66,7 +69,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -15,7 +15,9 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -15,7 +15,10 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.*;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
@@ -160,7 +161,7 @@ public abstract class MigrationTestCase {
 
     protected String getMigrationDir() { return MIGRATIONDIR; }
     protected String getBasedir() { return BASEDIR; }
-    
+
 
     @Test
     public void migrate() throws Exception {


### PR DESCRIPTION
Introduced a generic ConfigurationAware interface.

If a custom resolver or callback implements `ConfigurationAware`, the `FlywayConfiguration` get automatically injected. That way, resolvers and callbacks have access to important configurations like the locations (for custom resolvers) or PlaceholderResolvers.

Right now, Flyway implements FlywayConfiguration directly.
