### PR TITLE
Decoupled DbSupportFactory so that it can be used as a hook to custom…

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -825,8 +825,7 @@ public class Flyway {
      */
     @Deprecated
     public void setBaselineVersion(String baselineVersion) {
-        LOG.warn("Flyway.setBaselineVersion(String) is deprecated and will be removed in Flyway 4.0. Use setBaselineVersionAsString(String) instead" +
-                ".");
+        LOG.warn("Flyway.setBaselineVersion(String) is deprecated and will be removed in Flyway 4.0. Use setBaselineVersionAsString(String) instead.");
         this.baselineVersion = MigrationVersion.fromVersion(baselineVersion);
     }
 
@@ -862,8 +861,7 @@ public class Flyway {
      * Flyway does not migrate the wrong database in case of a configuration mistake!
      * </p>
      *
-     * @param baselineOnMigrate {@code true} if baseline should be called on migrate for non-empty schemas, {@code false} if not. (default: {@code
-     * false})
+     * @param baselineOnMigrate {@code true} if baseline should be called on migrate for non-empty schemas, {@code false} if not. (default: {@code false})
      */
     public void setBaselineOnMigrate(boolean baselineOnMigrate) {
         this.baselineOnMigrate = baselineOnMigrate;
@@ -983,8 +981,7 @@ public class Flyway {
     /**
      * Sets custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
      *
-     * @param resolvers The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply. (default:
-     *                  empty list)
+     * @param resolvers The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply. (default: empty list)
      */
     public void setResolvers(MigrationResolver... resolvers) {
         this.resolvers = resolvers;
@@ -993,8 +990,7 @@ public class Flyway {
     /**
      * Sets custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
      *
-     * @param resolvers The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for resolving
-     *                  Migrations to apply. (default: empty list)
+     * @param resolvers The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply. (default: empty list)
      * @deprecated Will be removed in Flyway 4.0. Use setResolversAsClassNames(String...) instead.
      */
     @Deprecated
@@ -1007,8 +1003,7 @@ public class Flyway {
     /**
      * Sets custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
      *
-     * @param resolvers The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for resolving
-     *                  Migrations to apply. (default: empty list)
+     * @param resolvers The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply. (default: empty list)
      */
     public void setResolversAsClassNames(String... resolvers) {
         List<MigrationResolver> resolverList = ClassUtils.instantiateAll(resolvers, classLoader);
@@ -1159,8 +1154,7 @@ public class Flyway {
      */
     public MigrationInfoService info() {
         return execute(new Command<MigrationInfoService>() {
-            public MigrationInfoService execute(Connection connectionMetaDataTable, Connection connectionUserObjects, DbSupport dbSupport, Schema[]
-                    schemas) {
+            public MigrationInfoService execute(Connection connectionMetaDataTable, Connection connectionUserObjects, DbSupport dbSupport, Schema[] schemas) {
                 for (FlywayCallback callback : getCallbacks()) {
                     callback.beforeInfo(connectionUserObjects);
                 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
@@ -15,39 +15,12 @@
  */
 package org.flywaydb.core.internal.dbsupport;
 
-import org.flywaydb.core.api.FlywayException;
-import org.flywaydb.core.internal.dbsupport.db2.DB2DbSupport;
-import org.flywaydb.core.internal.dbsupport.db2zos.DB2zosDbSupport;
-import org.flywaydb.core.internal.dbsupport.derby.DerbyDbSupport;
-import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
-import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
-import org.flywaydb.core.internal.dbsupport.mysql.MySQLDbSupport;
-import org.flywaydb.core.internal.dbsupport.oracle.OracleDbSupport;
-import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLDbSupport;
-import org.flywaydb.core.internal.dbsupport.redshift.RedshiftDbSupport;
-import org.flywaydb.core.internal.dbsupport.solid.SolidDbSupport;
-import org.flywaydb.core.internal.dbsupport.sqlite.SQLiteDbSupport;
-import org.flywaydb.core.internal.dbsupport.sqlserver.SQLServerDbSupport;
-import org.flywaydb.core.internal.dbsupport.vertica.VerticaDbSupport;
-import org.flywaydb.core.internal.util.logging.Log;
-import org.flywaydb.core.internal.util.logging.LogFactory;
-
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
 
 /**
  * Factory for obtaining the correct DbSupport instance for the current connection.
  */
-public class DbSupportFactory {
-    private static final Log LOG = LogFactory.getLog(DbSupportFactory.class);
-
-    /**
-     * Prevent instantiation.
-     */
-    private DbSupportFactory() {
-        //Do nothing
-    }
+public interface DbSupportFactory {
 
     /**
      * Initializes the appropriate DbSupport class for the database product used by the data source.
@@ -56,138 +29,5 @@ public class DbSupportFactory {
      * @param printInfo  Where the DB info should be printed in the logs.
      * @return The appropriate DbSupport class.
      */
-    public static DbSupport createDbSupport(Connection connection, boolean printInfo) {
-        String databaseProductName = getDatabaseProductName(connection);
-
-        if (printInfo) {
-            LOG.info("Database: " + getJdbcUrl(connection) + " (" + databaseProductName + ")");
-        }
-
-        if (databaseProductName.startsWith("Apache Derby")) {
-            return new DerbyDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("SQLite")) {
-            return new SQLiteDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("H2")) {
-            return new H2DbSupport(connection);
-        }
-        if (databaseProductName.contains("HSQL Database Engine")) {
-            // For regular Hsql and the Google Cloud SQL local default DB.
-            return new HsqlDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("Microsoft SQL Server")) {
-            return new SQLServerDbSupport(connection);
-        }
-        if (databaseProductName.contains("MySQL")) {
-            // For regular MySQL, MariaDB and Google Cloud SQL.
-            // Google Cloud SQL returns different names depending on the environment and the SDK version.
-            //   ex.: Google SQL Service/MySQL
-            return new MySQLDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("Oracle")) {
-            return new OracleDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("PostgreSQL 8")) {
-            // Redshift reports a databaseProductName of "PostgreSQL 8.0", and it uses the same JDBC driver,
-            // but only supports a subset of features. Therefore, we need to execute a query in order to
-            // distinguish it from the real PostgreSQL 8:
-            RedshiftDbSupport redshift = new RedshiftDbSupport(connection);
-            if (redshift.detect()) {
-                return redshift;
-            }
-        }
-        if (databaseProductName.startsWith("PostgreSQL")) {
-            return new PostgreSQLDbSupport(connection);
-        }
-        if (databaseProductName.startsWith("DB2")) {
-			if (getDatabaseProductVersion(connection).startsWith("DSN")){
-				return new DB2zosDbSupport(connection);
-			} else {
-				return new DB2DbSupport(connection);
-			}
-        }
-        if (databaseProductName.startsWith("Vertica")) {
-            return new VerticaDbSupport(connection);
-        }
-        if (databaseProductName.contains("solidDB")) {
-            // SolidDB was originally developed by a company named Solid and was sold afterwards to IBM.
-            // In the meanwhile IBM also sold solidDB to Unicom Systems.
-            // Therefore no vendor string in search criteria
-            return new SolidDbSupport(connection);
-        }
-
-        throw new FlywayException("Unsupported Database: " + databaseProductName);
-    }
-
-    /**
-     * Retrieves the Jdbc Url for this connection.
-     *
-     * @param connection The Jdbc connection.
-     * @return The Jdbc Url.
-     */
-
-    private static String getJdbcUrl(Connection connection) {
-        try {
-            return connection.getMetaData().getURL();
-        } catch (SQLException e) {
-            throw new FlywayException("Unable to retrieve the Jdbc connection Url!", e);
-        }
-    }
-
-    /**
-     * Retrieves the name of the database product.
-     *
-     * @param connection The connection to use to query the database.
-     * @return The name of the database product. Ex.: Oracle, MySQL, ...
-     */
-    private static String getDatabaseProductName(Connection connection) {
-        try {
-            DatabaseMetaData databaseMetaData = connection.getMetaData();
-            if (databaseMetaData == null) {
-                throw new FlywayException("Unable to read database metadata while it is null!");
-            }
-
-            String databaseProductName = databaseMetaData.getDatabaseProductName();
-            if (databaseProductName == null) {
-                throw new FlywayException("Unable to determine database. Product name is null.");
-            }
-
-            int databaseMajorVersion = databaseMetaData.getDatabaseMajorVersion();
-            int databaseMinorVersion = databaseMetaData.getDatabaseMinorVersion();
-
-            return databaseProductName + " " + databaseMajorVersion + "." + databaseMinorVersion;
-        } catch (SQLException e) {
-            throw new FlywayException("Error while determining database product name", e);
-        }
-    }
-
-	/**
-	 * Retrieves the database version.
-	 *
-	 * @param connection The connection to use to query the database.
-	 * @return The version of the database product.
-	 * Ex.: DSN11015 DB2 for z/OS Version 11
-	 *      SQL10050 DB" for Linux, UNIX and Windows Version 10.5
-	 */
-	private static String getDatabaseProductVersion(Connection connection) {
-		try {
-			DatabaseMetaData databaseMetaData = connection.getMetaData();
-			if (databaseMetaData == null) {
-				throw new FlywayException("Unable to read database metadata while it is null!");
-			}
-
-			String databaseProductVersion = databaseMetaData.getDatabaseProductVersion();
-			if (databaseProductVersion == null) {
-				throw new FlywayException("Unable to determine database. Product version is null.");
-			}
-
-
-			return databaseProductVersion;
-		} catch (SQLException e) {
-			throw new FlywayException("Error while determining database product version", e);
-		}
-	}
-
-
+    public DbSupport createDbSupport(Connection connection, boolean printInfo);
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactoryImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactoryImpl.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2010-2015 Axel Fontaine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.db2.DB2DbSupport;
+import org.flywaydb.core.internal.dbsupport.db2zos.DB2zosDbSupport;
+import org.flywaydb.core.internal.dbsupport.derby.DerbyDbSupport;
+import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
+import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
+import org.flywaydb.core.internal.dbsupport.mysql.MySQLDbSupport;
+import org.flywaydb.core.internal.dbsupport.oracle.OracleDbSupport;
+import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLDbSupport;
+import org.flywaydb.core.internal.dbsupport.redshift.RedshiftDbSupport;
+import org.flywaydb.core.internal.dbsupport.solid.SolidDbSupport;
+import org.flywaydb.core.internal.dbsupport.sqlite.SQLiteDbSupport;
+import org.flywaydb.core.internal.dbsupport.sqlserver.SQLServerDbSupport;
+import org.flywaydb.core.internal.dbsupport.vertica.VerticaDbSupport;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+/**
+ * Factory for obtaining the correct DbSupport instance for the current connection.
+ */
+public class DbSupportFactoryImpl implements DbSupportFactory {
+    private static final Log LOG = LogFactory.getLog(DbSupportFactoryImpl.class);
+
+    public DbSupportFactoryImpl() {
+        //Do nothing
+    }
+
+    /**
+     * Initializes the appropriate DbSupport class for the database product used by the data source.
+     *
+     * @param connection The Jdbc connection to use to query the database.
+     * @param printInfo  Where the DB info should be printed in the logs.
+     * @return The appropriate DbSupport class.
+     */
+    public DbSupport createDbSupport(Connection connection, boolean printInfo) {
+        String databaseProductName = getDatabaseProductName(connection);
+
+        if (printInfo) {
+            LOG.info("Database: " + getJdbcUrl(connection) + " (" + databaseProductName + ")");
+        }
+
+        if (databaseProductName.startsWith("Apache Derby")) {
+            return new DerbyDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("SQLite")) {
+            return new SQLiteDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("H2")) {
+            return new H2DbSupport(connection);
+        }
+        if (databaseProductName.contains("HSQL Database Engine")) {
+            // For regular Hsql and the Google Cloud SQL local default DB.
+            return new HsqlDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("Microsoft SQL Server")) {
+            return new SQLServerDbSupport(connection);
+        }
+        if (databaseProductName.contains("MySQL")) {
+            // For regular MySQL, MariaDB and Google Cloud SQL.
+            // Google Cloud SQL returns different names depending on the environment and the SDK version.
+            //   ex.: Google SQL Service/MySQL
+            return new MySQLDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("Oracle")) {
+            return new OracleDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("PostgreSQL 8")) {
+            // Redshift reports a databaseProductName of "PostgreSQL 8.0", and it uses the same JDBC driver,
+            // but only supports a subset of features. Therefore, we need to execute a query in order to
+            // distinguish it from the real PostgreSQL 8:
+            RedshiftDbSupport redshift = new RedshiftDbSupport(connection);
+            if (redshift.detect()) {
+                return redshift;
+            }
+        }
+        if (databaseProductName.startsWith("PostgreSQL")) {
+            return new PostgreSQLDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("DB2")) {
+            if (getDatabaseProductVersion(connection).startsWith("DSN")) {
+                return new DB2zosDbSupport(connection);
+            } else {
+                return new DB2DbSupport(connection);
+            }
+        }
+        if (databaseProductName.startsWith("Vertica")) {
+            return new VerticaDbSupport(connection);
+        }
+        if (databaseProductName.contains("solidDB")) {
+            // SolidDB was originally developed by a company named Solid and was sold afterwards to IBM.
+            // In the meanwhile IBM also sold solidDB to Unicom Systems.
+            // Therefore no vendor string in search criteria
+            return new SolidDbSupport(connection);
+        }
+
+        throw new FlywayException("Unsupported Database: " + databaseProductName);
+    }
+
+    /**
+     * Retrieves the Jdbc Url for this connection.
+     *
+     * @param connection The Jdbc connection.
+     * @return The Jdbc Url.
+     */
+
+    private String getJdbcUrl(Connection connection) {
+        try {
+            return connection.getMetaData().getURL();
+        } catch (SQLException e) {
+            throw new FlywayException("Unable to retrieve the Jdbc connection Url!", e);
+        }
+    }
+
+    /**
+     * Retrieves the name of the database product.
+     *
+     * @param connection The connection to use to query the database.
+     * @return The name of the database product. Ex.: Oracle, MySQL, ...
+     */
+    private String getDatabaseProductName(Connection connection) {
+        try {
+            DatabaseMetaData databaseMetaData = connection.getMetaData();
+            if (databaseMetaData == null) {
+                throw new FlywayException("Unable to read database metadata while it is null!");
+            }
+
+            String databaseProductName = databaseMetaData.getDatabaseProductName();
+            if (databaseProductName == null) {
+                throw new FlywayException("Unable to determine database. Product name is null.");
+            }
+
+            int databaseMajorVersion = databaseMetaData.getDatabaseMajorVersion();
+            int databaseMinorVersion = databaseMetaData.getDatabaseMinorVersion();
+
+            return databaseProductName + " " + databaseMajorVersion + "." + databaseMinorVersion;
+        } catch (SQLException e) {
+            throw new FlywayException("Error while determining database product name", e);
+        }
+    }
+
+    /**
+     * Retrieves the database version.
+     *
+     * @param connection The connection to use to query the database.
+     * @return The version of the database product.
+     * Ex.: DSN11015 DB2 for z/OS Version 11
+     *      SQL10050 DB" for Linux, UNIX and Windows Version 10.5
+     */
+    private String getDatabaseProductVersion(Connection connection) {
+        try {
+            DatabaseMetaData databaseMetaData = connection.getMetaData();
+            if (databaseMetaData == null) {
+                throw new FlywayException("Unable to read database metadata while it is null!");
+            }
+
+            String databaseProductVersion = databaseMetaData.getDatabaseProductVersion();
+            if (databaseProductVersion == null) {
+                throw new FlywayException("Unable to determine database. Product version is null.");
+            }
+
+
+            return databaseProductVersion;
+        } catch (SQLException e) {
+            throw new FlywayException("Error while determining database product version", e);
+        }
+    }
+
+
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerCaseSensitiveMigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerCaseSensitiveMigrationTestCase.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.dbsupport.sqlserver;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.DbSupportFactory;
+import org.flywaydb.core.internal.dbsupport.DbSupportFactoryImpl;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -52,7 +53,7 @@ public abstract class SQLServerCaseSensitiveMigrationTestCase {
         assertEquals(4, flyway.info().applied().length);
 
         Connection connection = dataSource.getConnection();
-        DbSupport dbSupport = DbSupportFactory.createDbSupport(connection, true);
+        DbSupport dbSupport = new DbSupportFactoryImpl().createDbSupport(connection, true);
 
         assertEquals(2, dbSupport.getJdbcTemplate().queryForInt("select count(*) from all_misters"));
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/jdbc/DriverDataSourceSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2015 Axel Fontaine
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/ConcurrentMigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/ConcurrentMigrationTestCase.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.migration;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.internal.dbsupport.DbSupportFactory;
+import org.flywaydb.core.internal.dbsupport.DbSupportFactoryImpl;
 import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
 import org.flywaydb.core.internal.util.logging.Log;
@@ -78,7 +79,7 @@ public abstract class ConcurrentMigrationTestCase {
         concurrentMigrationDataSource = createDataSource(customProperties);
 
         Connection connection = concurrentMigrationDataSource.getConnection();
-        schemaQuoted = DbSupportFactory.createDbSupport(connection, false).quote("concurrent_test");
+        schemaQuoted = new DbSupportFactoryImpl().createDbSupport(connection, false).quote("concurrent_test");
         connection.close();
 
         flyway = createFlyway();

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -66,7 +66,7 @@ public abstract class MigrationTestCase {
         dataSource = createDataSource(customProperties);
 
         connection = dataSource.getConnection();
-        dbSupport = DbSupportFactory.createDbSupport(connection, false);
+        dbSupport = new DbSupportFactoryImpl().createDbSupport(connection, false);
         jdbcTemplate = dbSupport.getJdbcTemplate();
 
 		configureFlyway();


### PR DESCRIPTION
Hi,

As we needed to customize the DbSupport for oracle and there was no real fix except extending the flyway class and overriding lots of methods to do so I decided to fix the root cause.

By moving this into a pluggable instance it can more easily be used to support newer database, even if the official flyway support is not yet ready. It would even be possible to start splitting out the db support so that the flyway-core can be less aware of all databases that it can support.

Kind regards,
Kris
