### PR TITLE
Fix for issue #253 Ignore line endings when calculating checksums

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -29,6 +29,9 @@ import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -156,15 +159,53 @@ public class SqlMigrationResolver implements MigrationResolver {
         return resource.getLocation().substring(location.getPath().length() + 1);
     }
 
-    /**
-     * Calculates the checksum of these bytes.
-     *
-     * @param bytes The bytes to calculate the checksum for.
-     * @return The crc-32 checksum of the bytes.
-     */
-    private static int calculateChecksum(byte[] bytes) {
+    private int calculateChecksum(byte[] bytes) {
+        final CRC32 crc = new CRC32();
+        crc.update(bytes);
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+        if ("UTF-8".equalsIgnoreCase(encoding)) {
+            ignoreUtf8BOM(inputStream);
+        }
+
         final CRC32 crc32 = new CRC32();
-        crc32.update(bytes);
+
+        while (true) {
+            final int value = inputStream.read();
+
+            if (value == -1) {
+                break;
+            }
+
+            if (value == 13) {
+                continue;
+            }
+
+            crc32.update((byte) value);
+        }
+
         return (int) crc32.getValue();
+    }
+
+    private static void ignoreUtf8BOM(InputStream inputStream) {
+        inputStream.mark(3);
+
+        try {
+            if (inputStream.read() == 0xEF) {
+                if (inputStream.read() == 0xBB) {
+                    if (inputStream.read() == 0xBF) {
+                        return;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            inputStream.reset();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverCRTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverCRTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver.sql;
+
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testcase for SqlMigration.
+ */
+public class SqlMigrationResolverCRTest {
+    @Test
+    public void resolveMigrations() {
+        SqlMigrationResolver sqlMigrationResolver =
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
+                        new Location("migration/cr"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "__", ".txt");
+        Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
+
+        assertEquals(2, migrations.size());
+
+        List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
+
+        assertEquals("1", migrationList.get(0).getVersion().toString());
+        assertEquals("2", migrationList.get(1).getVersion().toString());
+
+        assertEquals(migrationList.get(0).getChecksum(), migrationList.get(1).getChecksum());
+    }
+
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2015 Axel Fontaine
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/resources/migration/cr/V1__utf8_bom_win.txt
+++ b/flyway-core/src/test/resources/migration/cr/V1__utf8_bom_win.txt
@@ -1,2 +1,2 @@
-﻿Test checksum calculation
+﻿Test checksum calculation here
 Ignoring bom and cr symbols

--- a/flyway-core/src/test/resources/migration/cr/V1__utf8_bom_win.txt
+++ b/flyway-core/src/test/resources/migration/cr/V1__utf8_bom_win.txt
@@ -1,0 +1,2 @@
+﻿Test checksum calculation
+Ignoring bom and cr symbols

--- a/flyway-core/src/test/resources/migration/cr/V2__utf8_unix.txt
+++ b/flyway-core/src/test/resources/migration/cr/V2__utf8_unix.txt
@@ -1,2 +1,2 @@
-Test checksum calculation
+Test checksum calculation here
 Ignoring bom and cr symbols

--- a/flyway-core/src/test/resources/migration/cr/V2__utf8_unix.txt
+++ b/flyway-core/src/test/resources/migration/cr/V2__utf8_unix.txt
@@ -1,0 +1,2 @@
+Test checksum calculation
+Ignoring bom and cr symbols


### PR DESCRIPTION
Calculation migration checksum by ignoring CR symbols (\r) and BOM sequence for UTF-8 encoding. If there are no such symbols in migration checksum will not changed.

I created two .txt files for testing checksums but can't pull CRLF symbols to first one (BOM sequence was pulled). Who wants can do it youself.

#253