### PR TITLE
Firebird support

### DIFF
--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -122,6 +122,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.firebirdsql.jdbc</groupId>
+            <artifactId>jaybird-jdk16</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>
             <scope>test</scope>

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
@@ -19,6 +19,7 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.dbsupport.db2.DB2DbSupport;
 import org.flywaydb.core.internal.dbsupport.db2zos.DB2zosDbSupport;
 import org.flywaydb.core.internal.dbsupport.derby.DerbyDbSupport;
+import org.flywaydb.core.internal.dbsupport.firebird.FirebirdDbSupport;
 import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
 import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
 import org.flywaydb.core.internal.dbsupport.mysql.MySQLDbSupport;
@@ -111,6 +112,9 @@ public class DbSupportFactory {
         }
         if (databaseProductName.startsWith("Vertica")) {
             return new VerticaDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("Firebird")) {
+            return new FirebirdDbSupport(connection);
         }
 
         throw new FlywayException("Unsupported Database: " + databaseProductName);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdDbSupport.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.SqlStatementBuilder;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+/**
+ * Firebird-specific support.
+ */
+public class FirebirdDbSupport extends DbSupport {
+
+    private static final Log LOG = LogFactory.getLog(FirebirdDbSupport.class);
+
+    /**
+     * Creates a new instance.
+     *
+     * @param connection The connection to use.
+     */
+    public FirebirdDbSupport(Connection connection) {
+        super(new FirebirdJdbcTemplate(connection, Types.VARCHAR));
+    }
+
+    @Override
+    public String getDbName() {
+        return "firebird";
+    }
+
+    @Override
+    public String getCurrentUserFunction() {
+        return "CURRENT_USER";
+    }
+
+    @Override
+    protected String doGetCurrentSchema() throws SQLException {
+        return "";
+    }
+
+    @Override
+    protected void doSetCurrentSchema(Schema schema) throws SQLException {
+        LOG.info("Firebird does not support schemas! Current schema NOT changed to " + schema);
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "1";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "0";
+    }
+
+    @Override
+    public SqlStatementBuilder createSqlStatementBuilder() {
+        return new FirebirdSqlStatementBuilder();
+    }
+
+    @Override
+    public String doQuote(String identifier) {
+        return "\"" + identifier + "\"";
+        //return identifier;
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new FirebirdSchema(jdbcTemplate, this, name);
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return true;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdJdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdJdbcTemplate.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import org.flywaydb.core.internal.dbsupport.*;
+import org.flywaydb.core.internal.util.jdbc.RowMapper;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Firebird-specific JdbcTemplate which commits automatically after all possible data-changing operations. This
+ * behaviour is currently necessary because Firebird does not perform implicit commits after DDL operations within a
+ * single transaction.
+ *
+ */
+public class FirebirdJdbcTemplate extends JdbcTemplate {
+
+    private static final Log LOG = LogFactory.getLog(FirebirdJdbcTemplate.class);
+
+    /**
+     * Creates a new Firebird-specific JdbcTemplate.
+     *
+     * @param connection The DB connection to use.
+     * @param nullType The type to assign to a null value.
+     */
+    public FirebirdJdbcTemplate(Connection connection, int nullType) {
+        super(connection, nullType);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <b>Attention! this method also commits!</b>
+     */
+    @Override
+    public void execute(String sql, Object... params) throws SQLException {
+        super.execute(sql, params);
+        fakeAutoCommit();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <b>Attention! this method also commits!</b>
+     */
+    @Override
+    public void executeStatement(String sql) throws SQLException {
+        super.executeStatement(sql);
+        fakeAutoCommit();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <b>Attention! this method also commits!</b>
+     */
+    @Override
+    public void update(String sql, Object... params) throws SQLException {
+        super.update(sql, params);
+        fakeAutoCommit();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <b>Attention! this method also commits!</b>
+     */
+    @Override
+    public <T> List<T> query(String query, RowMapper<T> rowMapper) throws SQLException {
+        List<T> ret = super.query(query, rowMapper);
+        fakeAutoCommit();
+        return ret;
+    }
+
+    private void fakeAutoCommit() throws SQLException {
+        if (!getConnection().getAutoCommit()) {
+            getConnection().commit();
+        }
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdSchema.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+/**
+ * Firebird implementation.
+ */
+public class FirebirdSchema extends Schema<FirebirdDbSupport> {
+
+    private static final Log LOG = LogFactory.getLog(FirebirdDbSupport.class);
+
+    /**
+     * Creates a new Firebird schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport The database-specific support.
+     * @param name The name of the schema.
+     */
+    public FirebirdSchema(JdbcTemplate jdbcTemplate, FirebirdDbSupport dbSupport, String name) {
+        super(jdbcTemplate, dbSupport, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        try {
+            doAllTables();
+            return true;
+        } catch (SQLException ignored) {
+            return false;
+        }
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        Table[] tables = allTables();
+        return tables.length < 1;
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        LOG.info("Firebird does not support schemas! Schema NOT created: " + name);
+        throw new SQLException("Firebird does not support schemas! Schema NOT created: " + name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        LOG.info("Firebird does not support schemas! Schema NOT dropped: " + name);
+        throw new SQLException("Firebird does not support schemas! Schema NOT dropped: " + name);
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        try {
+            for (String statement : cleanConstraints()) {
+                jdbcTemplate.execute(statement);
+            }
+            for (String statement : cleanTriggers()) {
+                jdbcTemplate.execute(statement);
+            }
+            for (String statement : cleanGenerators()) {
+                jdbcTemplate.execute(statement);
+            }
+            for (String statement : cleanViews()) {
+                jdbcTemplate.execute(statement);
+            }
+            for (Table table : allTables()) {
+                table.drop();
+            }
+        } catch (SQLException e) {
+            throw e;
+        }
+
+    }
+
+    @Override
+    protected Table[] doAllTables() throws SQLException {
+        List<String> tableNames = jdbcTemplate.queryForStringList("select rdb$relation_name from rdb$relations where rdb$view_blr is null and (rdb$system_flag is null or rdb$system_flag = 0)");
+
+        Table[] tables = new Table[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new FirebirdTable(jdbcTemplate, dbSupport, this, tableNames.get(i).trim());
+        }
+        return tables;
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new FirebirdTable(jdbcTemplate, dbSupport, this, tableName);
+    }
+
+    private List<String> cleanConstraints() throws SQLException {
+        final String sql = "select 'alter table '||r.rdb$relation_name ||' drop constraint '||r.rdb$constraint_name||';' "
+                + "from rdb$relation_constraints r "
+                + "where (r.rdb$constraint_type='FOREIGN KEY') ";
+        return jdbcTemplate.queryForStringList(sql);
+    }
+
+    private List<String> cleanGenerators() throws SQLException {
+        List<String> generators = jdbcTemplate.queryForStringList("select rdb$generator_name from rdb$generators where rdb$system_flag is distinct from 1");
+
+        List<String> statements = new ArrayList<String>();
+        for (String generator : generators) {
+            statements.add("DROP SEQUENCE " + dbSupport.quote(generator.trim()));
+        }
+        return statements;
+    }
+
+    private List<String> cleanTriggers() throws SQLException {
+        List<String> triggers = jdbcTemplate.queryForStringList("select * from rdb$triggers where rdb$system_flag = 0");
+
+        List<String> statements = new ArrayList<String>();
+        for (String trigger : triggers) {
+            statements.add("DROP TRIGGER " + dbSupport.quote(trigger.trim()));
+        }
+        return statements;
+    }
+
+    private List<String> cleanViews() throws SQLException {
+        List<String> views = jdbcTemplate.queryForStringList("select rdb$relation_name from rdb$relations where rdb$view_blr is not null and (rdb$system_flag is null or rdb$system_flag = 0)");
+
+        List<String> statements = new ArrayList<String>();
+        for (String view : views) {
+            statements.add("DROP VIEW " + dbSupport.quote(view.trim()));
+        }
+        return statements;
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdSqlStatementBuilder.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import org.flywaydb.core.internal.dbsupport.Delimiter;
+import org.flywaydb.core.internal.dbsupport.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.StringUtils;
+
+/**
+ * SqlStatementBuilder supporting Firebird-specific delimiter changes.
+ */
+public class FirebirdSqlStatementBuilder extends SqlStatementBuilder {
+
+    private static final String SQL_TERM = "SET TERM";
+
+    @Override
+    public Delimiter extractNewDelimiterFromLine(String line) {
+        String l = line.trim().toUpperCase();
+        if (!l.startsWith(SQL_TERM) || l.length() < SQL_TERM.length() + 2) {
+            return null;
+        }
+        String newTerm = StringUtils.collapseWhitespace(l).substring(SQL_TERM.length() + 1);
+        if (newTerm.contains(" ")) { //terminator statement itself terminated
+            newTerm = newTerm.substring(0, newTerm.lastIndexOf(' '));
+        }
+        return new Delimiter(newTerm, false);
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdTable.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+
+import java.sql.SQLException;
+
+/**
+ * Firebird-specific table.
+ */
+public class FirebirdTable extends Table {
+
+    /**
+     * Creates a new Firebird table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport The database-specific support.
+     * @param schema The schema this table lives in.
+     * @param name The name of the table.
+     */
+    public FirebirdTable(JdbcTemplate jdbcTemplate, DbSupport dbSupport, Schema schema, String name) {
+        super(jdbcTemplate, dbSupport, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + dbSupport.quote(name));
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return exists(null, null, dbSupport.quote(name));
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
+    }
+
+    @Override
+    public String toString() {
+        return dbSupport.quote(name);
+    }
+    
+    
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
@@ -1,17 +1,14 @@
 /**
  * Copyright 2010-2014 Axel Fontaine
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.flywaydb.core.internal.resolver.sql;
 
@@ -23,11 +20,13 @@ import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
 
 import java.sql.Connection;
+import org.flywaydb.core.internal.dbsupport.firebird.FirebirdJdbcTemplate;
 
 /**
  * Database migration based on a sql file.
  */
 public class SqlMigrationExecutor implements MigrationExecutor {
+
     /**
      * Database-specific support.
      */
@@ -39,9 +38,8 @@ public class SqlMigrationExecutor implements MigrationExecutor {
     private final PlaceholderReplacer placeholderReplacer;
 
     /**
-     * The Resource pointing to the sql script.
-     * The complete sql script is not held as a member field here because this would use the total size of all
-     * sql migrations files in heap space during db migration, see issue 184.
+     * The Resource pointing to the sql script. The complete sql script is not held as a member field here because this
+     * would use the total size of all sql migrations files in heap space during db migration, see issue 184.
      */
     private final Resource sqlScriptResource;
 
@@ -53,10 +51,10 @@ public class SqlMigrationExecutor implements MigrationExecutor {
     /**
      * Creates a new sql script migration based on this sql script.
      *
-     * @param dbSupport           The database-specific support.
-     * @param sqlScriptResource   The resource containing the sql script.
+     * @param dbSupport The database-specific support.
+     * @param sqlScriptResource The resource containing the sql script.
      * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
-     * @param encoding            The encoding of this Sql migration.
+     * @param encoding The encoding of this Sql migration.
      */
     public SqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
         this.dbSupport = dbSupport;
@@ -70,11 +68,18 @@ public class SqlMigrationExecutor implements MigrationExecutor {
         String sqlScriptSource = sqlScriptResource.loadAsString(encoding);
         String sqlScriptSourceNoPlaceholders = placeholderReplacer.replacePlaceholders(sqlScriptSource);
         SqlScript sqlScript = new SqlScript(sqlScriptSourceNoPlaceholders, dbSupport);
-        sqlScript.execute(new JdbcTemplate(connection, 0));
+        sqlScript.execute(createJdbcTemplate(connection));
     }
 
     @Override
     public boolean executeInTransaction() {
         return true;
+    }
+
+    protected JdbcTemplate createJdbcTemplate(Connection connection) {
+        if (dbSupport.getJdbcTemplate() instanceof FirebirdJdbcTemplate) {
+            return new FirebirdJdbcTemplate(connection, 0);
+        }
+        return new JdbcTemplate(connection, 0);
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -183,6 +183,9 @@ public class DriverDataSource implements DataSource {
             return "com.vertica.jdbc.Driver";
         }
         
+        if (url.startsWith("jdbc:firebirdsql:")) {
+            return "org.firebirdsql.jdbc.FBDriver";
+        }
         return null;
     }
 

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/firebird/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/firebird/createMetaDataTable.sql
@@ -1,0 +1,37 @@
+--
+-- Copyright 2010-2014 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE "${table}" (
+    "version_rank"    INTEGER NOT NULL,
+    "installed_rank"  INTEGER NOT NULL,
+    "version"         VARCHAR(50) NOT NULL,
+    "description"     VARCHAR(200) NOT NULL,
+    "type"          VARCHAR(20) NOT NULL,
+    "script"          VARCHAR(1000) NOT NULL,
+    "checksum"        INTEGER,
+   "installed_by"    VARCHAR(100) NOT NULL,
+    "installed_on"    TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "execution_time"  INTEGER NOT NULL,
+    "success"        SMALLINT NOT NULL
+);
+
+
+ALTER TABLE "${table}" ADD CONSTRAINT "${table}_PK" PRIMARY KEY ("version");
+
+
+CREATE INDEX "${table}_VR_IDX" ON "${table}" ("version_rank");
+CREATE INDEX "${table}_IR_IDX" ON "${table}" ("installed_rank");
+CREATE INDEX "${table}_S_IDX" ON "${table}" ("success");

--- a/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
@@ -35,6 +35,7 @@ public class DbCategory {
     public interface MySQL extends OpenSourceDB {}
     public interface MariaDB extends OpenSourceDB {}
     public interface PostgreSQL extends OpenSourceDB {}
+    public interface Firebird extends OpenSourceDB {}
 
     public interface DB2 extends CommercialDB {}
     public interface Oracle extends CommercialDB {}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/firebird/FirebirdMigrationMediumTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2010-2014 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.firebird;
+
+import java.sql.SQLException;
+import java.util.Properties;
+import javax.sql.DataSource;
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.flywaydb.core.migration.MigrationTestCase;
+
+import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test to demonstrate the migration functionality using Firebird.
+ */
+@SuppressWarnings({"JavaDoc"})
+@Category(DbCategory.Firebird.class)
+public class FirebirdMigrationMediumTest extends MigrationTestCase {
+
+    @Override
+    protected DataSource createDataSource(Properties customProperties) {
+        String user = customProperties.getProperty("firebird.user", "flyway");
+        String password = customProperties.getProperty("firebird.password", "flyway");
+        String url = customProperties.getProperty("firebird.url", "jdbc:firebirdsql://localhost/flyway?encoding=UTF8");
+
+        return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, url, user, password);
+    }
+
+    @Override
+    protected String getQuoteLocation() {
+        return "migration/quote";
+    }
+
+    @Ignore
+    @Override
+    public void migrateMultipleSchemas() throws Exception {
+        //schemas not supported by Firebird
+    }
+
+    @Ignore
+    @Override
+    public void setCurrentSchema() throws Exception {
+        //schemas not supported by Firebird
+    }
+
+    @Ignore
+    @Override
+    public void schemaExists() throws SQLException {
+        //schemas not supported by Firebird
+    }
+
+    @Ignore
+    @Override
+    public void quote() throws Exception {
+        //schemas not supported by Firebird
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,12 @@
                 <optional>true</optional>
             </dependency>
             <dependency>
+                <groupId>org.firebirdsql.jdbc</groupId>
+                <artifactId>jaybird-jdk16</artifactId>
+                <version>2.2.5</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
                 <groupId>com.google.appengine</groupId>
                 <artifactId>appengine-api-1.0-sdk</artifactId>
                 <version>${version.appengine}</version>


### PR DESCRIPTION
First shot at [Firebird](http://www.firebirdsql.org/) support.
MigrationTestCase succeeds :white_check_mark:

the only crude part: flyway needs to run in some kind of auto-commit mode, since Firebird does not allow the mixing of DDL & DML within a single transaction - which would be nothing new as other DBs like Oracle also don't support it, but the problem here is that Firebird does also not perform implicit commits after DDL operations, so flyway could not create its metadataTable and insert the initial version otherwise.

maybe a better approach would be to include explicit commit-statements in the sql-scripts, but as this feels like a more heavy impact on the code base which is required for just this one DB, I just took the pragmatic route with a specialized JdbcTemplate.
