### PR TITLE
Allow the flyway-gradle-plugin to compile with 1.6 bytecode

### DIFF
--- a/flyway-gradle-plugin/build.gradle
+++ b/flyway-gradle-plugin/build.gradle
@@ -3,18 +3,20 @@ apply plugin: 'groovy'
 def pomProject = new XmlSlurper().parse(file('pom.xml'))
 
 group = pomProject.parent.groupId
-
 version = pomProject.parent.version
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
 
 repositories {
      mavenLocal()
 }
 
 dependencies {
-	compile "${group}:flyway-core:${version}"
+    compile "${group}:flyway-core:${version}"
     compile gradleApi()
     compile localGroovy()
-	testCompile 'junit:junit:4.11'
+    testCompile 'junit:junit:4.11'
     testCompile 'org.hsqldb:hsqldb:2.2.8'
 }
 
@@ -28,8 +30,8 @@ jar {
 test.dependsOn cleanTest
 
 test {
-	beforeTest { descriptor ->
-    	 println("Running: " + descriptor)
+    beforeTest { descriptor ->
+        println("Running: " + descriptor)
     }
 }
 


### PR DESCRIPTION
This should resolve #779. Curiously enough, this affects OSX builds of IntelliJ when using the Gradle Tooling API inside of IntelliJ since (as of this writing) it still uses the Mac Java 6 runtime under the covers to execute Gradle. Whenever `flyway` is included as a plugin dependency from a Gradle build, it will choke on the 1.7 compiled bytecode in the plugin when trying to parse the build.
