### PR TITLE
change for #830: allow tasks extending AbstractFlywayTask to set their o...

### DIFF
--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
@@ -39,7 +39,7 @@ abstract class AbstractFlywayTask extends DefaultTask {
     /**
      * The flyway {} block in the build script.
      */
-    private FlywayExtension extension
+    protected FlywayExtension extension
 
     AbstractFlywayTask() {
         group = 'Flyway'


### PR DESCRIPTION
Implementation of idea from issue #830:  allow tasks extending AbstractFlywayTask to set their own flyway properties by instantiating extension property specific for their task requirements. 
