### PR TITLE
Resolving the issue #1082

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1225,7 +1225,7 @@ public class Flyway {
     /**
      * @return A new, fully configured, PlaceholderReplacer.
      */
-    private PlaceholderReplacer createPlaceholderReplacer() {
+    protected PlaceholderReplacer createPlaceholderReplacer() {
         if (placeholderReplacement) {
             return new PlaceholderReplacer(placeholders, placeholderPrefix, placeholderSuffix);
         }


### PR DESCRIPTION
Changed the visibility of method `Flyway.createPlaceholderReplacer()` to `protected`.
Now, Flyway users can extend the `Flyway` class and override this method in order to use their own implementation of `PlaceholderReplacer`.
