### PR TITLE
Add support for Apache Phoenix (http://phoenix.apache.org/)

### DIFF
--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -140,6 +140,34 @@
             <artifactId>jtds</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-it</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-testing-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-hadoop-compat</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-hadoop2-compat</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.phoenix</groupId>
+            <artifactId>phoenix-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -245,7 +273,8 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$InstallableDB</excludedGroups>
+                            <!-- Don't run the embedded Phoenix test by default, it has its own profile -->
+                            <excludedGroups>org.flywaydb.core.DbCategory$InstallableDB,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -261,7 +290,7 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$CommercialDB</excludedGroups>
+                            <excludedGroups>org.flywaydb.core.DbCategory$CommercialDB,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -294,7 +323,7 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$ContributorSupportedDB</excludedGroups>
+                            <excludedGroups>org.flywaydb.core.DbCategory$ContributorSupportedDB,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -317,7 +346,7 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$DB2zOS,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$SolidDB</excludedGroups>
+                            <excludedGroups>org.flywaydb.core.DbCategory$DB2zOS,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$SolidDB,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -347,7 +376,7 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$Vertica,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$SolidDB</excludedGroups>
+                            <excludedGroups>org.flywaydb.core.DbCategory$Vertica,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$SolidDB,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -370,7 +399,39 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>org.flywaydb.core.DbCategory$Vertica,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$DB2zOS</excludedGroups>
+                            <excludedGroups>org.flywaydb.core.DbCategory$Vertica,org.flywaydb.core.DbCategory$Redshift,org.flywaydb.core.DbCategory$DB2zOS,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>PhoenixDBTest</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <!-- When using Phoenix, bring in extra SLF4J logging bridges so we can turn the log levels on Hadoop, HBase, etc. -->
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                    <version>1.7.7</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                    <version>1.7.7</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!-- Exclude everything but Phoenix -->
+                            <excludedGroups>org.flywaydb.core.DbCategory$CommercialDB,org.flywaydb.core.DbCategory$ContributorSupportedDB,org.flywaydb.core.DbCategory$OpenSourceDB,org.flywaydb.core.DbCategory$Derby,org.flywaydb.core.DbCategory$H2,org.flywaydb.core.DbCategory$HSQL,org.flywaydb.core.DbCategory$SQLite</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
 import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
 import org.flywaydb.core.internal.dbsupport.mysql.MySQLDbSupport;
 import org.flywaydb.core.internal.dbsupport.oracle.OracleDbSupport;
+import org.flywaydb.core.internal.dbsupport.phoenix.PhoenixDbSupport;
 import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLDbSupport;
 import org.flywaydb.core.internal.dbsupport.redshift.RedshiftDbSupport;
 import org.flywaydb.core.internal.dbsupport.solid.SolidDbSupport;
@@ -115,6 +116,9 @@ public class DbSupportFactory {
             // In the meanwhile IBM also sold solidDB to Unicom Systems.
             // Therefore no vendor string in search criteria
             return new SolidDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("Phoenix")) {
+            return new PhoenixDbSupport(connection);
         }
 
         throw new FlywayException("Unsupported Database: " + databaseProductName);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixDbSupport.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.phoenix;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * H2 database specific support
+ */
+public class PhoenixDbSupport extends DbSupport {
+    private static final Log LOG = LogFactory.getLog(PhoenixDbSupport.class);
+
+    public PhoenixDbSupport(Connection connection) {
+        super(new JdbcTemplate(connection, Types.VARCHAR));
+    }
+
+    public String getDbName() {
+        return "phoenix";
+    }
+
+    // Support quoting when given a null identifier. This happens when Phoenix
+    // has a null schema
+
+    public String quote(String... identifiers) {
+        String result = "";
+
+        boolean first = true;
+        boolean lastNull = false;
+        for (String identifier : identifiers) {
+            if (!first && !lastNull) {
+                result += ".";
+            }
+            first = false;
+            if(identifier == null) {
+                lastNull = true;
+            }
+            else {
+                result += doQuote(identifier);
+                lastNull = false;
+            }
+        }
+
+        return result;
+    }
+
+
+    @Override
+    protected void doSetCurrentSchema(Schema schema) throws SQLException {
+        LOG.info("Phoenix does not support setting the schema. Default schema NOT changed to " + schema);
+    }
+
+    @Override
+    public String getCurrentUserFunction()  {
+        String userName = null;
+        try {
+            userName = jdbcTemplate.getMetaData().getUserName();
+        } catch (SQLException e) { }
+
+        return userName;
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "TRUE";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "FALSE";
+    }
+
+    // Phoenix uses a null schema name by default
+    @Override
+    protected String doGetCurrentSchema() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Schema getCurrentSchema() {
+        try {
+            return getSchema(doGetCurrentSchema());
+        } catch (SQLException e) {
+            throw new FlywayException("Unable to retrieve the current schema for the connection", e);
+        }
+    }
+
+    public SqlStatementBuilder createSqlStatementBuilder() {
+        return new SqlStatementBuilder();
+    }
+
+    @Override
+    public String doQuote(String identifier) {
+        return "\"" + identifier + "\"";
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new PhoenixSchema(jdbcTemplate, this, name);
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixSchema.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.phoenix;
+
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+import org.flywaydb.core.internal.util.Pair;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.flywaydb.core.internal.util.jdbc.RowMapper;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Phoenix implementation of Schema.
+ */
+public class PhoenixSchema extends Schema<PhoenixDbSupport> {
+    private static final Log LOG = LogFactory.getLog(PhoenixSchema.class);
+
+    /**
+     * Creates a new Phoenix schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport    The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public PhoenixSchema(JdbcTemplate jdbcTemplate, PhoenixDbSupport dbSupport, String name) {
+        super(jdbcTemplate, dbSupport, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        if (name == null) {
+            return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSTEM.CATALOG WHERE table_schem IS NULL") > 0;
+        }
+        else {
+            return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSTEM.CATALOG WHERE table_schem=?", name) > 0;
+        }
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        return allTables().length == 0;
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        LOG.info("Phoenix does not support creating schemas. Schema not created: " + name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        LOG.info("Phoenix does not support dropping schemas directly. Running clean of objects instead");
+        doClean();
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        // Clean sequences
+        List<String> sequenceNames = listObjectsOfType("sequence");
+        for (String statement : generateDropStatements("SEQUENCE", sequenceNames, "")) {
+            jdbcTemplate.execute(statement);
+        }
+
+        // Clean views
+        List<String> viewNames = listObjectsOfType("view");
+        for (String statement : generateDropStatements("VIEW", viewNames, "")) {
+            jdbcTemplate.execute(statement);
+        }
+
+        // Clean indices - bit more complicated, the statement needs an index name and a table name
+        // listObjectsOfType("index") gives us a comma separated list of each
+
+        List<String> indexPairs = listObjectsOfType("index");
+        List<String> indexNames = new ArrayList<String>();
+        List<String> indexTables = new ArrayList<String>();
+        for(String indexPair : indexPairs) {
+            String[] splits = indexPair.split(",");
+            indexNames.add(splits[0]);
+            indexTables.add("ON " + dbSupport.quote(name, splits[1]));
+        }
+
+        // Generate statements for each index
+        List<String> statements = generateDropIndexStatements(indexNames, indexTables);
+        for(String statement: statements) {
+            jdbcTemplate.execute(statement);
+        }
+
+        // Drop each table
+        for (Table table : allTables()) {
+            table.drop();
+        }
+    }
+
+    /**
+     * Generate the statements for dropping all the objects of this type in this schema.
+     *
+     * @param objectType          The type of object to drop (Sequence, constant, ...)
+     * @param objectNames         The names of the objects to drop.
+     * @param dropStatementSuffix Suffix to append to the statement for dropping the objects.
+     * @return The list of statements.
+     */
+    private List<String> generateDropStatements(String objectType, List<String> objectNames, String dropStatementSuffix) {
+        List<String> statements = new ArrayList<String>();
+        for (String objectName : objectNames) {
+            String dropStatement =
+                    "DROP " + objectType + dbSupport.quote(name, objectName) + " " + dropStatementSuffix;
+
+            statements.add(dropStatement);
+        }
+        return statements;
+    }
+
+    private List<String> generateDropIndexStatements(List<String> objectNames, List<String> dropStatementSuffixes) {
+        List<String> statements = new ArrayList<String>();
+        for (int i = 0; i < objectNames.size(); i++) {
+            String dropStatement =
+                    "DROP INDEX " + dbSupport.quote(objectNames.get(i)) + " " + dropStatementSuffixes.get(i);
+
+            statements.add(dropStatement);
+        }
+        return statements;
+    }
+
+    @Override
+    protected Table[] doAllTables() throws SQLException {
+        List<String> tableNames = listObjectsOfType("table");
+
+        Table[] tables = new Table[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new PhoenixTable(jdbcTemplate, dbSupport, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    /**
+     * List the names of the objects of this type in this schema.
+     *
+     * @return The names of the objects.
+     * @throws java.sql.SQLException when the object names could not be listed.
+     */
+
+    protected List<String> listObjectsOfType(String type) throws SQLException {
+        if (type.equalsIgnoreCase("sequence")) {
+            if(name == null) {
+                String query = "SELECT SEQUENCE_NAME FROM SYSTEM.\"SEQUENCE\" WHERE SEQUENCE_SCHEMA IS NULL";
+                return jdbcTemplate.queryForStringList(query);
+            }
+            else {
+                String query = "SELECT SEQUENCE_NAME FROM SYSTEM.\"SEQUENCE\" WHERE SEQUENCE_SCHEMA = ?";
+                return jdbcTemplate.queryForStringList(query, name);
+            }
+        }
+
+        // Construct a general query structure for objects in the catalog
+        String queryStart = "SELECT TABLE_NAME FROM SYSTEM.CATALOG WHERE TABLE_SCHEM";
+        String queryMid = "";
+        String queryEnd = "";
+
+        if(name == null) {
+            queryMid += " IS NULL";
+        }
+        else {
+            queryMid += " = ?";
+        }
+
+        String tableType = "";
+        if (type.equalsIgnoreCase("table")) {
+            tableType = "u";
+        }
+        else if (type.equalsIgnoreCase("view")) {
+            tableType = "v";
+        }
+        else if (type.equalsIgnoreCase("index")) {
+            tableType = "i";
+
+            // Indices have two components, index name and table name so we'll have to fix up the query
+            queryStart = "SELECT TABLE_NAME, DATA_TABLE_NAME FROM SYSTEM.CATALOG WHERE TABLE_SCHEM";
+            queryEnd = " AND TABLE_TYPE = '" + tableType + "'";
+
+            // Create the final query, however jdbcTemplate.query doesn't take parameters
+            // We'll populate the schema name ourselves if needed
+
+            String query = queryStart + queryMid.replaceFirst("\\?", "'" + name + "'") + queryEnd;
+
+            // Return the index and table as a comma separated string
+            return jdbcTemplate.query(query, new RowMapper<String> () {
+                @Override
+                public String mapRow(ResultSet rs) throws SQLException {
+                    return rs.getString("TABLE_NAME") + "," + rs.getString("DATA_TABLE_NAME");
+                }
+            });
+        }
+
+        // Assemble the query for an index or a view
+        queryEnd = " AND TABLE_TYPE = '" + tableType + "'";
+        String query = queryStart + queryMid + queryEnd;
+
+        if(name == null) {
+            return jdbcTemplate.queryForStringList(query);
+        }
+        else {
+            return jdbcTemplate.queryForStringList(query, name);
+        }
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new PhoenixTable(jdbcTemplate, dbSupport, this, tableName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Schema schema = (Schema) o;
+        if(name == null) {
+            return name == schema.getName();
+        }
+        else {
+            return name.equals(schema.getName());
+        }
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixTable.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.phoenix;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import java.sql.SQLException;
+
+/**
+ * Phoenix-specific table.
+ */
+public class PhoenixTable extends Table {
+    private static final Log LOG = LogFactory.getLog(PhoenixTable.class);
+    /**
+     * Creates a new Phoenix table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport    The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public PhoenixTable(JdbcTemplate jdbcTemplate, DbSupport dbSupport, Schema schema, String name) {
+        super(jdbcTemplate, dbSupport, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + dbSupport.quote(schema.getName(), name));
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        if(schema.getName() == null) {
+            return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSTEM.CATALOG WHERE TABLE_NAME = ? and TABLE_SCHEM IS NULL AND TABLE_TYPE = 'u'", name) > 0;
+        }
+        else {
+            return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSTEM.CATALOG WHERE TABLE_NAME = ? and TABLE_SCHEM = ? AND TABLE_TYPE = 'u'", name, schema.getName()) > 0;
+        }
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        LOG.debug("Unable to lock " + this + " as Phoenix does not support locking. No concurrent migration supported.");
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/phoenix/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.dbsupport.phoenix;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
@@ -18,11 +18,7 @@ package org.flywaydb.core.internal.metadatatable;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
-import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
-import org.flywaydb.core.internal.dbsupport.Schema;
-import org.flywaydb.core.internal.dbsupport.SqlScript;
-import org.flywaydb.core.internal.dbsupport.Table;
+import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.flywaydb.core.internal.util.jdbc.RowMapper;
@@ -32,11 +28,7 @@ import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Supports reading and writing to the metadata table.
@@ -106,35 +98,80 @@ public class MetaDataTableImpl implements MetaDataTable {
         createIfNotExists();
 
         MigrationVersion version = appliedMigration.getVersion();
+
         try {
             int versionRank = calculateVersionRank(version);
 
-            jdbcTemplate.update("UPDATE " + table
-                    + " SET " + dbSupport.quote("version_rank") + " = " + dbSupport.quote("version_rank")
-                    + " + 1 WHERE " + dbSupport.quote("version_rank") + " >= ?", versionRank);
-            jdbcTemplate.update("INSERT INTO " + table
-                            + " (" + dbSupport.quote("version_rank")
-                            + "," + dbSupport.quote("installed_rank")
-                            + "," + dbSupport.quote("version")
-                            + "," + dbSupport.quote("description")
-                            + "," + dbSupport.quote("type")
-                            + "," + dbSupport.quote("script")
-                            + "," + dbSupport.quote("checksum")
-                            + "," + dbSupport.quote("installed_by")
-                            + "," + dbSupport.quote("execution_time")
-                            + "," + dbSupport.quote("success")
-                            + ")"
-                            + " VALUES (?, ?, ?, ?, ?, ?, ?, " + dbSupport.getCurrentUserFunction() + ", ?, ?)",
-                    versionRank,
-                    calculateInstalledRank(),
-                    version.toString(),
-                    appliedMigration.getDescription(),
-                    appliedMigration.getType().name(),
-                    appliedMigration.getScript(),
-                    appliedMigration.getChecksum(),
-                    appliedMigration.getExecutionTime(),
-                    appliedMigration.isSuccess()
-            );
+            // Try load an updateMetaDataTable.sql file if it exists
+            try {
+                String resourceName = "org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/updateMetaDataTable.sql";
+                String source = new ClassPathResource(resourceName, getClass().getClassLoader()).loadAsString("UTF-8");
+                Map<String, String> placeholders = new HashMap<String, String>();
+
+                // Placeholders for column names
+                placeholders.put("schema", table.getSchema().getName());
+                placeholders.put("table", table.getName());
+                placeholders.put("version_rank", dbSupport.quote("version_rank"));
+                placeholders.put("installed_rank", dbSupport.quote("installed_rank"));
+                placeholders.put("version", dbSupport.quote("version"));
+                placeholders.put("description", dbSupport.quote("description"));
+                placeholders.put("type", dbSupport.quote("type"));
+                placeholders.put("script", dbSupport.quote("script"));
+                placeholders.put("checksum", dbSupport.quote("checksum"));
+                placeholders.put("installed_by", dbSupport.quote("installed_by"));
+                placeholders.put("installed_on", dbSupport.quote("installed_by"));
+                placeholders.put("execution_time", dbSupport.quote("execution_time"));
+                placeholders.put("success", dbSupport.quote("success"));
+
+                // Placeholders for column values
+                placeholders.put("version_rank_val", String.valueOf(versionRank));
+                placeholders.put("installed_rank_val", String.valueOf(calculateInstalledRank()));
+                placeholders.put("version_val", version.toString());
+                placeholders.put("description_val", appliedMigration.getDescription());
+                placeholders.put("type_val", appliedMigration.getType().name());
+                placeholders.put("script_val", appliedMigration.getScript());
+                placeholders.put("checksum_val", String.valueOf(appliedMigration.getChecksum()));
+                placeholders.put("installed_by_val", dbSupport.getCurrentUserFunction());
+                placeholders.put("execution_time_val", String.valueOf(appliedMigration.getExecutionTime() * 1000L));
+                placeholders.put("success_val", String.valueOf(appliedMigration.isSuccess()));
+
+                String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+
+                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+
+                sqlScript.execute(jdbcTemplate);
+
+            }
+            // Fall back to hard-coded statements
+            catch (FlywayException e) {
+                jdbcTemplate.update("UPDATE " + table
+                        + " SET " + dbSupport.quote("version_rank") + " = " + dbSupport.quote("version_rank")
+                        + " + 1 WHERE " + dbSupport.quote("version_rank") + " >= ?", versionRank);
+                jdbcTemplate.update("INSERT INTO " + table
+                                + " (" + dbSupport.quote("version_rank")
+                                + "," + dbSupport.quote("installed_rank")
+                                + "," + dbSupport.quote("version")
+                                + "," + dbSupport.quote("description")
+                                + "," + dbSupport.quote("type")
+                                + "," + dbSupport.quote("script")
+                                + "," + dbSupport.quote("checksum")
+                                + "," + dbSupport.quote("installed_by")
+                                + "," + dbSupport.quote("execution_time")
+                                + "," + dbSupport.quote("success")
+                                + ")"
+                                + " VALUES (?, ?, ?, ?, ?, ?, ?, " + dbSupport.getCurrentUserFunction() + ", ?, ?)",
+                        versionRank,
+                        calculateInstalledRank(),
+                        version.toString(),
+                        appliedMigration.getDescription(),
+                        appliedMigration.getType().name(),
+                        appliedMigration.getScript(),
+                        appliedMigration.getChecksum(),
+                        appliedMigration.getExecutionTime(),
+                        appliedMigration.isSuccess()
+                );
+            }
+
             LOG.debug("MetaData table " + table + " successfully updated to reflect changes");
         } catch (SQLException e) {
             throw new FlywayException("Unable to insert row for version '" + version + "' in metadata table " + table, e);
@@ -353,12 +390,38 @@ public class MetaDataTableImpl implements MetaDataTable {
     @Override
     public void updateChecksum(MigrationVersion version, Integer checksum) {
         LOG.info("Updating checksum of " + version + " to " + checksum + " ...");
+
+        // Try load an updateChecksum.sql file if it exists
         try {
-            jdbcTemplate.update("UPDATE " + table + " SET " + dbSupport.quote("checksum") + "=" + checksum
-                    + " WHERE " + dbSupport.quote("version") + "='" + version + "'");
-        } catch (SQLException e) {
-            throw new FlywayException("Unable to update checksum in metadata table " + table
-                    + " for version " + version + " to " + checksum, e);
+            String resourceName = "org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/updateChecksum.sql";
+            String source = new ClassPathResource(resourceName, getClass().getClassLoader()).loadAsString("UTF-8");
+            Map<String, String> placeholders = new HashMap<String, String>();
+
+            // Placeholders for column names
+            placeholders.put("schema", table.getSchema().getName());
+            placeholders.put("table", table.getName());
+            placeholders.put("version", dbSupport.quote("version"));
+            placeholders.put("checksum", dbSupport.quote("checksum"));
+
+            // Placeholders for column values
+            placeholders.put("version_val", version.toString());
+            placeholders.put("checksum_val", String.valueOf(checksum));
+
+            String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+
+            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+
+            sqlScript.execute(jdbcTemplate);
+
+        } catch (FlywayException fe) {
+            try {
+                jdbcTemplate.update("UPDATE " + table + " SET " + dbSupport.quote("checksum") + "=" + checksum
+                        + " WHERE " + dbSupport.quote("version") + "='" + version + "'");
+            }
+            catch (SQLException e) {
+                throw new FlywayException("Unable to update checksum in metadata table " + table
+                        + " for version " + version + " to " + checksum, e);
+            }
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -192,6 +192,10 @@ public class DriverDataSource implements DataSource {
             return "oracle.jdbc.OracleDriver";
         }
 
+        if (url.startsWith("jdbc:phoenix")) {
+            return "org.apache.phoenix.jdbc.PhoenixDriver";
+        }
+
         if (url.startsWith("jdbc:postgresql:")) {
             // The format of Redshift JDBC urls is the same as PostgreSQL, and Redshift uses the same JDBC driver
             return "org.postgresql.Driver";

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/createMetaDataTable.sql
@@ -1,0 +1,35 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Create table
+CREATE TABLE "${schema}"."${table}" (
+    "version" VARCHAR(50) NOT NULL PRIMARY KEY,
+    "version_rank" INTEGER,
+    "installed_rank" INTEGER,
+    "description" VARCHAR(200),
+    "type" VARCHAR(20),
+    "script" VARCHAR(1000),
+    "checksum" INTEGER,
+    "installed_by" VARCHAR(100),
+    "installed_on" TIMESTAMP,
+    "execution_time" INTEGER,
+    "success" BOOLEAN
+);
+
+-- Create indices
+CREATE INDEX "${table}_vr_idx" ON "${schema}"."${table}" ("version_rank");
+CREATE INDEX "${table}_ir_idx" ON "${schema}"."${table}" ("installed_rank");
+CREATE INDEX "${table}_s_idx" ON "${schema}"."${table}" ("success");

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateChecksum.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateChecksum.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+-- Update checksum for a version
+UPSERT INTO "${schema}"."${table}" (
+    ${version},
+    ${checksum}
+) VALUES (
+     '${version_val}',
+     ${checksum_val}
+);

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateMetaDataTable.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Update version ranks if needed
+UPSERT INTO "${schema}"."${table}"
+SELECT     ${version},
+           ${version_rank} + 1 AS ${version_rank},
+           ${installed_rank}
+           ${version},
+           ${description},
+           ${type},
+           ${script},
+           ${checksum},
+           ${installed_by},
+           CURRENT_TIME(),
+           ${execution_time},
+           ${success}
+FROM       "${schema}"."${table}"
+WHERE      ${version_rank} >= ${version_rank_val};
+
+-- Add new metadata row
+UPSERT INTO "${schema}"."${table}" VALUES (
+    '${version_val}',
+    ${version_rank_val},
+    ${installed_rank_val},
+    '${description_val}',
+    '${type_val}',
+    '${script_val}',
+    ${checksum_val},
+    '${installed_by_val}',
+    CURRENT_TIME(),
+    ${execution_time_val},
+    ${success_val}
+);

--- a/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
@@ -31,6 +31,7 @@ public class DbCategory {
     public interface H2 extends EmbeddedDB {}
     public interface HSQL extends EmbeddedDB {}
     public interface SQLite extends EmbeddedDB {}
+    public interface Phoenix extends EmbeddedDB {}
 
     public interface MySQL extends OpenSourceDB {}
     public interface MariaDB extends OpenSourceDB {}
@@ -45,4 +46,5 @@ public class DbCategory {
     public interface Vertica extends ContributorSupportedDB {}
     public interface Redshift extends ContributorSupportedDB {}
     public interface SolidDB extends ContributorSupportedDB {}
+
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/phoenix/PhoenixMigrationMediumTest.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.phoenix;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.*;
+import org.flywaydb.core.internal.dbsupport.FlywaySqlScriptException;
+import org.flywaydb.core.migration.MigrationTestCase;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import javax.sql.DataSource;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+
+/**
+ * Test to demonstrate the migration functionality using Phoenix.
+ */
+@Category(DbCategory.Phoenix.class)
+public class PhoenixMigrationMediumTest extends MigrationTestCase {
+    private static final Log LOG = LogFactory.getLog(PhoenixMigrationMediumTest.class);
+
+    @Override
+    protected String getBaseDir() { return "migration/dbsupport/phoenix/sql/sql"; }
+
+    protected static HBaseTestingUtility testUtility = null;
+    protected static DriverDataSource dataSource = null;
+
+    @BeforeClass
+    public static void beforeClassSetUp() throws Exception {
+        // Startup HBase in-memory cluster
+        LOG.info("Starting mini-cluster");
+        testUtility = new HBaseTestingUtility();
+        testUtility.startMiniCluster();
+
+        // Set up Phoenix schema
+        String server = testUtility.getConfiguration().get("hbase.zookeeper.quorum");
+        String port = testUtility.getConfiguration().get("hbase.zookeeper.property.clientPort");
+        String zkServer = server + ":" + port;
+
+        dataSource = new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, "jdbc:phoenix:" + zkServer, "", "");
+    }
+
+
+    @Override
+    protected DataSource createDataSource(Properties customProperties) throws Exception {
+       return dataSource;
+       //return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, "jdbc:phoenix:dbserver", "", "");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Don't close the connection after each test
+    }
+
+    @AfterClass
+    public static void afterClassTearDown() throws Exception {
+        LOG.info("Shutting down mini-cluster");
+        dataSource.close();
+        testUtility.shutdownMiniCluster();
+    }
+
+    @Override
+    protected String getQuoteLocation() {
+        return "migration/dbsupport/phoenix/sql/quote";
+    }
+
+    @Test
+    public void repair() throws Exception {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/future_failed");
+        assertEquals(4, flyway.info().all().length);
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywayException e) {
+            //Expected
+        }
+
+        if (dbSupport.supportsDdlTransactions()) {
+            assertEquals("2.0", flyway.info().current().getVersion().toString());
+            assertEquals(MigrationState.SUCCESS, flyway.info().current().getState());
+        } else {
+            assertEquals("3", flyway.info().current().getVersion().toString());
+            assertEquals(MigrationState.FAILED, flyway.info().current().getState());
+        }
+
+        flyway.repair();
+        assertEquals("2.0", flyway.info().current().getVersion().toString());
+        assertEquals(MigrationState.SUCCESS, flyway.info().current().getState());
+    }
+
+    @Test
+    public void repairChecksum() {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/comment");
+        Integer commentChecksum = flyway.info().pending()[0].getChecksum();
+
+        flyway.setLocations(getQuoteLocation());
+        Integer quoteChecksum = flyway.info().pending()[0].getChecksum();
+
+        assertNotEquals(commentChecksum, quoteChecksum);
+
+        flyway.migrate();
+        assertEquals(quoteChecksum, flyway.info().applied()[1].getChecksum());
+
+        flyway.setLocations("migration/dbsupport/phoenix/sql/comment");
+        flyway.repair();
+        assertEquals(commentChecksum, flyway.info().applied()[1].getChecksum());
+    }
+
+    @Test(expected = FlywayException.class)
+    public void validateMoreAppliedThanAvailable() throws Exception {
+        flyway.setLocations(getBaseDir());
+        flyway.migrate();
+
+        assertEquals("2.0", flyway.info().current().getVersion().toString());
+
+        flyway.setLocations("migration/dbsupport/phoenix/sql/validate");
+        flyway.validate();
+    }
+
+    @Test
+    public void validateClean() throws Exception {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/validate");
+        flyway.migrate();
+
+        assertEquals("1", flyway.info().current().getVersion().toString());
+
+        flyway.setValidateOnMigrate(true);
+        flyway.setCleanOnValidationError(true);
+        flyway.setSqlMigrationPrefix("PhoenixCheckValidate");
+        assertEquals(1, flyway.migrate());
+    }
+
+    @Test
+    public void failedMigration() throws Exception {
+        String tableName = "before_the_error";
+
+        flyway.setLocations("migration/dbsupport/phoenix/sql/failed");
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put("tableName", dbSupport.quote(tableName));
+        flyway.setPlaceholders(placeholders);
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywaySqlScriptException e) {
+            System.out.println(e.getMessage());
+            // root cause of exception must be defined, and it should be FlywaySqlScriptException
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof SQLException);
+            // and make sure the failed statement was properly recorded
+            assertEquals(21, e.getLineNumber());
+            assertEquals("THIS IS NOT VALID SQL", e.getStatement());
+        }
+
+        MigrationInfo migration = flyway.info().current();
+        assertEquals(
+                dbSupport.supportsDdlTransactions(),
+                !dbSupport.getCurrentSchema().getTable(tableName).exists());
+        if (dbSupport.supportsDdlTransactions()) {
+            assertNull(migration);
+        } else {
+            MigrationVersion version = migration.getVersion();
+            assertEquals("1", version.toString());
+            assertEquals("Should Fail", migration.getDescription());
+            assertEquals(MigrationState.FAILED, migration.getState());
+            assertEquals(2, flyway.info().applied().length);
+        }
+    }
+
+    @Test
+    public void futureFailedMigration() throws Exception {
+        flyway.setValidateOnMigrate(false);
+        flyway.setLocations("migration/dbsupport/phoenix/sql/future_failed");
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywayException e) {
+            //Expected
+        }
+
+        flyway.setLocations(getBaseDir());
+        if (dbSupport.supportsDdlTransactions()) {
+            flyway.migrate();
+        } else {
+            try {
+                flyway.migrate();
+                fail();
+            } catch (FlywayException e) {
+                //Expected
+            }
+        }
+    }
+
+    @Test
+    public void futureFailedMigrationIgnore() throws Exception {
+        flyway.setValidateOnMigrate(false);
+        flyway.setLocations("migration/dbsupport/phoenix/sql/future_failed");
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywayException e) {
+            //Expected
+        }
+
+        flyway.setIgnoreFailedFutureMigration(true);
+        flyway.setLocations(getBaseDir());
+        flyway.migrate();
+    }
+
+    @Test
+    public void futureFailedMigrationIgnoreAvailableMigrations() throws Exception {
+        flyway.setValidateOnMigrate(false);
+        flyway.setLocations("migration/dbsupport/phoenix/sql/future_failed");
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywayException e) {
+            //Expected
+        }
+
+        flyway.setIgnoreFailedFutureMigration(true);
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywayException e) {
+            if (dbSupport.supportsDdlTransactions()) {
+                assertTrue(e.getMessage().contains("THIS IS NOT VALID SQL"));
+            } else {
+                assertTrue(e.getMessage().contains("contains a failed migration"));
+            }
+        }
+    }
+
+    @Test(expected = FlywayException.class)
+    public void nonEmptySchema() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE t1 (\n" +
+                "  name VARCHAR(25) NOT NULL PRIMARY KEY\n" +
+                "  )");
+
+        flyway.setLocations(getBaseDir());
+        flyway.migrate();
+    }
+
+    @Test
+    public void nonEmptySchemaWithInit() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE t1 (\n" +
+                "  name VARCHAR(25) NOT NULL PRIMARY KEY\n" +
+                "  )");
+
+        flyway.setLocations(getBaseDir());
+        flyway.setBaselineVersionAsString("0");
+        flyway.baseline();
+        flyway.migrate();
+    }
+
+    @Test
+    public void nonEmptySchemaWithInitOnMigrate() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE t1 (\n" +
+                "  name VARCHAR(25) NOT NULL PRIMARY KEY\n" +
+                "  )");
+
+        flyway.setLocations(getBaseDir());
+        flyway.setBaselineVersionAsString("0");
+        flyway.setBaselineOnMigrate(true);
+        flyway.migrate();
+        MigrationInfo[] migrationInfos = flyway.info().all();
+
+        assertEquals(5, migrationInfos.length);
+
+        assertEquals(MigrationType.BASELINE, migrationInfos[0].getType());
+        assertEquals("0", migrationInfos[0].getVersion().toString());
+
+        assertEquals("2.0", flyway.info().current().getVersion().toString());
+    }
+
+    @Test
+    public void nonEmptySchemaWithInitOnMigrateHighVersion() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE t1 (\n" +
+                "  name VARCHAR(25) NOT NULL PRIMARY KEY\n" +
+                "  )");
+
+        flyway.setLocations(getBaseDir());
+        flyway.setBaselineOnMigrate(true);
+        flyway.setBaselineVersion(MigrationVersion.fromVersion("99"));
+        flyway.migrate();
+        MigrationInfo[] migrationInfos = flyway.info().all();
+
+        assertEquals(5, migrationInfos.length);
+
+        assertEquals(MigrationType.SQL, migrationInfos[0].getType());
+        assertEquals("1", migrationInfos[0].getVersion().toString());
+        assertEquals(MigrationState.BELOW_BASELINE, migrationInfos[0].getState());
+
+        MigrationInfo migrationInfo = flyway.info().current();
+        assertEquals(MigrationType.BASELINE, migrationInfo.getType());
+        assertEquals("99", migrationInfo.getVersion().toString());
+    }
+
+    @Test
+    public void semicolonWithinStringLiteral() throws Exception {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/semicolon");
+        flyway.migrate();
+
+        assertEquals("1.1", flyway.info().current().getVersion().toString());
+        assertEquals("Populate table", flyway.info().current().getDescription());
+        assertEquals("Mr. Semicolon+Linebreak;\nanother line",
+                jdbcTemplate.queryForString("SELECT * FROM test_user ORDER BY LENGTH(NAME) DESC LIMIT 1"));
+    }
+
+    @Test
+    public void migrateMultipleSchemas() throws Exception {
+        flyway.setSchemas("flyway_1", "flyway_2", "flyway_3");
+        flyway.clean();
+
+        flyway.setLocations("migration/dbsupport/phoenix/sql/multi");
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put("schema1", dbSupport.quote("flyway_1"));
+        placeholders.put("schema2", dbSupport.quote("flyway_2"));
+        placeholders.put("schema3", dbSupport.quote("flyway_3"));
+        flyway.setPlaceholders(placeholders);
+        flyway.migrate();
+        assertEquals("2.0", flyway.info().current().getVersion().toString());
+        assertEquals("Add foreign key", flyway.info().current().getDescription());
+        assertEquals(0, flyway.migrate());
+
+        assertEquals(4, flyway.info().applied().length);
+        assertEquals(2, jdbcTemplate.queryForInt("select count(*) from " + dbSupport.quote("flyway_1") + ".test_user1"));
+        assertEquals(2, jdbcTemplate.queryForInt("select count(*) from " + dbSupport.quote("flyway_2") + ".test_user2"));
+        assertEquals(2, jdbcTemplate.queryForInt("select count(*) from " + dbSupport.quote("flyway_3") + ".test_user3"));
+
+        flyway.clean();
+    }
+
+    @Ignore
+    public void setCurrentSchema() throws Exception {
+        //Not supported by Phoenix
+    }
+
+    @Test
+    public void subDir() {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/subdir");
+        assertEquals(3, flyway.migrate());
+    }
+
+    @Test
+    public void comment() {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/comment");
+        assertEquals(1, flyway.migrate());
+    }
+
+    @Test
+    public void outOfOrderMultipleRankIncrease() {
+        flyway.setLocations("migration/dbsupport/phoenix/sql/sql");
+        flyway.migrate();
+
+        flyway.setLocations("migration/dbsupport/phoenix/sql/sql", "migration/dbsupport/phoenix/sql/outoforder");
+        flyway.setOutOfOrder(true);
+        flyway.migrate();
+
+        assertEquals(org.flywaydb.core.api.MigrationState.OUT_OF_ORDER, flyway.info().all()[3].getState());
+    }
+
+    @Test
+    public void schemaExists() throws SQLException {
+        assertFalse(dbSupport.getSchema("InVaLidScHeMa").exists());
+    }
+}

--- a/flyway-core/src/test/resources/hbase-site.xml
+++ b/flyway-core/src/test/resources/hbase-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2010-2015 Axel Fontaine
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <!-- This is needed for index creation for Apache Phoenix -->
+  <property>
+    <name>hbase.regionserver.wal.codec</name>
+    <value>org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec</value>
+  </property>
+</configuration>

--- a/flyway-core/src/test/resources/logback.xml
+++ b/flyway-core/src/test/resources/logback.xml
@@ -28,4 +28,13 @@
     </root>
 
     <logger name="org.springframework" level="INFO"/>
+
+    <!-- Phoenix and the HBase minicluster are extremely verbose by default -->
+    <logger name="org.mortbay" level="WARN"/>
+    <logger name="org.apache.commons" level="WARN"/>
+    <logger name="org.apache.hadoop" level="ERROR"/>
+    <logger name="org.apache.jasper" level="WARN"/>
+    <logger name="org.apache.phoenix" level="ERROR"/>
+    <logger name="org.apache.zookeeper" level="WARN"/>
+    <logger name="BlockStateChange" level="WARN"/>
 </configuration>

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/comment/V1__Comment.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/comment/V1__Comment.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+/*
+   First ' comment
+ */
+CREATE TABLE user1 (
+  name VARCHAR(25) NOT NULL
+  -- second '
+  CONSTRAINT pk PRIMARY KEY(name)
+);
+
+CREATE TABLE group1 (
+/*
+  third '
+ */
+  name VARCHAR(25) NOT NULL
+  CONSTRAINT pk PRIMARY KEY(name)
+);
+
+-- 'fourth'
+CREATE TABLE table1 (
+-- ' fifth
+  name VARCHAR(25) NOT NULL
+  CONSTRAINT pk PRIMARY KEY(name)
+);
+
+CREATE TABLE table2 (
+/*'
+  sixth
+ '*/
+  name VARCHAR(25) NOT NULL
+  CONSTRAINT pk PRIMARY KEY(name)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/current_schema/V1__Current.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/current_schema/V1__Current.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user1 (
+  name VARCHAR(25) NOT NULL  -- this is a valid comment
+  CONSTRAINT pk PRIMARY KEY(name)
+);
+
+INSERT INTO ${schema1}.test_user1 (name) VALUES ('Mr. T');
+INSERT INTO ${schema1}.test_user1 (name) VALUES ('Mr. Semicolon;');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/failed/V1__Should_Fail.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/failed/V1__Should_Fail.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${tableName} (
+  id INTEGER PRIMARY KEY
+);
+
+THIS IS NOT VALID SQL;
+THIS MIGRATION SHOULD FAIL;

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V1_1__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V1_1__Populate_table.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO test_user (name) VALUES ('Mr. T');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V1__First.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  name VARCHAR(25) NOT NULL PRIMARY KEY
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V2_0__Add_couple_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V2_0__Add_couple_table.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE couple (
+  id INTEGER NOT NULL,
+  name1 VARCHAR(25),
+  name2 VARCHAR(25)
+  CONSTRAINT pk PRIMARY KEY (id)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V3__Should_Fail.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/future_failed/V3__Should_Fail.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+THIS IS NOT VALID SQL;
+THIS MIGRATION SHOULD FAIL;

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V1_2__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V1_2__Populate_table.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO ${schema1}.test_user1 (name) VALUES ('Mr. T');
+UPSERT INTO ${schema1}.test_user1 (name) VALUES ('Mr. Semicolon;');
+
+UPSERT INTO ${schema2}.test_user2 (name) VALUES ('Mr. T');
+UPSERT INTO ${schema2}.test_user2 (name) VALUES ('Mr. Semicolon;');
+
+UPSERT INTO ${schema3}.test_user3 (name) VALUES ('Mr. T');
+UPSERT INTO ${schema3}.test_user3 (name) VALUES ('Mr. Semicolon;');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V1__First.sql
@@ -1,0 +1,27 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${schema1}.test_user1 (
+  name VARCHAR(25) NOT NULL PRIMARY KEY  -- this is a valid comment
+);
+
+CREATE TABLE ${schema2}.test_user2 (
+  name VARCHAR(25) NOT NULL PRIMARY KEY -- this is a valid comment
+);
+
+CREATE TABLE ${schema3}.test_user3 (
+  name VARCHAR(25) NOT NULL PRIMARY KEY  -- this is a valid comment
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V2_0__Add_couple_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/multi/V2_0__Add_couple_table.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${schema1}.couple1 (
+  id INTEGER NOT NULL,
+  name1 VARCHAR(25) NOT NULL,
+  name2 VARCHAR(25) NOT NULL
+  CONSTRAINT pk PRIMARY KEY (id, name1, name2)
+);
+UPSERT INTO ${schema1}.couple1 (id, name1, name2) VALUES (1, 'Mr. T', 'Mr. Semicolon;');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/outoforder/V1_1_1__Late_arrivals.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/outoforder/V1_1_1__Late_arrivals.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO test_user (name, id) VALUES ('Dr. Evil', 3);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/quote/V1__TableNameQuote.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/quote/V1__TableNameQuote.sql
@@ -1,0 +1,27 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE "user" (
+  name VARCHAR(25) NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE "group" (
+  name VARCHAR(25) NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE "table" (
+  name VARCHAR(25) NOT NULL PRIMARY KEY
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/semicolon/V1_1__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/semicolon/V1_1__Populate_table.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO test_user (name) VALUES ('Mr. T');
+UPSERT INTO test_user (name) VALUES ('Mr. Semicolon;');
+UPSERT INTO test_user (name) VALUES ('Mr. Semicolon+Linebreak;
+another line');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/semicolon/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/semicolon/V1__First.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  name VARCHAR(100) NOT NULL PRIMARY KEY
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1_1__View.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1_1__View.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE VIEW all_misters AS SELECT * FROM test_user WHERE name LIKE 'Mr.%';

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1_2__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1_2__Populate_table.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO test_user (name, id) VALUES ('Mr. Iße T', 1);
+UPSERT INTO test_user (name, id) VALUES ('Mr. Semicolon;', 2);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V1__First.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(25) -- this is a valid ' comment
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V2_0__Add_primary_key_and_super_mega_humongous_padding_to_exceed_the_maximum_column_length_in_the_metadata_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/sql/V2_0__Add_primary_key_and_super_mega_humongous_padding_to_exceed_the_maximum_column_length_in_the_metadata_table.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE couple (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name1 VARCHAR(25),
+  name2 VARCHAR(25)
+);
+
+UPSERT INTO couple (id, name1, name2) VALUES (1, 'Mr. Iße T', 'Mr. Semicolon;');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/V1_1__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/V1_1__Populate_table.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+UPSERT INTO test_user (name) VALUES ('Mr. T');

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/dir1/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/dir1/V1__First.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  name VARCHAR(25) NOT NULL PRIMARY KEY
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/dir2/V2_0__Add_couple_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/subdir/dir2/V2_0__Add_couple_table.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE couple (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name1 VARCHAR(25),
+  name2 VARCHAR(25)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/validate/PhoenixCheckValidate1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/validate/PhoenixCheckValidate1__First.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- CHANGE IN COMMENT
+
+CREATE TABLE test_user (
+  id INTEGER NOT NULL,
+  name VARCHAR(25) NOT NULL  -- this is a valid comment
+  CONSTRAINT pk PRIMARY KEY (id, name)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/validate/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/phoenix/sql/validate/V1__First.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_user (
+  id INTEGER NOT NULL,
+  name VARCHAR(25) NOT NULL,  -- this is a valid comment
+  CONSTRAINT pk PRIMARY KEY(id, name)
+);

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,8 @@
         <version.mariadb>1.1.7</version.mariadb>
         <version.postgresql>9.3-1102-jdbc4</version.postgresql>
         <version.sqlite>3.7.15-M1</version.sqlite>
+        <version.phoenix>4.2.2</version.phoenix>
+        <version.hbase>0.98.4-hadoop2</version.hbase>
         <version.equinox>3.6.0.v20100517</version.equinox>
         <version.equinoxcommon>3.6.0.v20100503</version.equinoxcommon>
         <version.android>4.0.1.2</version.android>
@@ -251,6 +253,73 @@
                 <groupId>com.vertica</groupId>
                 <artifactId>vertica-jdbc</artifactId>
                 <version>7.0.0-0</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.phoenix</groupId>
+                <artifactId>phoenix-core</artifactId>
+                <version>${version.phoenix}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>org.slf4j</artifactId>
+                        <groupId>slf4j-api</groupId>
+                    </exclusion>
+                </exclusions>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-it</artifactId>
+                <version>${version.hbase}</version>
+                <type>test-jar</type>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-testing-util</artifactId>
+                <version>${version.hbase}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                </exclusions>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-hadoop-compat</artifactId>
+                <version>${version.hbase}</version>
+                <type>test-jar</type>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-hadoop2-compat</artifactId>
+                <version>${version.hbase}</version>
+                <type>test-jar</type>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
PR for issue https://github.com/flyway/flyway/issues/929

It has been set up as an EmbeddedDB, although the Phoenix tests
should be disabled by default unless run in the new 'PhoenixDBTest'
profile.

Notable changes to core classes:

* MetaDataTableImpl:

Due to Phoenix's peculiar syntax, the hardcoded statements in
addAppliedMigration() and updateChecksum() won't work. It now
attempts to load a .sql template and run that, if it exists.

* MigrationTestCase:

Added checks for applied migrations of type MigrationType.SCHEMA
and adjusted asserts accordingly. Also added a 'getBaseDir()'
method, and replaced direct calls to BASEDIR with this. Several of
the tests in MigrationTestCase can then be used in the Phoenix
tests by overriding that method.