### PR TITLE
Introduce skipDefaultResolvers property

### DIFF
--- a/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
+++ b/flyway-ant/src/main/java/org/flywaydb/ant/AbstractFlywayTask.java
@@ -88,7 +88,8 @@ public abstract class AbstractFlywayTask extends Task {
     private String[] locations = flyway.getLocations();
 
     /**
-     * The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
+     * The custom MigrationResolvers to be used in addition or as replacement to the built-in (as determined by the
+     * skipDefaultResolvers property) ones for resolving Migrations to apply.
      * <p>(default: none)</p>
      */
     private String[] resolvers;
@@ -173,6 +174,15 @@ public abstract class AbstractFlywayTask extends Task {
      */
     public void setResolvers(String resolvers) {
         this.resolvers = StringUtils.tokenizeToStringArray(resolvers, ",");
+    }
+
+    /**
+     * Configures whether default built-in resolvers should be skipped. If true, only custom resolvers are used.
+     *
+     * @param skipDefaultResolvers Whether built-int resolvers should be skipped.
+     */
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        flyway.setSkipDefaultResolvers(skipDefaultResolvers);
     }
 
     /**

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -70,6 +70,10 @@ flyway.url=
 # Comma-separated list of fully qualified class names of custom MigrationResolver to use for resolving migrations.
 # flyway.resolvers=
 
+# If set to true, default built-in resolvers (jdbc, spring-jdbc and sql) are skipped and only custom resolvers as
+# defined by 'flyway.resolvers'.
+# flyway.skipDefaultResolvers=
+
 # Comma-separated list of directories containing JDBC drivers and Java-based migrations. (default: <INSTALL-DIR>/jars)
 # flyway.jarDirs=
 

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -231,6 +231,7 @@ public class Main {
         LOG.info("table                        : Name of Flyway's metadata table");
         LOG.info("locations                    : Classpath locations to scan recursively for migrations");
         LOG.info("resolvers                    : Comma-separated list of custom MigrationResolvers");
+        LOG.info("skipDefaultResolvers         : Skips default resolvers (jdbc, sql and Spring-jdbc)");
         LOG.info("sqlMigrationPrefix           : File name prefix for sql migrations");
         LOG.info("repeatableSqlMigrationPrefix : File name prefix for repeatable sql migrations");
         LOG.info("sqlMigrationSeparator        : File name separator for sql migrations");

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -246,6 +246,11 @@ public class Flyway implements FlywayConfiguration {
     private MigrationResolver[] resolvers = new MigrationResolver[0];
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     */
+    private boolean skipDefaultResolvers;
+
+    /**
      * Whether Flyway created the DataSource.
      */
     private boolean createdDataSource;
@@ -440,6 +445,16 @@ public class Flyway implements FlywayConfiguration {
         return resolvers;
     }
 
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
+    }
+
+    /**
+     * Retrieves the dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     *
+     * @return The dataSource to use to access the database. Must have the necessary privileges to execute ddl.
+     */
     @Override
     public DataSource getDataSource() {
         return dataSource;
@@ -807,6 +822,15 @@ public class Flyway implements FlywayConfiguration {
     }
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @param skipDefaultResolvers Whether default built-in resolvers should be skipped.
+     */
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    /**
      * <p>Starts the database migration. All pending migrations will be applied in order.
      * Calling migrate on an up-to-date database has no effect.</p>
      * <img src="http://flywaydb.org/assets/balsamiq/command-migrate.png" alt="migrate">
@@ -1145,6 +1169,10 @@ public class Flyway implements FlywayConfiguration {
         String resolversProp = getValueAndRemoveEntry(props, "flyway.resolvers");
         if (StringUtils.hasLength(resolversProp)) {
             setResolversAsClassNames(StringUtils.tokenizeToStringArray(resolversProp, ","));
+        }
+        String skipDefaultResolverProp = getValueAndRemoveEntry(props, "flyway.skipDefaultResolvers");
+        if (skipDefaultResolverProp != null) {
+            setSkipDefaultResolvers(Boolean.parseBoolean(skipDefaultResolverProp));
         }
         String callbacksProp = getValueAndRemoveEntry(props, "flyway.callbacks");
         if (StringUtils.hasLength(callbacksProp)) {

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -43,6 +43,13 @@ public interface FlywayConfiguration {
     ClassLoader getClassLoader();
 
     /**
+     * Whether Flyway should skip the default resolvers. If true, only custom resolvers are used.
+     *
+     * @return Whether default built-in resolvers should be skipped.
+     */
+    boolean isSkipDefaultResolvers();
+
+    /**
      * Retrieves the dataSource to use to access the database. Must have the necessary privileges to execute ddl.
      *
      * @return The dataSource to use to access the database. Must have the necessary privileges to execute ddl.

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -73,13 +73,15 @@ public class CompositeMigrationResolver implements MigrationResolver {
                                       String sqlMigrationSeparator, String sqlMigrationSuffix,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
-        for (Location location : locations.getLocations()) {
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
-                    encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
-            migrationResolvers.add(new JdbcMigrationResolver(scanner, location, config));
+        if (!config.isSkipDefaultResolvers()) {
+            for (Location location : locations.getLocations()) {
+                migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
+                        encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+                migrationResolvers.add(new JdbcMigrationResolver(scanner, location, config));
 
-            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, location, config));
+                if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
+                    migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, location, config));
+                }
             }
         }
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -141,6 +141,21 @@ public class CompositeMigrationResolverSmallTest {
         CompositeMigrationResolver.checkForIncompatibilities(migrations);
     }
 
+    @Test
+    public void skipDefaultResolvers() {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        config.setSkipDefaultResolvers(true);
+
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
+                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
+                "UTF-8", "V", "R", "__", ".sql", PlaceholderReplacer.NO_PLACEHOLDERS);
+
+        Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
+
+        assertTrue(migrations.isEmpty());
+    }
+
     /**
      * Creates a migration for our tests.
      *
@@ -160,5 +175,4 @@ public class CompositeMigrationResolverSmallTest {
         migration.setType(aMigrationType);
         return migration;
     }
-
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -37,6 +37,7 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     private String sqlMigrationSeparator;
     private String sqlMigrationSuffix;
     private MyCustomMigrationResolver[] migrationResolvers = new MyCustomMigrationResolver[0];
+    private boolean skipDefaultResolvers;
 
     public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
             String sqlMigrationPrefix, String repeatableSqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
@@ -71,6 +72,15 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
+    @Override
+    public boolean isSkipDefaultResolvers() {
+        return skipDefaultResolvers;
     }
 
     @Override

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/FlywayExtension.groovy
@@ -64,11 +64,17 @@ public class FlywayExtension {
     String[] locations
 
     /**
-     * The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for
-     * resolving Migrations to apply.
+     * The fully qualified class names of the custom MigrationResolvers to be used in addition (default)
+     * or as a replacement (using skipDefaultResolvers) to the built-in ones for resolving Migrations to
+     * apply.
      * <p>(default: none)</p>
      */
     String[] resolvers
+
+    /**
+     * If set to true, default built-in resolvers will be skipped, only custom migration resolvers will be used.
+     */
+    Boolean skipDefaultResolvers
 
     /**
      * The file name prefix for Sql migrations

--- a/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
+++ b/flyway-gradle-plugin/src/main/groovy/org/flywaydb/gradle/task/AbstractFlywayTask.groovy
@@ -106,6 +106,7 @@ abstract class AbstractFlywayTask extends DefaultTask {
         propSetAsBoolean(flyway, 'cleanOnValidationError')
         propSetAsBoolean(flyway, 'cleanDisabled')
         propSetAsBoolean(flyway, 'baselineOnMigrate')
+        propSetAsBoolean(flyway, 'skipDefaultResolvers')
 
         def sysSchemas = System.getProperty("flyway.schemas")
         if (sysSchemas != null) {

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -153,14 +153,22 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private String[] locations;
 
     /**
-     * The fully qualified class names of the custom MigrationResolvers to be used in addition to the built-in ones for
-     * resolving Migrations to apply.
+     * The fully qualified class names of the custom MigrationResolvers to be used in addition or as replacement
+     * (if skipDefaultResolvers is true) to the built-in ones for resolving Migrations to apply.
      * <p>(default: none)</p>
      * <p>Also configurable with Maven or System Property: ${flyway.resolvers} (Comma-separated list)</p>
      *
      * @parameter
      */
     private String[] resolvers = new String[0];
+
+    /**
+     * When set to true, default resolvers are skipped, i.e. only custom resolvers as defined by 'resolvers'
+     * are used.
+     *
+     * @parameter
+     */
+    private boolean skipDefaultResolvers;
 
     /**
      * The encoding of Sql migrations. (default: UTF-8)<br> <p>Also configurable with Maven or System Property:
@@ -450,6 +458,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
                 locations = new String[] { Location.FILESYSTEM_PREFIX + mavenProject.getBasedir().getAbsolutePath() + "/src/main/resources/db/migration"};
             }
             flyway.setResolversAsClassNames(resolvers);
+            flyway.setSkipDefaultResolvers(skipDefaultResolvers);
             flyway.setCallbacksAsClassNames(callbacks);
             flyway.setEncoding(encoding);
             flyway.setSqlMigrationPrefix(sqlMigrationPrefix);


### PR DESCRIPTION
This allows to completely skip the usage of the built-in resolvers and thus only rely on custom resolvers.