### PR TITLE
Fix flyway script on Git Bash for Windows

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -19,7 +19,7 @@
 cygwin=false
 linux=false
 case "`uname`" in
-  CYGWIN*) cygwin=true;;
+  CYGWIN*|MINGW*) cygwin=true;;
   Linux*) linux=true;;
 esac
 


### PR DESCRIPTION
New Git Bash for Windows (https://git-for-windows.github.io/) is recognized
as "MINGW..." system. For example on my test machine `uname` returns
the following:

```
$ uname
MINGW64_NT-6.1
```

This patch expands on the fix done in #735 to use Windows classpath
separator when running in Git Bash for Windows.