### PR TITLE
#1043 checkForUnmatchedPlaceholderExpression now only performs check …

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/PlaceholderReplacer.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/PlaceholderReplacer.java
@@ -88,18 +88,20 @@ public class PlaceholderReplacer {
      * @throws FlywayException An exception listing the unmatched expressions.
      */
     private void checkForUnmatchedPlaceholderExpression(String input) {
-        String regex = Pattern.quote(placeholderPrefix) + "(.+?)" + Pattern.quote(placeholderSuffix);
-        Matcher matcher = Pattern.compile(regex).matcher(input);
-
-        Set<String> unmatchedPlaceHolderExpressions = new TreeSet<String>();
-        while (matcher.find()) {
-            unmatchedPlaceHolderExpressions.add(matcher.group());
-        }
-
-        if (!unmatchedPlaceHolderExpressions.isEmpty()) {
-            throw new FlywayException("No value provided for placeholder expressions: "
-                    + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions)
-                    + ".  Check your configuration!");
-        }
+    	if(StringUtils.hasLength(placeholderPrefix) && StringUtils.hasLength(placeholderSuffix)) {
+	        String regex = Pattern.quote(placeholderPrefix) + "(.+?)" + Pattern.quote(placeholderSuffix);
+	        Matcher matcher = Pattern.compile(regex).matcher(input);
+	
+	        Set<String> unmatchedPlaceHolderExpressions = new TreeSet<String>();
+	        while (matcher.find()) {
+	            unmatchedPlaceHolderExpressions.add(matcher.group());
+	        }
+	
+	        if (!unmatchedPlaceHolderExpressions.isEmpty()) {
+	            throw new FlywayException("No value provided for placeholder expressions: "
+	                    + StringUtils.collectionToCommaDelimitedString(unmatchedPlaceHolderExpressions)
+	                    + ".  Check your configuration!");
+	        }
+    	}
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/PlaceholderReplacerSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/PlaceholderReplacerSmallTest.java
@@ -78,7 +78,7 @@ public class PlaceholderReplacerSmallTest {
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "#[", "]");
         placeholderReplacer.replacePlaceholders(TEST_STR);
     }
-
+    
     @Test
     public void unmatchedPlaceholdersWithMultipleOccurences() throws FlywayException {
         thrown.expect(FlywayException.class);
@@ -86,5 +86,11 @@ public class PlaceholderReplacerSmallTest {
         Map<String, String> placeholders = new HashMap<String, String>();
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
         placeholderReplacer.replacePlaceholders(TEST_STR + TEST_STR);
+    }
+
+    @Test
+    public void noPlaceholders() {
+        PlaceholderReplacer placeholderReplacer = PlaceholderReplacer.NO_PLACEHOLDERS;
+        assertEquals(TEST_STR, placeholderReplacer.replacePlaceholders(TEST_STR));
     }
 }


### PR DESCRIPTION
…if both prefix are suffix are not empty

This is a fix for  #1043