### PR TITLE
Don't merge: #1078: Allow default resolvers to be replaced

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1014,15 +1014,14 @@ public class Flyway implements FlywayConfiguration {
     /**
      * Creates the MigrationResolver.
      *
-     * @param dbSupport The database-specific support.
      * @return A new, fully configured, MigrationResolver instance.
      */
-    private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
+    private MigrationResolver createMigrationResolver() {
         for (MigrationResolver resolver : resolvers) {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, this);
+        return new CompositeMigrationResolver(this);
     }
 
     /**
@@ -1235,7 +1234,7 @@ public class Flyway implements FlywayConfiguration {
 
             // force creation of a new Scanner to prevent location caching, because the classpath might have been changed
             Scanner scanner = Scanner.createNew(classLoader);
-            MigrationResolver migrationResolver = createMigrationResolver(dbSupport);
+            MigrationResolver migrationResolver = createMigrationResolver();
 
             if (callbacks.length == 0) {
                 setCallbacks(new SqlScriptFlywayCallback(dbSupport, scanner, locations, createPlaceholderReplacer(),

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -306,11 +306,7 @@ public class Flyway implements FlywayConfiguration {
         return target;
     }
 
-    /**
-     * Checks whether placeholders should be replaced.
-     *
-     * @return Whether placeholders should be replaced. (default: true)
-     */
+    @Override
     public boolean isPlaceholderReplacement() {
         return placeholderReplacement;
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -246,6 +246,11 @@ public class Flyway implements FlywayConfiguration {
     private MigrationResolver[] resolvers = new MigrationResolver[0];
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     */
+    private boolean skipDefaultResolvers;
+
+    /**
      * Whether Flyway created the DataSource.
      */
     private boolean createdDataSource;
@@ -440,6 +445,16 @@ public class Flyway implements FlywayConfiguration {
         return resolvers;
     }
 
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
+    }
+
+    /**
+     * Retrieves the dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     *
+     * @return The dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     */
     @Override
     public DataSource getDataSource() {
         return dataSource;
@@ -807,6 +822,15 @@ public class Flyway implements FlywayConfiguration {
     }
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @param skipDefaultResolvers Whether default built-in resolvers should be skipped.
+     */
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    /**
      * <p>Starts the database migration. All pending migrations will be applied in order.
      * Calling migrate on an up-to-date database has no effect.</p>
      * <img src="http://flywaydb.org/assets/balsamiq/command-migrate.png" alt="migrate">
@@ -1141,6 +1165,10 @@ public class Flyway implements FlywayConfiguration {
         String resolversProp = getValueAndRemoveEntry(props, "flyway.resolvers");
         if (StringUtils.hasLength(resolversProp)) {
             setResolversAsClassNames(StringUtils.tokenizeToStringArray(resolversProp, ","));
+        }
+        String skipDefaultResolverProp = getValueAndRemoveEntry(props, "flyway.skipDefaultResolvers");
+        if (skipDefaultResolverProp != null) {
+            setSkipDefaultResolvers(Boolean.parseBoolean(skipDefaultResolverProp));
         }
         String callbacksProp = getValueAndRemoveEntry(props, "flyway.callbacks");
         if (StringUtils.hasLength(callbacksProp)) {

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1015,15 +1015,14 @@ public class Flyway implements FlywayConfiguration {
      * Creates the MigrationResolver.
      *
      * @param dbSupport The database-specific support.
-     * @param scanner   The Scanner for resolving migrations.
      * @return A new, fully configured, MigrationResolver instance.
      */
-    private MigrationResolver createMigrationResolver(DbSupport dbSupport, Scanner scanner) {
+    private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
         for (MigrationResolver resolver : resolvers) {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, scanner, this, locations,
+        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations,
                 encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix,
                 createPlaceholderReplacer(), resolvers);
     }
@@ -1236,8 +1235,9 @@ public class Flyway implements FlywayConfiguration {
                 schemas[i] = dbSupport.getSchema(schemaNames[i]);
             }
 
-            Scanner scanner = new Scanner(classLoader);
-            MigrationResolver migrationResolver = createMigrationResolver(dbSupport, scanner);
+            // force creation of a new Scanner to prevent location caching, because the classpath might have been changed
+            Scanner scanner = Scanner.createNew(classLoader);
+            MigrationResolver migrationResolver = createMigrationResolver(dbSupport);
 
             if (callbacks.length == 0) {
                 setCallbacks(new SqlScriptFlywayCallback(dbSupport, scanner, locations, createPlaceholderReplacer(),

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1022,9 +1022,7 @@ public class Flyway implements FlywayConfiguration {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations,
-                encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix,
-                createPlaceholderReplacer(), resolvers);
+        return new CompositeMigrationResolver(dbSupport, this);
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -43,6 +43,13 @@ public interface FlywayConfiguration {
     ClassLoader getClassLoader();
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @return Whether default built-in resolvers should be skipped.
+     */
+    boolean isSkipDefaultResolvers();
+
+    /**
      * Retrieves the dataSource to use to access the database. Must have the necessary privileges to execute ddl.
      *
      * @return The dataSource to use to access the database. Must have the necessary privileges to execute ddl.

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
@@ -99,7 +99,7 @@ public class SqlScriptFlywayCallback implements FlywayCallback {
                                 "-> " + existing.getResource().getLocationOnDisk() + "\n" +
                                 "-> " + resource.getLocationOnDisk());
                     }
-                    scripts.put(key, new SqlScript(dbSupport, resource, placeholderReplacer, encoding));
+                    scripts.put(key, new SqlScript(resource, placeholderReplacer, encoding));
                 }
             }
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlScript.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlScript.java
@@ -38,46 +38,33 @@ public class SqlScript {
     private static final Log LOG = LogFactory.getLog(SqlScript.class);
 
     /**
-     * The database-specific support.
-     */
-    private final DbSupport dbSupport;
-
-    /**
-     * The sql statements contained in this script.
-     */
-    private final List<SqlStatement> sqlStatements;
-
-    /**
      * The resource containing the statements.
      */
     private final Resource resource;
+
+    private PlaceholderReplacer placeholderReplacer;
+    private String sqlScriptSource;
 
     /**
      * Creates a new sql script from this source.
      *
      * @param sqlScriptSource The sql script as a text block with all placeholders already replaced.
-     * @param dbSupport       The database-specific support.
      */
-    public SqlScript(String sqlScriptSource, DbSupport dbSupport) {
-        this.dbSupport = dbSupport;
-        this.sqlStatements = parse(sqlScriptSource);
+    public SqlScript(String sqlScriptSource) {
+        this.sqlScriptSource = sqlScriptSource;
         this.resource = null;
+        this.placeholderReplacer = PlaceholderReplacer.NO_PLACEHOLDERS;
     }
 
     /**
      * Creates a new sql script from this resource.
-     *
-     * @param dbSupport           The database-specific support.
-     * @param sqlScriptResource   The resource containing the statements.
+     *  @param sqlScriptResource   The resource containing the statements.
      * @param placeholderReplacer The placeholder replacer.
      * @param encoding            The encoding to use.
      */
-    public SqlScript(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
-        this.dbSupport = dbSupport;
-
-        String sqlScriptSource = sqlScriptResource.loadAsString(encoding);
-        this.sqlStatements = parse(placeholderReplacer.replacePlaceholders(sqlScriptSource));
-
+    public SqlScript(Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
+        this.placeholderReplacer = placeholderReplacer;
+        this.sqlScriptSource = sqlScriptResource.loadAsString(encoding);
         this.resource = sqlScriptResource;
     }
 
@@ -86,8 +73,8 @@ public class SqlScript {
      *
      * @return The sql statements contained in this script.
      */
-    public List<SqlStatement> getSqlStatements() {
-        return sqlStatements;
+    public List<SqlStatement> getSqlStatements(DbSupport dbSupport) {
+        return parse(placeholderReplacer.replacePlaceholders(sqlScriptSource), dbSupport);
     }
 
     /**
@@ -103,7 +90,8 @@ public class SqlScript {
      * @param jdbcTemplate The jdbc template to use to execute this script.
      */
     public void execute(final JdbcTemplate jdbcTemplate) {
-        for (SqlStatement sqlStatement : sqlStatements) {
+        DbSupport dbSupport = DbSupportFactory.createDbSupport(jdbcTemplate.getConnection(), false);
+        for (SqlStatement sqlStatement : getSqlStatements(dbSupport)) {
             String sql = sqlStatement.getSql();
             LOG.debug("Executing SQL: " + sql);
 
@@ -126,18 +114,19 @@ public class SqlScript {
      * @return The parsed statements.
      */
     /* private -> for testing */
-    List<SqlStatement> parse(String sqlScriptSource) {
-        return linesToStatements(readLines(new StringReader(sqlScriptSource)));
+    List<SqlStatement> parse(String sqlScriptSource, DbSupport dbSupport) {
+        return linesToStatements(readLines(new StringReader(sqlScriptSource)), dbSupport);
     }
 
     /**
      * Turns these lines in a series of statements.
      *
      * @param lines The lines to analyse.
+     * @param dbSupport
      * @return The statements contained in these lines (in order).
      */
     /* private -> for testing */
-    List<SqlStatement> linesToStatements(List<String> lines) {
+    List<SqlStatement> linesToStatements(List<String> lines, DbSupport dbSupport) {
         List<SqlStatement> statements = new ArrayList<SqlStatement>();
 
         Delimiter nonStandardDelimiter = null;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
@@ -81,7 +81,7 @@ public class MetaDataTableImpl implements MetaDataTable {
         placeholders.put("table", table.getName());
         String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-        SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+        SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
         sqlScript.execute(jdbcTemplate);
 
         LOG.debug("Metadata table " + table + " created.");
@@ -126,7 +126,7 @@ public class MetaDataTableImpl implements MetaDataTable {
 
                 String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
 
                 sqlScript.execute(jdbcTemplate);
             } else {
@@ -361,7 +361,7 @@ public class MetaDataTableImpl implements MetaDataTable {
 
             String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
 
             sqlScript.execute(jdbcTemplate);
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -19,7 +19,6 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
@@ -47,11 +46,10 @@ public class CompositeMigrationResolver implements MigrationResolver {
     /**
      * Creates a new CompositeMigrationResolver.
      *
-     * @param dbSupport                    The database-specific support.
      * @param config                       The configuration object.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration config) {
-        migrationResolvers.add(new SqlMigrationResolver(dbSupport, config));
+    public CompositeMigrationResolver(FlywayConfiguration config) {
+        migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config));
         migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config));
 
         if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -15,8 +15,8 @@
  */
 package org.flywaydb.core.internal.resolver;
 
-import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
@@ -24,18 +24,8 @@ import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.FeatureDetector;
-import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Facility for retrieving and sorting the available migrations from the classpath through the various migration
@@ -57,31 +47,17 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * Creates a new CompositeMigrationResolver.
      *
      * @param dbSupport                    The database-specific support.
-     * @param classLoader                  The classloader for loading migrations on the classpath.
-     * @param locations                    The locations where migrations are located.
-     * @param encoding                     The encoding of Sql migrations.
-     * @param sqlMigrationPrefix           The file name prefix for sql migrations.
-     * @param repeatableSqlMigrationPrefix The file name prefix for repeatable sql migrations.
-     * @param sqlMigrationSeparator        The file name separator for sql migrations.
-     * @param sqlMigrationSuffix           The file name suffix for sql migrations.
-     * @param placeholderReplacer          The placeholder replacer to use.
-     * @param customMigrationResolvers     Custom Migration Resolvers.
+     * @param config                       The configuration object.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, FlywayConfiguration config, Locations locations,
-                                      String encoding,
-                                      String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
-                                      String sqlMigrationSeparator, String sqlMigrationSuffix,
-                                      PlaceholderReplacer placeholderReplacer,
-                                      MigrationResolver... customMigrationResolvers) {
-        migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, locations, placeholderReplacer,
-                encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
-        migrationResolvers.add(new JdbcMigrationResolver(classLoader, locations, config));
+    public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration config) {
+        migrationResolvers.add(new SqlMigrationResolver(dbSupport, config));
+        migrationResolvers.add(new JdbcMigrationResolver(config));
 
-        if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
-            migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, locations, config));
+        if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {
+            migrationResolvers.add(new SpringJdbcMigrationResolver(config));
         }
 
-        migrationResolvers.addAll(Arrays.asList(customMigrationResolvers));
+        migrationResolvers.addAll(Arrays.asList(config.getResolvers()));
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.flywaydb.core.internal.util.FeatureDetector;
 
 import java.util.*;
@@ -51,10 +52,10 @@ public class CompositeMigrationResolver implements MigrationResolver {
      */
     public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration config) {
         migrationResolvers.add(new SqlMigrationResolver(dbSupport, config));
-        migrationResolvers.add(new JdbcMigrationResolver(config));
+        migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config));
 
         if (new FeatureDetector(config.getClassLoader()).isSpringJdbcAvailable()) {
-            migrationResolvers.add(new SpringJdbcMigrationResolver(config));
+            migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config));
         }
 
         migrationResolvers.addAll(Arrays.asList(config.getResolvers()));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -73,14 +73,12 @@ public class CompositeMigrationResolver implements MigrationResolver {
                                       String sqlMigrationSeparator, String sqlMigrationSuffix,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
-        for (Location location : locations.getLocations()) {
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, location, placeholderReplacer,
-                    encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
-            migrationResolvers.add(new JdbcMigrationResolver(classLoader, location, config));
+        migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, locations, placeholderReplacer,
+                encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+        migrationResolvers.add(new JdbcMigrationResolver(classLoader, locations, config));
 
-            if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, location, config));
-            }
+        if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
+            migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, locations, config));
         }
 
         migrationResolvers.addAll(Arrays.asList(customMigrationResolvers));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -57,7 +57,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * Creates a new CompositeMigrationResolver.
      *
      * @param dbSupport                    The database-specific support.
-     * @param scanner                      The Scanner for loading migrations on the classpath.
+     * @param classLoader                  The classloader for loading migrations on the classpath.
      * @param locations                    The locations where migrations are located.
      * @param encoding                     The encoding of Sql migrations.
      * @param sqlMigrationPrefix           The file name prefix for sql migrations.
@@ -67,19 +67,19 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param placeholderReplacer          The placeholder replacer to use.
      * @param customMigrationResolvers     Custom Migration Resolvers.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, Scanner scanner, FlywayConfiguration config, Locations locations,
+    public CompositeMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, FlywayConfiguration config, Locations locations,
                                       String encoding,
                                       String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
                                       String sqlMigrationSeparator, String sqlMigrationSuffix,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         for (Location location : locations.getLocations()) {
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
+            migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, location, placeholderReplacer,
                     encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
-            migrationResolvers.add(new JdbcMigrationResolver(scanner, location, config));
+            migrationResolvers.add(new JdbcMigrationResolver(classLoader, location, config));
 
-            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, location, config));
+            if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
+                migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, location, config));
             }
         }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -57,13 +57,11 @@ public class JdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The locations where to migrations are located. Non classpath locations are ignored.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public JdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -62,12 +62,12 @@ public class JdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param location      The base package on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(Scanner scanner, Location location, FlywayConfiguration configuration) {
+    public JdbcMigrationResolver(ClassLoader classLoader, Location location, FlywayConfiguration configuration) {
         this.location = location;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.jdbc;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
@@ -38,11 +39,7 @@ import java.util.List;
  * Migration resolver for Jdbc migrations. The classes must have a name like R__My_description, V1__Description
  * or V1_1_3__Description.
  */
-public class JdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base package on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class JdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -54,22 +51,16 @@ public class JdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public JdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) continue;
             resolveMigrationsForSingleLocation(location, migrations);
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -63,12 +63,12 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param location      The base package on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(Scanner scanner, Location location, FlywayConfiguration configuration) {
+    public SpringJdbcMigrationResolver(ClassLoader classLoader, Location location, FlywayConfiguration configuration) {
         this.location = location;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
@@ -39,11 +40,7 @@ import java.util.List;
  * Migration resolver for Spring Jdbc migrations. The classes must have a name like V1 or V1_1_3 or V1__Description
  * or V1_1_3__Description.
  */
-public class SpringJdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base package on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class SpringJdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -55,22 +52,16 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public Collection<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) continue;
             resolveMigrationsForSingleLocation(location, migrations);
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -58,13 +58,11 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The locations where to migrations are located. Non classpath locations are ignored.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
@@ -15,10 +15,9 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
-import org.flywaydb.core.internal.dbsupport.DbSupport;
-import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.api.resolver.MigrationExecutor;
 import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
 
@@ -28,11 +27,6 @@ import java.sql.Connection;
  * Database migration based on a sql file.
  */
 public class SqlMigrationExecutor implements MigrationExecutor {
-    /**
-     * Database-specific support.
-     */
-    private final DbSupport dbSupport;
-
     /**
      * The placeholder replacer to apply to sql migration scripts.
      */
@@ -52,14 +46,11 @@ public class SqlMigrationExecutor implements MigrationExecutor {
 
     /**
      * Creates a new sql script migration based on this sql script.
-     *
-     * @param dbSupport           The database-specific support.
-     * @param sqlScriptResource   The resource containing the sql script.
+     *  @param sqlScriptResource   The resource containing the sql script.
      * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
      * @param encoding            The encoding of this Sql migration.
      */
-    public SqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
-        this.dbSupport = dbSupport;
+    public SqlMigrationExecutor(Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
         this.sqlScriptResource = sqlScriptResource;
         this.encoding = encoding;
         this.placeholderReplacer = placeholderReplacer;
@@ -67,7 +58,7 @@ public class SqlMigrationExecutor implements MigrationExecutor {
 
     @Override
     public void execute(Connection connection) {
-        SqlScript sqlScript = new SqlScript(dbSupport, sqlScriptResource, placeholderReplacer, encoding);
+        SqlScript sqlScript = new SqlScript(sqlScriptResource, placeholderReplacer, encoding);
         sqlScript.execute(new JdbcTemplate(connection, 0));
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -93,7 +93,7 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
-     * @param scanner                      The Scanner for loading migrations on the classpath.
+     * @param classloader                  The classloader for loading migrations from the classpath.
      * @param location                     The location on the classpath where to migrations are located.
      * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
      * @param encoding                     The encoding of Sql migrations.
@@ -102,12 +102,12 @@ public class SqlMigrationResolver implements MigrationResolver {
      * @param sqlMigrationSeparator        The separator for sql migrations
      * @param sqlMigrationSuffix           The suffix for sql migrations
      */
-    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Location location,
+    public SqlMigrationResolver(DbSupport dbSupport, ClassLoader classloader, Location location,
                                 PlaceholderReplacer placeholderReplacer, String encoding,
                                 String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
                                 String sqlMigrationSeparator, String sqlMigrationSuffix) {
         this.dbSupport = dbSupport;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classloader);
         this.location = location;
         this.placeholderReplacer = placeholderReplacer;
         this.encoding = encoding;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -18,11 +18,11 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.callback.SqlScriptFlywayCallback;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
@@ -45,60 +45,50 @@ import java.util.zip.CRC32;
  * Migration resolver for sql files on the classpath. The sql files must have names like
  * V1__Description.sql or V1_1__Description.sql.
  */
-public class SqlMigrationResolver implements MigrationResolver {
-    /**
-     * Database-specific support.
-     */
-    private final DbSupport dbSupport;
+public class SqlMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The scanner to use.
      */
-    private final Scanner scanner;
+    private Scanner scanner;
 
     /**
      * The base directory on the classpath where to migrations are located.
      */
-    private final Locations locations;
+    private Locations locations;
 
     /**
      * The placeholder replacer to apply to sql migration scripts.
      */
-    private final PlaceholderReplacer placeholderReplacer;
+    private PlaceholderReplacer placeholderReplacer;
 
     /**
      * The encoding of Sql migrations.
      */
-    private final String encoding;
+    private String encoding;
 
     /**
      * The prefix for sql migrations
      */
-    private final String sqlMigrationPrefix;
+    private String sqlMigrationPrefix;
 
     /**
      * The prefix for repeatable sql migrations
      */
-    private final String repeatableSqlMigrationPrefix;
+    private String repeatableSqlMigrationPrefix;
 
     /**
      * The separator for sql migrations
      */
-    private final String sqlMigrationSeparator;
+    private String sqlMigrationSeparator;
 
     /**
      * The suffix for sql migrations
      */
-    private final String sqlMigrationSuffix;
+    private String sqlMigrationSuffix;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param dbSupport                    The database-specific support.
-     * @param configuration                The configuration object.
-     */
-    public SqlMigrationResolver(DbSupport dbSupport, FlywayConfiguration configuration) {
-        this.dbSupport = dbSupport;
+    @Override
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.scanner = Scanner.create(configuration.getClassLoader());
         this.locations = new Locations(configuration.getLocations());
         this.placeholderReplacer = createPlaceholderReplacer(configuration);
@@ -147,7 +137,7 @@ public class SqlMigrationResolver implements MigrationResolver {
             migration.setChecksum(calculateChecksum(resource, resource.loadAsString(encoding)));
             migration.setType(MigrationType.SQL);
             migration.setPhysicalLocation(resource.getLocationOnDisk());
-            migration.setExecutor(new SqlMigrationExecutor(dbSupport, resource, placeholderReplacer, encoding));
+            migration.setExecutor(new SqlMigrationExecutor(resource, placeholderReplacer, encoding));
             migrations.add(migration);
         }
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
@@ -19,7 +19,7 @@ import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 
 /**
- * Utility class for interfaced based injection.
+ * Utility class for interface based injection.
  */
 public class ConfigurationInjectionUtils {
 
@@ -30,13 +30,13 @@ public class ConfigurationInjectionUtils {
     /**
      * Injects the given flyway configuration into the target object if target implements the
      * {@link ConfigurationAware} interface. Does nothing if target is not configuration aware.
-     *
      * @param target The object to inject the configuration into.
      * @param configuration The configuration to inject.
      */
-    public static void injectFlywayConfiguration(Object target, FlywayConfiguration configuration) {
+    public static <T> T injectFlywayConfiguration(T target, FlywayConfiguration configuration) {
         if (target instanceof ConfigurationAware) {
             ((ConfigurationAware) target).setFlywayConfiguration(configuration);
         }
+        return target;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
@@ -39,4 +39,5 @@ public class ConfigurationInjectionUtils {
         }
         return target;
     }
+
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
@@ -18,10 +18,14 @@ package org.flywaydb.core.internal.util.scanner;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ResourceAndClassScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.android.AndroidScanner;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemScanner;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Scanner for Resources and Classes.
@@ -32,13 +36,48 @@ public class Scanner {
     private final ClassLoader classLoader;
     private final FileSystemScanner fileSystemScanner = new FileSystemScanner();
 
-    public Scanner(ClassLoader classLoader) {
+    private Scanner(ClassLoader classLoader) {
         this.classLoader = classLoader;
         if (new FeatureDetector(classLoader).isAndroidAvailable()) {
             resourceAndClassScanner = new AndroidScanner(classLoader);
         } else {
             resourceAndClassScanner = new ClassPathScanner(classLoader);
         }
+    }
+
+    private static Map<ClassLoader, WeakReference<Scanner>> scannerCache = new WeakHashMap<ClassLoader, WeakReference<Scanner>>();
+
+    /**
+     * Create or retrieves a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key.
+     * @param classLoader The classloader to scan.
+     * @return A new or existing Scanner instance, never null.
+     */
+    public static synchronized Scanner create(ClassLoader classLoader) {
+        WeakReference<Scanner> result = scannerCache.get(classLoader);
+
+        if (result == null || result.get() == null) {
+            return createNew(classLoader);
+        }
+
+        return result.get();
+    }
+
+    /**
+     * Creates a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key. This method is necessary when flyway is methods are called a) multiple times
+     * in one run, b) using the same classloader and c) when the classpath of the classloader changes between
+     * invocations. This can happen for example in the Maven plugin in a "clean migrate" scenario, where between
+     * the clean step an the migrate step source code is compiled / copied and the classloader extended (with the
+     * target/classes folder, Maven 2 did create a new classloader, thus the problem did not occur).
+     * @param classLoader The classloader to scan.
+     * @return A new Scanner instance, never null.
+     */
+    public static synchronized Scanner createNew(ClassLoader classLoader) {
+        WeakReference<Scanner> result = new WeakReference<Scanner>(new Scanner(classLoader));
+        scannerCache.put(classLoader, result);
+
+        return result.get();
     }
 
     /**

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -25,7 +25,6 @@ import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.junit.Test;
 
 import javax.sql.DataSource;
-
 import java.sql.Connection;
 import java.util.Properties;
 
@@ -195,5 +194,18 @@ public class FlywaySmallTest {
         } catch (FlywayException e) {
             //expected
         }
+    }
+
+    @Test
+    public void customResolversHaveConfigurationInjected() {
+        MyConfigurationAwareCustomMigrationResolver configResolver = new MyConfigurationAwareCustomMigrationResolver();
+
+        Flyway flyway = new Flyway();
+        flyway.setDataSource("jdbc:h2:mem:flyway_test;DB_CLOSE_DELAY=-1", "sa", "");
+        flyway.setResolvers(configResolver);
+
+        flyway.migrate();
+
+        configResolver.assertFlywayConfigurationIsSet();
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/SqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/SqlScriptSmallTest.java
@@ -35,7 +35,9 @@ public class SqlScriptSmallTest {
     /**
      * Class under test.
      */
-    private SqlScript sqlScript = new SqlScript("", new MySQLDbSupport(null));
+    private SqlScript sqlScript = new SqlScript("");
+
+    private DbSupport dbSupport = new MySQLDbSupport(null);
 
     /**
      * Input lines.
@@ -45,14 +47,14 @@ public class SqlScriptSmallTest {
     @Test
     public void stripSqlCommentsNoComment() {
         lines.add("select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals("select * from table", sqlStatements.get(0).getSql());
     }
 
     @Test
     public void stripSqlCommentsSingleLineComment() {
         lines.add("--select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(0, sqlStatements.size());
     }
 
@@ -60,7 +62,7 @@ public class SqlScriptSmallTest {
     public void stripSqlCommentsMultiLineCommentSingleLine() {
         lines.add("/*comment line*/");
         lines.add("select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals("select * from table", sqlStatements.get(0).getSql());
     }
 
@@ -68,7 +70,7 @@ public class SqlScriptSmallTest {
     public void stripSqlCommentsMultiLineCommentMultipleLines() {
         lines.add("/*comment line");
         lines.add("more comment text*/");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(0, sqlStatements.size());
     }
 
@@ -78,7 +80,7 @@ public class SqlScriptSmallTest {
         lines.add("from mytable");
         lines.add("where col1 > 10;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -99,7 +101,7 @@ public class SqlScriptSmallTest {
         lines.add("DELIMITER ;");
         lines.add("*/");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(1, sqlStatements.size());
 
         SqlStatement sqlStatement = sqlStatements.get(0);
@@ -122,7 +124,7 @@ public class SqlScriptSmallTest {
         lines.add("--these statements are imported the above multiline is detected");
         lines.add("INSERT INTO mytable (id, data1, data2)VALUES (5,1,'hi');");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(2, sqlStatements.size());
 
         assertEquals(6, sqlStatements.get(0).getLineNumber());
@@ -140,7 +142,7 @@ public class SqlScriptSmallTest {
         lines.add("select 4;");
         lines.add("$$");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(4, sqlStatements.size());
 
         assertEquals("select 1", sqlStatements.get(0).getSql());
@@ -155,7 +157,7 @@ public class SqlScriptSmallTest {
         lines.add("DROP TABLE IF EXISTS account;");
         lines.add("/*!40101 SET character_set_client = utf8 */;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(3, sqlStatements.size());
 
@@ -172,7 +174,7 @@ public class SqlScriptSmallTest {
         }
         lines.add("(1, '2', '3', '4');");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -187,7 +189,7 @@ public class SqlScriptSmallTest {
         lines.add("-----------------------------------------*/");
         lines.add("SELECT 1;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -204,7 +206,7 @@ public class SqlScriptSmallTest {
         lines.add("Please find your quote attached in PDF format.'");
         lines.add("where templatename = 'quote_template';");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -227,7 +229,7 @@ public class SqlScriptSmallTest {
         lines.add("");
         lines.add("update emailtemplate set body = 'Howdy';");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(3, sqlStatements.size());
 
@@ -250,7 +252,7 @@ public class SqlScriptSmallTest {
         placeholders.put("or_replace", "OR REPLACE");
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(placeholderReplacer.replacePlaceholders(source));
+        List<SqlStatement> sqlStatements = sqlScript.parse(placeholderReplacer.replacePlaceholders(source), dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -268,7 +270,7 @@ public class SqlScriptSmallTest {
                 "    Please find your quote attached in PDF format.'\n" +
                 "where templatename = 'quote_template'";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -283,7 +285,7 @@ public class SqlScriptSmallTest {
                 "    set   body='Thanks !' /* my pleasure */\n" +
                 "  and  subject = 'To our favorite customer!'";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -299,7 +301,7 @@ public class SqlScriptSmallTest {
                 "INSERT INTO `bonlayout` (`vertriebslinie`, `lang`, `position`, `layout`) VALUES ('CH01RE', 'en', 'EC_KNR_1_0', '<RIGHT>Account #: \n" +
                 "___________________________</RIGHT>');";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(2, sqlStatements.size());
     }
@@ -309,7 +311,7 @@ public class SqlScriptSmallTest {
     public void parseWithTrailingComment() {
         String sql = "ALTER TABLE A RENAME TO B; -- trailing comment\r\n" +
                 "ALTER TABLE B RENAME TO C;";
-        List<SqlStatement> statements = sqlScript.parse(sql);
+        List<SqlStatement> statements = sqlScript.parse(sql, dbSupport);
         assertEquals(2, statements.size());
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mysql/MySQLSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mysql/MySQLSqlScriptSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.dbsupport.mysql;
 
+import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.dbsupport.SqlStatement;
 import org.junit.Test;
@@ -22,20 +23,22 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test for MySQL SqlScript.
  */
 public class MySQLSqlScriptSmallTest {
+
+    private DbSupport dbSupport = new MySQLDbSupport(null);;
+
     @Test
     public void multiLineCommentDirective() throws Exception {
         String source = "/*!50001 CREATE ALGORITHM=UNDEFINED */\n" +
                 "/*!50013 DEFINER=`user`@`%` SQL SECURITY DEFINER */\n" +
                 "/*!50001 VIEW `viewname` AS select `t`.`id` AS `someId`,`t`.`name` AS `someName` from `someTable` `t` where `t`.`state` = 0 */;\n";
 
-        SqlScript sqlScript = new SqlScript(source, new MySQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
         assertEquals(1, sqlStatements.get(0).getLineNumber());
     }
@@ -48,8 +51,8 @@ public class MySQLSqlScriptSmallTest {
                 "`name` varchar(10)\n" +
                 ") ENGINE=MyISAM */;\n" +                
                 "INSERT INTO tablename VALUES ('a','b');";
-        SqlScript sqlScript = new SqlScript(source, new MySQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(3, sqlStatements.size());
         assertEquals(1, sqlStatements.get(0).getLineNumber());
         assertEquals(2, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSqlScriptSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.dbsupport.oracle;
 
+import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.dbsupport.SqlStatement;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
@@ -29,13 +30,16 @@ import static org.junit.Assert.assertTrue;
  * Test for OracleSqlScript.
  */
 public class OracleSqlScriptSmallTest {
+    
+    private DbSupport dbSupport = new OracleDbSupport(null);
+    
     @Test
     public void parseSqlStatements() throws Exception {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/placeholders/V1__Placeholders.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(3, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertEquals(27, sqlStatements.get(1).getLineNumber());
@@ -48,8 +52,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/function/V2__FunctionWithConditionals.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertTrue(sqlStatements.get(0).getSql().contains("/* for the rich */"));
@@ -60,8 +64,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/function/V1__Function.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(5, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(26, sqlStatements.get(1).getLineNumber());
@@ -76,8 +80,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/package/V1__Package.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(2, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(33, sqlStatements.get(1).getLineNumber());
@@ -88,8 +92,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/qquote/V1__Q_Quote.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(12, sqlStatements.size());
     }
 
@@ -125,8 +129,8 @@ public class OracleSqlScriptSmallTest {
                 "END <trigger-name>;\n" +
                 "/";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
     }
 
@@ -148,8 +152,8 @@ public class OracleSqlScriptSmallTest {
                 "AND D.IDS = IDS\n" +
                 ");";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
     }
 
@@ -185,8 +189,8 @@ public class OracleSqlScriptSmallTest {
                 "\n" +
                 "EXECUTE set_right_value_for_sequence('SEQ_ATR', 'TOTCATTRIB', 'ATTRIB_ID');";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(2, sqlStatements.size());
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlScriptSmallTest.java
@@ -33,8 +33,8 @@ public class PostgreSQLSqlScriptSmallTest {
         String source = new ClassPathResource(
                 "migration/dbsupport/postgresql/sql/dollar/V2__Even_more_dollars.sql", Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new PostgreSQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new PostgreSQLDbSupport(null));
         assertEquals(3, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(23, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSqlScriptSmallTest.java
@@ -33,8 +33,8 @@ public class VerticaSqlScriptSmallTest {
         String source = new ClassPathResource(
                 "migration/dbsupport/vertica/sql/dollar/V1__Dollar.sql", Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new VerticaDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new VerticaDbSupport(null));
         assertEquals(10, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(19, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -40,7 +40,7 @@ public class CompositeMigrationResolverSmallTest {
 
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                Thread.currentThread().getContextClassLoader(), config,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
                 "UTF-8", "V", "R", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -20,12 +20,12 @@ import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -36,13 +36,10 @@ import static org.junit.Assert.assertTrue;
 public class CompositeMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsMultipleLocations() {
-        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1");
+        config.setResolvers(new MyCustomMigrationResolver());
 
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                Thread.currentThread().getContextClassLoader(), config,
-                new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", "R", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -39,7 +39,7 @@ public class CompositeMigrationResolverSmallTest {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1");
         config.setResolvers(new MyCustomMigrationResolver());
 
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
@@ -157,5 +157,4 @@ public class CompositeMigrationResolverSmallTest {
         migration.setType(aMigrationType);
         return migration;
     }
-
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -37,6 +37,7 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     private String sqlMigrationSeparator;
     private String sqlMigrationSuffix;
     private MyCustomMigrationResolver[] migrationResolvers = new MyCustomMigrationResolver[0];
+    private boolean skipDefaultResolvers;
 
     public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
             String sqlMigrationPrefix, String repeatableSqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
@@ -71,6 +72,15 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
     }
 
     @Override

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
@@ -17,6 +17,14 @@ package org.flywaydb.core.internal.resolver;
 
 import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 /**
 * Created by Axel on 3/7/14.
@@ -30,7 +38,13 @@ public class MyConfigurationAwareCustomMigrationResolver extends MyCustomMigrati
         this.flywayConfiguration = flywayConfiguration;
     }
 
-    public boolean isFlywayConfigurationSet() {
-        return flywayConfiguration != null;
+    @Override
+    public List<ResolvedMigration> resolveMigrations() {
+        assertFlywayConfigurationIsSet();
+        return new ArrayList<ResolvedMigration>();
+    }
+
+    public void assertFlywayConfigurationIsSet() {
+        assertThat(flywayConfiguration, is(notNullValue()));
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -21,6 +21,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -40,15 +41,14 @@ public class JdbcMigrationResolverSmallTest {
     @Test(expected = FlywayException.class)
     public void broken() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
-        new JdbcMigrationResolver(config).resolveMigrations();
+        ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
 
-        JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(config);
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -75,7 +75,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -84,7 +84,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -21,7 +21,6 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
-import org.flywaydb.core.internal.util.Locations;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -40,13 +39,16 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
+        new JdbcMigrationResolver(config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
+
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -73,7 +75,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -82,7 +84,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -15,14 +15,13 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
-import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -37,18 +36,17 @@ import static org.junit.Assert.assertNull;
  * Test for JdbcMigrationResolver.
  */
 public class JdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -75,7 +73,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -84,7 +82,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -21,7 +21,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
-import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -40,13 +40,13 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -21,7 +21,6 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -35,13 +34,12 @@ import static org.junit.Assert.assertNull;
  * Test for SpringJdbcMigrationResolver.
  */
 public class SpringJdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -60,7 +58,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -69,7 +67,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -38,8 +39,7 @@ public class SpringJdbcMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
-        SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -58,7 +58,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -67,7 +67,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -20,7 +20,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
-import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class SpringJdbcMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Location("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
-import org.flywaydb.core.internal.util.Locations;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -38,8 +37,9 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrations() {
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -58,7 +58,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -67,7 +67,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -16,7 +16,7 @@
 package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class SqlMigrationResolverMediumTest {
 
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
+                        new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
                         "UTF-8", "V", "R", "__", ".sql");
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -38,7 +39,7 @@ public class SqlMigrationResolverMediumTest {
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:" + new File(path).getPath());
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(null, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -16,8 +16,7 @@
 package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.junit.Test;
 
 import java.io.File;
@@ -38,10 +37,8 @@ public class SqlMigrationResolverMediumTest {
         @SuppressWarnings("ConstantConditions")
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        "UTF-8", "V", "R", "__", ".sql");
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:" + new File(path).getPath());
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(null, config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -18,7 +18,6 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,7 +39,7 @@ public class SqlMigrationResolverMediumTest {
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
                         "UTF-8", "V", "R", "__", ".sql");
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -18,7 +18,6 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -27,21 +26,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Testcase for SqlMigration.
  */
 public class SqlMigrationResolverSmallTest {
 
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
-
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
@@ -61,7 +56,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsRoot() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Location(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql");
 
         //changed to 2 as new test cases are added for SybaseASE
@@ -71,7 +66,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
                         "CheckValidate", "R", "__", ".sql");
 
@@ -81,7 +76,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -91,7 +86,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Location(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -101,7 +96,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
                         "V", "R", "__", ".sql");
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -16,9 +16,8 @@
 package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -37,8 +36,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("migration/subdir"));
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -56,9 +54,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsRoot() {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "");
+        config.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql");
+                new SqlMigrationResolver(null, config);
 
         //changed to 2 as new test cases are added for SybaseASE
         assertEquals(2, sqlMigrationResolver.resolveMigrations().size());
@@ -67,9 +66,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                        "CheckValidate", "R", "__", ".sql");
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing"));
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -77,8 +74,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("db/migration")));
@@ -87,8 +83,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations(""));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("")));
@@ -97,9 +92,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                        "V", "R", "__", ".sql");
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir"));
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"), new Location("filesystem:/some/dir")));
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
@@ -37,7 +38,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
+                        new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -56,7 +57,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsRoot() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Location(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql");
 
         //changed to 2 as new test cases are added for SybaseASE
@@ -67,7 +68,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
+                        new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
                         "CheckValidate", "R", "__", ".sql");
 
         sqlMigrationResolver.resolveMigrations();
@@ -77,30 +78,30 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                        new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
-                new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader())));
+                new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("db/migration")));
     }
 
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Location(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
-                new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader())));
+                new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("")));
     }
 
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
+                        new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
                         "V", "R", "__", ".sql");
 
-        assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql")));
+        assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"), new Location("filesystem:/some/dir")));
     }
 
     @Test

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
@@ -33,10 +34,12 @@ import static org.junit.Assert.*;
  */
 public class SqlMigrationResolverSmallTest {
 
+    private FlywayConfigurationForTests config;
+
     @Test
     public void resolveMigrations() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("migration/subdir"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -56,8 +59,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsRoot() {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "");
         config.setRepeatableSqlMigrationPrefix("X");
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         //changed to 2 as new test cases are added for SybaseASE
         assertEquals(2, sqlMigrationResolver.resolveMigrations().size());
@@ -65,16 +67,16 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsNonExisting() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         sqlMigrationResolver.resolveMigrations();
     }
 
     @Test
     public void extractScriptName() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("db/migration")));
@@ -82,8 +84,8 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameRootLocation() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations(""));
+        config = FlywayConfigurationForTests.createWithLocations("");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()), new Location("")));
@@ -91,8 +93,8 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameFileSystemPrefix() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"), new Location("filesystem:/some/dir")));
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -20,11 +20,9 @@ import org.flywaydb.core.api.*;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
-import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.sql.Connection;
@@ -226,7 +223,7 @@ public abstract class MigrationTestCase {
      */
     private void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, Thread.currentThread().getContextClassLoader(),
                 new Location(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 "UTF-8",

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -21,7 +21,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
-import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.junit.After;
 import org.junit.Before;
@@ -224,7 +224,7 @@ public abstract class MigrationTestCase {
     private void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
                 dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Location(getBasedir()),
+                new Locations(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 "UTF-8",
                 "V", "R", "__", ".sql");

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -20,9 +20,8 @@ import org.flywaydb.core.api.*;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -222,12 +221,9 @@ public abstract class MigrationTestCase {
      * @param migrationInfo The migration to check.
      */
     private void assertChecksum(MigrationInfo migrationInfo) {
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Locations(getBasedir()),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                "UTF-8",
-                "V", "R", "__", ".sql");
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations(getBasedir());
+
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(dbSupport, config);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -22,6 +22,7 @@ import org.flywaydb.core.internal.dbsupport.*;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -223,7 +224,7 @@ public abstract class MigrationTestCase {
     private void assertChecksum(MigrationInfo migrationInfo) {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations(getBasedir());
 
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(dbSupport, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {


### PR DESCRIPTION
This PR allows default resolvers to be completely replaced (#1078) (possibly by subclasses of the original classes). In order to do this, a couple of changes are necessary, which I will accumulate here:
- [x] Every information necessary for the resolvers should be injected instead of using the constructor. This allows custom resolvers and default resolvers to behave similarily.
- [x] Howevery, currently, three things can not be injected: `Location`, `DbSupport` and `Scanner` (because they are internal API/not available from `FlywayConfiguration`). I propose the following solutions for these:
  - [x] Change of the location handling of the default resolvers. Currently, one instance of each resolver is created per location. However, the current mechanism does not allow to inject a single location into a custom resolver. Thus, only one instance of each resolver (jdbc, spingJdbc, sql) should be created which should iterate the locations by itself. Since the locations as a whole CAN be injected via `FlywayConfiguration`, this would be sufficient
  - [x] change the `Scanner` caching mechanism. By not passing the Scanner around, but instead using a factory method with WeakReference based caching mechanism, the benefits of `Scanner` caching can still be reaped.
  - [x] ~~DbSupport is internal API. By providing a second interface (DbSupportAware), which itself is internal API, we could inject DbSupport into custom resolvers (replacements/subclasses of the default resolvers). This would, of course bear the risking of breaking DbAware custom resolvers with new versions of Flyway, which must be clearly stated.~~
  - [x] Remove usage of `DbSupport` in `SqlMigrationResolver` altogether. The Resolver and Executor do not really need it, they simple hand it down to SqlScript, which could always create a matching DbSupport object using the jdbcTemplate's connection during `execute()`. This would result in a lot more DbSupport objects being created, which could be (if necessary) negated by caching the `DbSupport` objects with their connection (`WeakReference in`WeakHashMap`). Also, now the parsing of the scripts would be done during the actual execution of the migration, not at resolving time (this could also be prevented by giving`SqlScript`access to the`FlywayConfiguration` object)
- [x] Built in custom resolvers must be skippable. This can either be done using a new property (`skipDefaultResolvers`), or by introducing three new properties defining the class names of the default resolvers. While the later would be somewhat more convenient for implementers, the first is IMHO cleaner.

The following two changes are part of a separate PR #1185
- [x] ~~Provide some methods of the default resolvers as protected, to allow overriding specific methods (Usecase for us: Parse the migration version not only from the filename, but also from the folder structure : 1.4_new_Feature/5_procedures/V1.2__demo_procedure --> 1.4.5.1.2)~~
- [x] ~~JdbcResolver and SpringJdbcResolver are almost identical. By extracting a common superclass, we could make it a lot easier to support similar frameworks.~~
