### PR TITLE
log informational messages from the database at INFO level

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
@@ -239,8 +239,12 @@ public class JdbcTemplate {
             } finally {
                 @SuppressWarnings("ThrowableResultOfMethodCallIgnored") SQLWarning warning = statement.getWarnings();
                 while (warning != null) {
-                    LOG.warn(warning.getMessage()
-                            + " (SQL State: " + warning.getSQLState() + " - Error Code: " + warning.getErrorCode() + ")");
+                    if ("00000".equals(warning.getSQLState())) {
+                        LOG.info(warning.getMessage());
+                    } else {
+                        LOG.warn(warning.getMessage()
+                                + " (SQL State: " + warning.getSQLState() + " - Error Code: " + warning.getErrorCode() + ")");
+                    }
                     warning = warning.getNextWarning();
                 }
                 // retrieve all results to ensure all errors are detected


### PR DESCRIPTION
Addresses #774.

Logging at appropriate levels makes it possible for an application using flyway to show users possible migration errors while suppressing expected informational messages.

errors returned by the database are still logged at the WARN level.
