### PR TITLE
Db2zos set sqlid second try

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2zos/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2zos/createMetaDataTable.sql
@@ -13,6 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
 set current sqlid = '${schema}';
 
 CREATE TABLESPACE SDBVERS


### PR DESCRIPTION
Hi

We started to use Flyway 3.1 this week for our db2 z/OS databases. Then we discovered an error when Flyway created schema_version table. The first statement in the createMetaDataTable.sql script had disappered. I tested and found that since I had put the statement to close to the license text, it was deleted by the license plugin.

So I do a second try. 

Christine
