### PR TITLE
Do not try to run migrations in transactions on databases that do not support transactional ddl

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -278,7 +278,7 @@ public class DbMigrate {
             }
 
             final MigrationExecutor migrationExecutor = migration.getResolvedMigration().getExecutor();
-            if (migrationExecutor.executeInTransaction()) {
+            if (dbSupport.supportsDdlTransactions() && migrationExecutor.executeInTransaction()) {
                 new TransactionTemplate(connectionUserObjects).execute(new TransactionCallback<Void>() {
                     public Void doInTransaction() throws SQLException {
                         migrationExecutor.execute(connectionUserObjects);


### PR DESCRIPTION
Previously, in ticket #655, PostgresSQL was given special java api support to do things like `vacuum` that do not play nicely within transactions.

I currently have a script that renames a lot of constraints in Oracle, and apparently, there is some hidden limit to that within a transaction that causes the script to fault, yet run fine without a wrapping transaction.

However, #655 introduced `supportsDdlTransactions`, a good hint that perhaps, for migrating, we should not use a transaction, since an error will mean that we will most likely end up in an inconsistent state, and need other tools for rollbacks (I've been using vagrant && vagrant-snapshot).