### PR TITLE
Log the update count with DEBUG priority after running a SQL script

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
@@ -248,7 +248,11 @@ public class JdbcTemplate {
                     warning = warning.getNextWarning();
                 }
                 // retrieve all results to ensure all errors are detected
-                while (hasResults || statement.getUpdateCount() != -1) {
+                int updateCount = -1;
+                while (hasResults || (updateCount = statement.getUpdateCount()) != -1) {
+                    if (updateCount != -1) {
+                        LOG.debug("Update Count: " + updateCount);
+                    }
                     hasResults = statement.getMoreResults();
                 }
             }


### PR DESCRIPTION
Our DBA team want to be able to see the number of rows updated by Flyway.  We occasionally have data migrations via an UPDATE statement, and we want to record the number of rows updated in each database environment for auditing purposes.  I've logged with DEBUG priority because most users obviously don't need this feature.