### PR TITLE
#1078: skip default resolvers

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -231,6 +231,11 @@ public class Flyway implements FlywayConfiguration {
     private MigrationResolver[] resolvers = new MigrationResolver[0];
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     */
+    private boolean skipDefaultResolvers;
+
+    /**
      * Whether Flyway created the DataSource.
      */
     private boolean createdDataSource;
@@ -510,6 +515,16 @@ public class Flyway implements FlywayConfiguration {
     @Override
     public MigrationResolver[] getResolvers() {
         return resolvers;
+    }
+
+    /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @return Whether default built-in resolvers should be skipped.
+     */
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
     }
 
     /**
@@ -886,6 +901,15 @@ public class Flyway implements FlywayConfiguration {
     }
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @param skipDefaultResolvers Whether default built-in resolvers should be skipped.
+     */
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    /**
      * <p>Starts the database migration. All pending migrations will be applied in order.
      * Calling migrate on an up-to-date database has no effect.</p>
      * <img src="http://flywaydb.org/assets/balsamiq/command-migrate.png" alt="migrate">
@@ -1210,6 +1234,10 @@ public class Flyway implements FlywayConfiguration {
         String resolversProp = getValueAndRemoveEntry(props, "flyway.resolvers");
         if (StringUtils.hasLength(resolversProp)) {
             setResolversAsClassNames(StringUtils.tokenizeToStringArray(resolversProp, ","));
+        }
+        String skipDefaultResolverProp = getValueAndRemoveEntry(props, "flyway.skipDefaultResolvers");
+        if (skipDefaultResolverProp != null) {
+            setSkipDefaultResolvers(Boolean.parseBoolean(skipDefaultResolverProp));
         }
         String callbacksProp = getValueAndRemoveEntry(props, "flyway.callbacks");
         if (StringUtils.hasLength(callbacksProp)) {

--- a/flyway-core/src/main/java/org/flywaydb/core/api/ConfigurationAware.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/ConfigurationAware.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api;
+
+/**
+ * Marks a class as configuration aware (callbacks and migrations). Configuration aware classes
+ * get the flyway master configuration injected upon creation.
+ */
+public interface ConfigurationAware {
+
+    void setFlywayConfiguration(FlywayConfiguration flywayConfiguration);
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Scanner;
+
+/**
+ * Readonly interface for main flyway configuration. Can be used to provide configuration data to migrations and callbacks.
+ */
+public interface FlywayConfiguration {
+
+    FlywayCallback[] getCallbacks();
+
+    ClassLoader getClassLoader();
+
+    DataSource getDataSource();
+
+    MigrationVersion getBaselineVersion();
+
+    String getBaselineDescription();
+
+    MigrationResolver[] getResolvers();
+
+    String getSqlMigrationSuffix();
+
+    String getSqlMigrationSeparator();
+
+    String getSqlMigrationPrefix();
+
+    String getPlaceholderSuffix();
+
+    String getPlaceholderPrefix();
+
+    Map<String, String> getPlaceholders();
+
+    MigrationVersion getTarget();
+
+    String getTable();
+
+    String[] getSchemas();
+
+    String getEncoding();
+
+    String[] getLocations();
+
+    Scanner getScanner();
+
+    PlaceholderReplacer createPlaceholderReplacer();
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/FlywayConfiguration.java
@@ -33,6 +33,8 @@ public interface FlywayConfiguration {
 
     ClassLoader getClassLoader();
 
+    boolean isSkipDefaultResolvers();
+
     DataSource getDataSource();
 
     MigrationVersion getBaselineVersion();

--- a/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
@@ -15,9 +15,9 @@
  */
 package org.flywaydb.core.api.callback;
 
-import org.flywaydb.core.api.MigrationInfo;
-
 import java.sql.Connection;
+
+import org.flywaydb.core.api.MigrationInfo;
 
 /**
  * This is the main callback interface that should be implemented to get access to flyway lifecycle notifications.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
@@ -21,7 +21,8 @@ import java.sql.Connection;
  * Interface to be implemented by Jdbc Java Migrations. By default the migration version and description will be extracted
  * from the class name. This can be overriden by also implementing the MigrationInfoProvider interface, in which
  * case it can be specified programmatically. The checksum of this migration (for validation) will also be null, unless
- * the migration also implements the MigrationChecksumProvider, in which case it can be returned programmatically.
+ * the migration also implements the MigrationChecksumProvider, in which case it can be returned programmatically. When
+ * the JdbcMigration implements ConfigurationAware, the master flyway configuration is automatically injected upon creation.
  */
 public interface JdbcMigration {
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -61,13 +61,16 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param config                   The configuration object.
      */
     public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration config) {
-        PlaceholderReplacer placeholderReplacer = config.createPlaceholderReplacer();
-        for (Location location : new Locations(config.getLocations()).getLocations()) {
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, config, location, placeholderReplacer));
-            migrationResolvers.add(new JdbcMigrationResolver(config, location));
 
-            if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(config, location));
+        if (!config.isSkipDefaultResolvers()) {
+            PlaceholderReplacer placeholderReplacer = config.createPlaceholderReplacer();
+            for (Location location : new Locations(config.getLocations()).getLocations()) {
+                migrationResolvers.add(new SqlMigrationResolver(dbSupport, config, location, placeholderReplacer));
+                migrationResolvers.add(new JdbcMigrationResolver(config, location));
+
+                if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {
+                    migrationResolvers.add(new SpringJdbcMigrationResolver(config, location));
+                }
             }
         }
 
@@ -103,6 +106,11 @@ public class CompositeMigrationResolver implements MigrationResolver {
         checkForIncompatibilities(migrations);
 
         return migrations;
+    }
+
+    /* private -> for testing */
+    Collection<MigrationResolver> getMigrationResolvers() {
+        return migrationResolvers;
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -15,6 +15,8 @@
  */
 package org.flywaydb.core.internal.resolver;
 
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
@@ -56,31 +58,20 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * Creates a new CompositeMigrationResolver.
      *
      * @param dbSupport                The database-specific support.
-     * @param scanner                  The Scanner for loading migrations on the classpath.
-     * @param locations                The locations where migrations are located.
-     * @param encoding                 The encoding of Sql migrations.
-     * @param sqlMigrationPrefix       The file name prefix for sql migrations.
-     * @param sqlMigrationSeparator    The file name separator for sql migrations.
-     * @param sqlMigrationSuffix       The file name suffix for sql migrations.
-     * @param placeholderReplacer      The placeholder replacer to use.
-     * @param customMigrationResolvers Custom Migration Resolvers.
+     * @param config                   The configuration object.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, Scanner scanner, Locations locations,
-                                      String encoding,
-                                      String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
-                                      PlaceholderReplacer placeholderReplacer,
-                                      MigrationResolver... customMigrationResolvers) {
-        for (Location location : locations.getLocations()) {
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
-                    encoding, sqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
-            migrationResolvers.add(new JdbcMigrationResolver(scanner, location));
+    public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration config) {
+        PlaceholderReplacer placeholderReplacer = config.createPlaceholderReplacer();
+        for (Location location : new Locations(config.getLocations()).getLocations()) {
+            migrationResolvers.add(new SqlMigrationResolver(dbSupport, config, location, placeholderReplacer));
+            migrationResolvers.add(new JdbcMigrationResolver(config, location));
 
-            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, location));
+            if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {
+                migrationResolvers.add(new SpringJdbcMigrationResolver(config, location));
             }
         }
 
-        migrationResolvers.addAll(Arrays.asList(customMigrationResolvers));
+        migrationResolvers.addAll(Arrays.asList(config.getResolvers()));
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
@@ -27,6 +28,7 @@ import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
 import org.flywaydb.core.internal.util.ClassUtils;
+import org.flywaydb.core.internal.util.InjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Pair;
 import org.flywaydb.core.internal.util.StringUtils;
@@ -52,14 +54,20 @@ public class JdbcMigrationResolver implements MigrationResolver {
     private Scanner scanner;
 
     /**
+     * The flyway master configuration.
+     */
+    private FlywayConfiguration configuration;
+
+    /**
      * Creates a new instance.
      *
+     * @param configuration The configurration instance.
      * @param location The base package on the classpath where to migrations are located.
-     * @param scanner  The Scanner for loading migrations on the classpath.
      */
-    public JdbcMigrationResolver(Scanner scanner, Location location) {
+    public JdbcMigrationResolver(FlywayConfiguration configuration, Location location) {
         this.location = location;
-        this.scanner = scanner;
+        this.scanner = configuration.getScanner();
+        this.configuration = configuration;
     }
 
     public List<ResolvedMigration> resolveMigrations() {
@@ -72,7 +80,7 @@ public class JdbcMigrationResolver implements MigrationResolver {
         try {
             Class<?>[] classes = scanner.scanForClasses(location, JdbcMigration.class);
             for (Class<?> clazz : classes) {
-                JdbcMigration jdbcMigration = ClassUtils.instantiate(clazz.getName(), scanner.getClassLoader());
+                JdbcMigration jdbcMigration = InjectionUtils.instantiateAndInjectConfiguration(clazz.getName(), scanner.getClassLoader(), configuration);
 
                 ResolvedMigrationImpl migrationInfo = extractMigrationInfo(jdbcMigration);
                 migrationInfo.setPhysicalLocation(ClassUtils.getLocationOnDisk(clazz));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -15,6 +15,8 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.MigrationResolver;
@@ -83,25 +85,19 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport             The database-specific support.
-     * @param scanner               The Scanner for loading migrations on the classpath.
+     * @param config                The configurration instance.
      * @param location              The location on the classpath where to migrations are located.
      * @param placeholderReplacer   The placeholder replacer to apply to sql migration scripts.
-     * @param encoding              The encoding of Sql migrations.
-     * @param sqlMigrationPrefix    The prefix for sql migrations
-     * @param sqlMigrationSeparator The separator for sql migrations
-     * @param sqlMigrationSuffix    The suffix for sql migrations
      */
-    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Location location,
-                                PlaceholderReplacer placeholderReplacer, String encoding,
-                                String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix) {
+    public SqlMigrationResolver(DbSupport dbSupport, FlywayConfiguration config, Location location, PlaceholderReplacer placeholderReplacer) {
         this.dbSupport = dbSupport;
-        this.scanner = scanner;
+        this.scanner = config.getScanner();
         this.location = location;
         this.placeholderReplacer = placeholderReplacer;
-        this.encoding = encoding;
-        this.sqlMigrationPrefix = sqlMigrationPrefix;
-        this.sqlMigrationSeparator = sqlMigrationSeparator;
-        this.sqlMigrationSuffix = sqlMigrationSuffix;
+        this.encoding = config.getEncoding();
+        this.sqlMigrationPrefix = config.getSqlMigrationPrefix();
+        this.sqlMigrationSeparator = config.getSqlMigrationSeparator();
+        this.sqlMigrationSuffix = config.getSqlMigrationSuffix();
     }
 
     public List<ResolvedMigration> resolveMigrations() {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ClassUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ClassUtils.java
@@ -15,6 +15,8 @@
  */
 package org.flywaydb.core.internal.util;
 
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 
 import java.io.UnsupportedEncodingException;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/InjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/InjectionUtils.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.FlywayException;
+
+/**
+ * Utility class for interfaced based injection.
+ */
+public class InjectionUtils {
+
+    private InjectionUtils() {
+        // Utility class
+    }
+
+    /**
+     * Injects the given flyway configuration into the target object if target implements the
+     * {@link ConfigurationAware} interface. Does nothing if target is not configuration aware.
+     *
+     * @param target The object to inject the configuration into.
+     * @param configuration The configuration to inject.
+     */
+    public static void injectFlywayConfiguration(Object target, FlywayConfiguration configuration) {
+        if (target instanceof ConfigurationAware) {
+            ((ConfigurationAware) target).setFlywayConfiguration(configuration);
+        }
+    }
+
+    // Must be synchronized for the Maven Parallel Junit runner to work
+    public static synchronized <T> T instantiateAndInjectConfiguration(String className, ClassLoader classLoader, FlywayConfiguration config) throws Exception {
+        T result = ClassUtils.instantiate(className, classLoader);
+        injectFlywayConfiguration(result, config);
+        return result;
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackImpl.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackImpl.java
@@ -18,16 +18,21 @@ package org.flywaydb.core;
 import static org.junit.Assert.assertNotNull;
 
 import java.sql.Connection;
+
 import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.ConfigurationAware;
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.MigrationInfo;
 
 /**
  * Sample FlywayCallback implementation to test that the lifecycle
  * notifications are getting called correctly
- * 
+ *
  * @author Dan Bunker
  */
-public class FlywayCallbackImpl implements FlywayCallback {
+public class FlywayCallbackImpl implements FlywayCallback, ConfigurationAware {
+
+    private FlywayConfiguration flywayConfiguration;
 	private boolean beforeClean = false;
 	private boolean afterClean = false;
 	private boolean beforeMigrate = false;
@@ -129,6 +134,11 @@ public class FlywayCallbackImpl implements FlywayCallback {
         assertNotNull(dataConnection);
 	}
 
+	@Override
+	public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+	}
+
 	public boolean isBeforeClean() {
 		return beforeClean;
 	}
@@ -185,4 +195,7 @@ public class FlywayCallbackImpl implements FlywayCallback {
 		return afterInfo;
 	}
 
+	public void assertFlywayConfigurationSet() {
+		assertNotNull("Configuration must have been set", flywayConfiguration);
+	}
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayCallbackSmallTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
  * Tests for Flyway Callbacks
  */
 public class FlywayCallbackSmallTest {
+
     @Test
     public void cleanTest() {
         Properties properties = createProperties("clean");

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayResolverImpl.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayResolverImpl.java
@@ -13,35 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flywaydb.core.internal.resolver.jdbc.dummy;
+package org.flywaydb.core;
 
 import org.flywaydb.core.api.ConfigurationAware;
 import org.flywaydb.core.api.FlywayConfiguration;
-import org.flywaydb.core.api.FlywayException;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.junit.Assert;
 
-import java.sql.Connection;
+import java.util.Collection;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
- * Test migration. Doubles as test for {@link ConfigurationAware} migration.
+ * Dummy implementation for Resolvers to check configuration injection.
  */
-public class V2__InterfaceBasedMigration implements JdbcMigration, ConfigurationAware {
+public class FlywayResolverImpl implements MigrationResolver, ConfigurationAware {
 
     private FlywayConfiguration flywayConfiguration;
 
     @Override
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+
         this.flywayConfiguration = flywayConfiguration;
     }
 
-    public void migrate(Connection connection) throws Exception {
-        if (flywayConfiguration == null) {
-            throw new FlywayException("Flyway configuration has not been set on migration");
-        }
-        // Do nothing else
+    @Override
+    public Collection<ResolvedMigration> resolveMigrations() {
+        return null;
     }
 
-    public boolean isFlywayConfigurationSet() {
-        return flywayConfiguration != null;
+    public void assertFlywayConfigurationSet() {
+        assertNotNull("Configuration must have been set", flywayConfiguration);
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -19,11 +19,13 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.resolver.MyConfigurationAwareCustomMigrationResolver;
 import org.flywaydb.core.internal.resolver.MyCustomMigrationResolver;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.junit.Test;
 
 import javax.sql.DataSource;
+
 import java.sql.Connection;
 import java.util.Properties;
 
@@ -129,6 +131,17 @@ public class FlywaySmallTest {
         flyway.configure(properties);
 
         assertEquals(MyCustomMigrationResolver.class, flyway.getResolvers()[0].getClass());
+    }
+
+    @Test
+    public void configureCustomConfigAwareMigrationResolvers() {
+        Properties properties = new Properties();
+        properties.setProperty("flyway.resolvers", MyConfigurationAwareCustomMigrationResolver.class.getName());
+
+        Flyway flyway = new Flyway();
+        flyway.configure(properties);
+
+        assertTrue(((MyConfigurationAwareCustomMigrationResolver) flyway.getResolvers()[0]).isFlywayConfigurationSet());
     }
 
     @Test

--- a/flyway-core/src/test/java/org/flywaydb/core/InjectionTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/InjectionTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core;
+
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class InjectionTest {
+
+    @Test
+    public void customCallbacksMustContainFlywayConfiguration() {
+        Properties properties = createProperties("callback");
+
+        FlywayCallbackImpl callback = new FlywayCallbackImpl();
+
+        final Flyway flyway = new Flyway();
+        flyway.configure(properties);
+        flyway.setCallbacks(callback);
+
+        callback.assertFlywayConfigurationSet();
+    }
+
+    @Test
+    public void customCallbacksViaPropertiesMustContainFlywayConfiguration() {
+        Properties properties = createProperties("callback");
+        properties.setProperty("flyway.callbacks", FlywayCallbackImpl.class.getName());
+
+        final Flyway flyway = new Flyway();
+        flyway.configure(properties);
+
+        FlywayCallbackImpl callback = (FlywayCallbackImpl) flyway.getCallbacks()[0];
+        callback.assertFlywayConfigurationSet();
+    }
+
+    @Test
+    public void customResolversMustContainFlywayConfiguration() {
+        Properties properties = createProperties("resolver");
+
+        FlywayResolverImpl resolver = new FlywayResolverImpl();
+
+        final Flyway flyway = new Flyway();
+        flyway.configure(properties);
+        flyway.setResolvers(resolver);
+
+        resolver.assertFlywayConfigurationSet();
+    }
+
+    @Test
+    public void customResolversViaPropertiesMustContainFlywayConfiguration() {
+        Properties properties = createProperties("resolver");
+        properties.setProperty("flyway.resolvers", FlywayResolverImpl.class.getName());
+
+        final Flyway flyway = new Flyway();
+        flyway.configure(properties);
+
+        for (MigrationResolver resolver : flyway.getResolvers()) {
+            if (resolver instanceof FlywayResolverImpl) {
+                ((FlywayResolverImpl) resolver).assertFlywayConfigurationSet();
+                return;
+            }
+        }
+
+        Assert.fail("Flyway instance does not contain expected instance of FlywayResolverImpl.");
+    }
+
+    private Properties createProperties(String name) {
+        Properties properties = new Properties();
+        properties.setProperty("flyway.user", "sa");
+        properties.setProperty("flyway.password", "");
+        properties.setProperty("flyway.url", "jdbc:h2:mem:flyway_test_injection_" + name + ";DB_CLOSE_DELAY=-1");
+        properties.setProperty("flyway.driver", "org.h2.Driver");
+        properties.setProperty("flyway.locations", "migration/dbsupport/h2/sql/domain");
+        properties.setProperty("flyway.validateOnMigrate", "false");
+        return properties;
+    }
+
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
@@ -41,10 +42,13 @@ public class CompositeMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsMultipleLocations() {
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()),
-                new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
+        FlywayConfiguration config = new FlywayConfigurationForTests(
+                Thread.currentThread().getContextClassLoader(),
+                new String[] {"migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"},
+                "UTF-8", "V", "__", ".sql",
+                new MyCustomMigrationResolver());
+
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -40,6 +40,7 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     private String sqlMigrationSuffix;
     private MyCustomMigrationResolver[] migrationResolvers;
     private Scanner scanner;
+    private boolean skipDefaultResolvers;
 
     public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
             String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
@@ -67,6 +68,15 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
     }
 
     @Override

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2010-2015 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.resolver;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.util.Locations;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.Scanner;
+
+/**
+ * Dummy Implementation of {@link FlywayConfiguration} for unit tests.
+ */
+public class FlywayConfigurationForTests implements FlywayConfiguration {
+
+    private ClassLoader classLoader;
+    private String[] locations;
+    private String encoding;
+    private String sqlMigrationPrefix;
+    private String sqlMigrationSeparator;
+    private String sqlMigrationSuffix;
+    private MyCustomMigrationResolver[] migrationResolvers;
+    private Scanner scanner;
+
+    public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
+            String sqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
+            MyCustomMigrationResolver... myCustomMigrationResolver) {
+        this.classLoader = contextClassLoader;
+        this.locations = locations;
+        this.encoding = encoding;
+        this.sqlMigrationPrefix = sqlMigrationPrefix;
+        this.sqlMigrationSeparator = sqlMigrationSeparator;
+        this.sqlMigrationSuffix = sqlMigrationSuffix;
+        this.migrationResolvers = myCustomMigrationResolver;
+        this.scanner = new Scanner(classLoader);
+    }
+
+    public FlywayConfigurationForTests(ClassLoader contextClassLoader) {
+        classLoader = contextClassLoader;
+        this.scanner = new Scanner(classLoader);
+    }
+
+    @Override
+    public FlywayCallback[] getCallbacks() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    @Override
+    public DataSource getDataSource() {
+        return null;
+    }
+
+    @Override
+    public MigrationResolver[] getResolvers() {
+        return migrationResolvers;
+    }
+
+    @Override
+    public String getBaselineDescription() {
+        return null;
+    }
+
+    @Override
+    public MigrationVersion getBaselineVersion() {
+        return null;
+    }
+
+    @Override
+    public String getSqlMigrationSuffix() {
+        return sqlMigrationSuffix;
+    }
+
+    @Override
+    public String getSqlMigrationSeparator() {
+        return sqlMigrationSeparator;
+    }
+
+    @Override
+    public String getSqlMigrationPrefix() {
+        return sqlMigrationPrefix;
+    }
+
+    @Override
+    public String getPlaceholderSuffix() {
+        return null;
+    }
+
+    @Override
+    public String getPlaceholderPrefix() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getPlaceholders() {
+        return null;
+    }
+
+    @Override
+    public MigrationVersion getTarget() {
+        return null;
+    }
+
+    @Override
+    public String getTable() {
+        return null;
+    }
+
+    @Override
+    public String[] getSchemas() {
+        return null;
+    }
+
+    @Override
+    public String[] getLocations() {
+        return this.locations;
+    }
+
+    @Override
+    public Scanner getScanner() {
+        return scanner;
+    }
+
+    @Override
+    public PlaceholderReplacer createPlaceholderReplacer() {
+        return null;
+    }
+
+    @Override
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
@@ -13,32 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flywaydb.core.internal.resolver.jdbc.dummy;
+package org.flywaydb.core.internal.resolver;
 
 import org.flywaydb.core.api.ConfigurationAware;
 import org.flywaydb.core.api.FlywayConfiguration;
-import org.flywaydb.core.api.FlywayException;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.MigrationType;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
 
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Test migration. Doubles as test for {@link ConfigurationAware} migration.
- */
-public class V2__InterfaceBasedMigration implements JdbcMigration, ConfigurationAware {
+* Created by Axel on 3/7/14.
+*/
+public class MyConfigurationAwareCustomMigrationResolver extends MyCustomMigrationResolver implements ConfigurationAware {
 
     private FlywayConfiguration flywayConfiguration;
 
     @Override
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
         this.flywayConfiguration = flywayConfiguration;
-    }
-
-    public void migrate(Connection connection) throws Exception {
-        if (flywayConfiguration == null) {
-            throw new FlywayException("Flyway configuration has not been set on migration");
-        }
-        // Do nothing else
     }
 
     public boolean isFlywayConfigurationSet() {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -15,14 +15,17 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,17 +37,17 @@ import static org.junit.Assert.assertNull;
  * Test for JdbcMigrationResolver.
  */
 public class JdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
+    private final FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader());
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/error")).resolveMigrations();
+        new JdbcMigrationResolver(config, new Location("org/flywaydb/core/internal/resolver/jdbc/error")).resolveMigrations();
     }
 
     @Test
-    public void resolveMigrations() {
+    public void resolveMigrations() throws Exception {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"));
+                new JdbcMigrationResolver(config, new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"));
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -55,6 +58,10 @@ public class JdbcMigrationResolverSmallTest {
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
         assertNull(migrationInfo.getChecksum());
+
+        // do a test execute, since the migration does not do anything, we simply test whether the
+        // configuration has been set correctly
+        migrationInfo.getExecutor().execute(null);
 
         ResolvedMigration migrationInfo1 = migrationList.get(1);
         assertEquals("3.5", migrationInfo1.getVersion().toString());
@@ -67,7 +74,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(config, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -76,7 +83,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(config, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -15,7 +15,9 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
@@ -33,12 +35,14 @@ import static org.junit.Assert.assertNull;
  * Test for SpringJdbcMigrationResolver.
  */
 public class SpringJdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
+    private final FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader());
 
     @Test
     public void resolveMigrations() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader());
+
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/spring/dummy"));
+                new SpringJdbcMigrationResolver(config, new Location("org/flywaydb/core/internal/resolver/spring/dummy"));
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -57,7 +61,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -66,7 +70,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -15,7 +15,9 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -39,10 +41,10 @@ public class SqlMigrationResolverMediumTest {
         @SuppressWarnings("ConstantConditions")
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "V", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
-                        new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        "UTF-8", "V", "__", ".sql");
+                new SqlMigrationResolver(null, config,
+                        new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -15,7 +15,10 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.FlywayConfiguration;
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -34,13 +37,13 @@ import static org.junit.Assert.assertEquals;
  */
 public class SqlMigrationResolverSmallTest {
 
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
-
     @Test
     public void resolveMigrations() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "V", "__", ".sql");
+
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
-                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "__", ".sql");
+                new SqlMigrationResolver(null, config,
+                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -58,9 +61,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsRoot() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "CheckValidate", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "__", ".sql");
+                new SqlMigrationResolver(null, config, new Location(""),
+                        PlaceholderReplacer.NO_PLACEHOLDERS);
 
         //changed to 2 as new test cases are added for SybaseASE
         assertEquals(2, sqlMigrationResolver.resolveMigrations().size());
@@ -68,19 +72,20 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsNonExisting() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "CheckValidate", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
-                        new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                        "CheckValidate", "__", ".sql");
+                new SqlMigrationResolver(null, config,
+                        new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS);
 
         sqlMigrationResolver.resolveMigrations();
     }
 
     @Test
     public void extractScriptName() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "db_", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
-                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "__", ".sql");
+                new SqlMigrationResolver(null, config,
+                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -88,9 +93,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameRootLocation() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "db_", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "__", ".sql");
+                new SqlMigrationResolver(null, config, new Location(""),
+                        PlaceholderReplacer.NO_PLACEHOLDERS);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -98,10 +104,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameFileSystemPrefix() {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "V", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
-                        new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                        "V", "__", ".sql");
+                new SqlMigrationResolver(null, config,
+                        new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS);
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql")));
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.*;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
@@ -160,7 +161,7 @@ public abstract class MigrationTestCase {
 
     protected String getMigrationDir() { return MIGRATIONDIR; }
     protected String getBasedir() { return BASEDIR; }
-    
+
 
     @Test
     public void migrate() throws Exception {
@@ -224,12 +225,11 @@ public abstract class MigrationTestCase {
      * @param migrationInfo The migration to check.
      */
     private void assertChecksum(MigrationInfo migrationInfo) {
+        FlywayConfiguration config = new FlywayConfigurationForTests(Thread.currentThread().getContextClassLoader(), new String[0], "UTF-8", "V", "__", ".sql");
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, config,
                 new Location(getBasedir()),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                "UTF-8",
-                "V", "__", ".sql");
+                PlaceholderReplacer.NO_PLACEHOLDERS);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {
@@ -597,7 +597,7 @@ public abstract class MigrationTestCase {
         assertTrue(dbSupport.getOriginalSchema().exists());
         assertFalse(dbSupport.getSchema("InVaLidScHeMa").exists());
     }
-	
+
     protected void createTestTable() throws SQLException {
         jdbcTemplate.execute("CREATE TABLE t1 (\n" +
                 "  name VARCHAR(25) NOT NULL,\n" +
@@ -607,15 +607,15 @@ public abstract class MigrationTestCase {
 	protected String getFutureFailedLocation() {
 		return "migration/future_failed";
 	}
-	
+
 	protected String getValidateLocation() {
 		return "migration/validate";
 	}
-	
+
 	protected String getSemiColonLocation() {
 		return "migration/semicolon";
 	}
-	
+
 	protected String getCommentLocation() {
 		return "migration/comment";
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,11 @@
                 <classifier>macosx-x64</classifier>
                 <type>tar.gz</type>
             </dependency>
+            <dependency>
+                <groupId>sqlline</groupId>
+                <artifactId>sqlline</artifactId>
+                <version>1.1.9</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR is a trivial implementation of #1078. It introduces a new parameter flyway.skipDefaultResolvers to allow working with custom resolvers, only.

It is base on my previous PR (#805) implementing a mechanism to provide the flyway configuration to callbacks and resolvers.