### PR TITLE
added support for non-transactional SQL migrations

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -22,6 +22,7 @@ import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
+import org.flywaydb.core.internal.resolver.sql.NTSqlMigrationResolver;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
@@ -72,6 +73,10 @@ public class CompositeMigrationResolver implements MigrationResolver {
         for (Location location : locations.getLocations()) {
             migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, location, placeholderReplacer,
                     encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+
+            migrationResolvers.add(new NTSqlMigrationResolver(dbSupport, classLoader, location, placeholderReplacer,
+                    encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+
             migrationResolvers.add(new JdbcMigrationResolver(classLoader, location));
 
             if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationExecutor.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.sql;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.SqlScript;
+import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Resource;
+
+/**
+ * Database migration based on a sql file.
+ */
+public class NTSqlMigrationExecutor extends SqlMigrationExecutor implements MigrationExecutor {
+
+    /**
+     * Creates a new sql script migration based on this sql script.
+     *
+     * @param dbSupport           The database-specific support.
+     * @param sqlScriptResource   The resource containing the sql script.
+     * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
+     * @param encoding            The encoding of this Sql migration.
+     */
+    public NTSqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
+        super(dbSupport, sqlScriptResource, placeholderReplacer, encoding);
+    }
+
+    @Override
+    public boolean executeInTransaction() {
+        return false;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolver.java
@@ -36,7 +36,7 @@ import java.util.zip.CRC32;
 
 /**
  * Migration resolver for sql files on the classpath. The sql files must have names like
- * V1__Description.sql.notxn
+ * NTV1__Description.sql
  */
 public class NTSqlMigrationResolver implements MigrationResolver {
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolver.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.sql;
+
+import org.flywaydb.core.api.MigrationType;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
+import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
+import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
+import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Pair;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Resource;
+import org.flywaydb.core.internal.util.scanner.Scanner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.CRC32;
+
+/**
+ * Migration resolver for sql files on the classpath. The sql files must have names like
+ * V1__Description.sql.notxn
+ */
+public class NTSqlMigrationResolver implements MigrationResolver {
+    /**
+     * Database-specific support.
+     */
+    private final DbSupport dbSupport;
+
+    /**
+     * The scanner to use.
+     */
+    private final Scanner scanner;
+
+    /**
+     * The base directory on the classpath where to migrations are located.
+     */
+    private final Location location;
+
+    /**
+     * The placeholder replacer to apply to sql migration scripts.
+     */
+    private final PlaceholderReplacer placeholderReplacer;
+
+    /**
+     * The encoding of Sql migrations.
+     */
+    private final String encoding;
+
+    /**
+     * The prefix for sql migrations
+     */
+    private final String sqlMigrationPrefix = "NTV";
+
+    /**
+     * The separator for sql migrations
+     */
+    private final String sqlMigrationSeparator;
+
+    /**
+     * The suffix for sql migrations
+     */
+    private final String sqlMigrationSuffix;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param dbSupport             The database-specific support.
+     * @param classLoader           The ClassLoader for loading migrations on the classpath.
+     * @param location              The location on the classpath where to migrations are located.
+     * @param placeholderReplacer   The placeholder replacer to apply to sql migration scripts.
+     * @param encoding              The encoding of Sql migrations.
+     * @param sqlMigrationPrefix    The prefix for sql migrations
+     * @param sqlMigrationSeparator The separator for sql migrations
+     * @param sqlMigrationSuffix    The suffix for sql migrations
+     */
+    public NTSqlMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, Location location,
+                                PlaceholderReplacer placeholderReplacer, String encoding,
+                                String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix) {
+
+        this.dbSupport = dbSupport;
+        this.scanner = new Scanner(classLoader);
+        this.location = location;
+        this.placeholderReplacer = placeholderReplacer;
+        this.encoding = encoding;
+        this.sqlMigrationSeparator = sqlMigrationSeparator;
+        this.sqlMigrationSuffix = sqlMigrationSuffix;
+    }
+
+    @Override
+    public List<ResolvedMigration> resolveMigrations() {
+        List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
+
+        Resource[] resources = scanner.scanForResources(location, sqlMigrationPrefix, sqlMigrationSuffix);
+        for (Resource resource : resources) {
+            ResolvedMigrationImpl resolvedMigration = extractMigrationInfo(resource);
+            resolvedMigration.setPhysicalLocation(resource.getLocationOnDisk());
+            resolvedMigration.setExecutor(new NTSqlMigrationExecutor(dbSupport, resource, placeholderReplacer, encoding));
+
+            migrations.add(resolvedMigration);
+        }
+
+        Collections.sort(migrations, new ResolvedMigrationComparator());
+        return migrations;
+    }
+
+    /**
+     * Extracts the migration info for this resource.
+     *
+     * @param resource The resource to analyse.
+     * @return The migration info.
+     */
+    private ResolvedMigrationImpl extractMigrationInfo(Resource resource) {
+        ResolvedMigrationImpl migration = new ResolvedMigrationImpl();
+
+        Pair<MigrationVersion, String> info =
+                MigrationInfoHelper.extractVersionAndDescription(resource.getFilename(),
+                        sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix);
+        migration.setVersion(info.getLeft());
+        migration.setDescription(info.getRight());
+
+        migration.setScript(extractScriptName(resource));
+
+        migration.setChecksum(calculateChecksum(resource.loadAsBytes()));
+        migration.setType(MigrationType.SQL);
+        return migration;
+    }
+
+    /**
+     * Extracts the script name from this resource.
+     *
+     * @param resource The resource to process.
+     * @return The script name.
+     */
+    /* private -> for testing */ String extractScriptName(Resource resource) {
+        if (location.getPath().isEmpty()) {
+            return resource.getLocation();
+        }
+
+        return resource.getLocation().substring(location.getPath().length() + 1);
+    }
+
+    /**
+     * Calculates the checksum of these bytes.
+     *
+     * @param bytes The bytes to calculate the checksum for.
+     * @return The crc-32 checksum of the bytes.
+     */
+    private static int calculateChecksum(byte[] bytes) {
+        final CRC32 crc32 = new CRC32();
+        crc32.update(bytes);
+        return (int) crc32.getValue();
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/NTSqlMigrationResolverSmallTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.sql;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
+import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testcase for Non Transactional SqlMigration.
+ */
+public class NTSqlMigrationResolverSmallTest {
+    @Test
+    public void resolveMigrations() {
+        NTSqlMigrationResolver ntSqlMigrationResolver =
+                new NTSqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
+                        new Location("migration/notxnsql"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "NTV", "__", ".sql");
+        Collection<ResolvedMigration> migrations = ntSqlMigrationResolver.resolveMigrations();
+
+        assertEquals(2, migrations.size());
+
+        List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
+
+        assertEquals("1", migrationList.get(0).getVersion().toString());
+        assertEquals("1.1", migrationList.get(1).getVersion().toString());
+
+        assertEquals("NTV1__Create_colors_type.sql", migrationList.get(0).getScript());
+        assertEquals("NTV1_1__Update_colors_type.sql", migrationList.get(1).getScript());
+    }
+}

--- a/flyway-core/src/test/resources/migration/notxnsql/NTV1_1__Update_colors_type.sql
+++ b/flyway-core/src/test/resources/migration/notxnsql/NTV1_1__Update_colors_type.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TYPE color_type ADD VALUE 'orange' AFTER 'blue';

--- a/flyway-core/src/test/resources/migration/notxnsql/NTV1__Create_colors_type.sql
+++ b/flyway-core/src/test/resources/migration/notxnsql/NTV1__Create_colors_type.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2015 Axel Fontaine
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TYPE colors_type  AS ENUM ('red', 'green', 'blue');


### PR DESCRIPTION
fixes #1026 
- added new Resolver and Executor classes
- NTSqlMigrationResolver works on the files prefixed with "NTV", currently hardcoded. (Looking forward for suggestions over this)
- Added the new resolver in migrationResolvers while creating CompositeMigrationResolver instance
- added small test for new resolver
