### PR TITLE
Print error messages to stderr(System.err) from CLI

### DIFF
--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/ConsoleLog.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/ConsoleLog.java
@@ -53,11 +53,11 @@ public class ConsoleLog implements Log {
     }
 
     public void error(String message) {
-        System.out.println("ERROR: " + message);
+        System.err.println("ERROR: " + message);
     }
 
     public void error(String message, Exception e) {
-        System.out.println("ERROR: " + message);
-        e.printStackTrace();
+        System.err.println("ERROR: " + message);
+        e.printStackTrace(System.err);
     }
 }

--- a/flyway-commandline/src/test/java/org/flywaydb/commandline/ConsoleLogTest.java
+++ b/flyway-commandline/src/test/java/org/flywaydb/commandline/ConsoleLogTest.java
@@ -1,0 +1,46 @@
+package org.flywaydb.commandline;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.PrintStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsoleLogTest {
+    private PrintStream oldErr;
+
+    @Mock
+    private PrintStream mockedErr;
+
+    @Before
+    public void setUp() throws Exception {
+        oldErr = System.err;
+        System.setErr(mockedErr);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.setErr(oldErr);
+    }
+
+    @Test
+    public void errorGoesToSystemErr() throws Exception {
+        new ConsoleLog(ConsoleLog.Level.INFO).error("F00b4r");
+        verify(mockedErr).println("ERROR: F00b4r");
+    }
+
+    @Test
+    public void errorAndStackTraceGoesToSystemErr() throws Exception {
+        final Exception mockedException = mock(Exception.class);
+        new ConsoleLog(ConsoleLog.Level.INFO).error("F00b4r", mockedException);
+        verify(mockedErr).println("ERROR: F00b4r");
+        verify(mockedException).printStackTrace(mockedErr);
+    }
+}


### PR DESCRIPTION
I need to redirect error messages from command line into separate file. It's possible to use ```|grep 'ERROR:'``` but it will not catch exception stacktraces, because they are not prefixed with ```ERROR:```

I think this is a good behavior for command line tool