### PR TITLE
Fix for #724:  Added command-line flags (-userPrompt, -passwordPrompt) to prompt for…

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -28,6 +28,7 @@ import org.flywaydb.core.internal.util.logging.Log;
 import org.flywaydb.core.internal.util.logging.LogFactory;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 
+import java.io.Console;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilenameFilter;
@@ -179,7 +180,7 @@ public class Main {
         LOG.info("* Usage");
         LOG.info("********");
         LOG.info("");
-        LOG.info("flyway [options] command");
+        LOG.info("flyway [options] [flags] command");
         LOG.info("");
         LOG.info("By default, the configuration will be read from conf/flyway.conf.");
         LOG.info("Options passed from the command-line override the configuration.");
@@ -222,6 +223,11 @@ public class Main {
         LOG.info("configFile             : Config file to use (default: conf/flyway.properties)");
         LOG.info("configFileEncoding     : Encoding of the config file (default: UTF-8)");
         LOG.info("jarDirs                : Dirs for Jdbc drivers & Java migrations (default: jars)");
+        LOG.info("");
+        LOG.info("Flags (Format: -flag)");
+        LOG.info("=======");
+        LOG.info("userPrompt             : Prompt for username");
+        LOG.info("passwordPrompt         : Prompt for password");
         LOG.info("");
         LOG.info("Add -X to print debug output");
         LOG.info("Add -q to suppress all output, except for errors and warnings");
@@ -450,9 +456,30 @@ public class Main {
      */
     /* private -> for testing*/
     static void overrideConfiguration(Properties properties, String[] args) {
+        boolean userPrompt = false;
+        boolean passwordPrompt = false;
+        
         for (String arg : args) {
             if (isPropertyArgument(arg)) {
                 properties.put("flyway." + getArgumentProperty(arg), getArgumentValue(arg));
+            } else if (arg.equals("-userPrompt")){
+                userPrompt = true;
+            } else if (arg.equals("-passwordPrompt")){
+                passwordPrompt = true;
+            }
+        }
+
+        if (userPrompt || passwordPrompt) {
+            Console console = System.console();
+        
+            if (userPrompt) {
+                System.out.print("Enter user: ");
+                properties.put("flyway.user", console.readLine());
+            }
+
+            if (passwordPrompt) {
+                System.out.print("Enter password: ");
+                properties.put("flyway.password", String.valueOf(console.readPassword()));
             }
         }
     }


### PR DESCRIPTION
… the user and/or password.

https://github.com/flyway/flyway/issues/724

This issue was opened last year, but as I have recently recommended and begun implementation of FlywayDB in my current company, our OPS department really wanted this feature for production so passwords don't appear in the shell history.

I've added a first implementation attempt.  I think it matches coding standards required.  I've tested it with the current v3.2.1 core library.

It uses the java.io.Console.readPassword() method which masks input from prying eyes.