### PR TITLE
Escape command-line arguments.

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -16,9 +16,9 @@
 #
 
 # Save current directory
-OLDDIR=`pwd`
+OLDDIR="$(pwd)"
 cygwin=false
-case "`uname`" in
+case "$(uname)" in
   CYGWIN*) cygwin=true;;
 esac
 
@@ -26,33 +26,33 @@ esac
 PRG="$0"
 
 while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
+  ls="$(ls -ld "$PRG")"
+  link="$(expr "$ls" : '.*-> \(.*\)$')"
   if expr "$link" : '/.*' > /dev/null; then
     PRG="$link"
   else
-    PRG=`dirname "$PRG"`/"$link"
+    PRG="$(dirname "$PRG")/$link"
   fi
 done
 
 # Set the current directory to the installation directory
-INSTALLDIR=`dirname "$PRG"`
+INSTALLDIR="$(dirname "$PRG")"
 cd "$INSTALLDIR"
 
 # Use JAVA_HOME if it is set
 if [ -z "$JAVA_HOME" ]; then
  JAVA_CMD=java
 else
- JAVA_CMD=$JAVA_HOME/bin/java
+ JAVA_CMD="$JAVA_HOME/bin/java"
 fi
 
 CP="./lib/*:./drivers/*"
 
 if $cygwin; then
-  CP=$(cygpath -pw "$CP")
+  CP="$(cygpath -pw "$CP")"
 fi
 
-"$JAVA_CMD" -cp "$CP" org.flywaydb.commandline.Main $@
+"$JAVA_CMD" -cp "$CP" org.flywaydb.commandline.Main "$@"
 
 # Save the exit code
 JAVA_EXIT_CODE=$?


### PR DESCRIPTION
Following the instructions at
http://flywaydb.org/documentation/existing.html on Linux, the following
command fails with `ERROR: Invalid operation: version`:

    ./flyway baseline -Dflyway.baselineVersion=1 \
        -Dflyway.baselineDescription="Base version"

The problem is that the `flyway` Bash script does not properly escape
the command line arguments.

This patch adds quotes around all variables to fix this error. As a
side effect, it also allows to have spaces in the Flyway installation
directory name.