### PR TITLE
PostgreSQL: trim schema name.

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
@@ -121,7 +121,7 @@ public class PostgreSQLDbSupport extends DbSupport {
 
     @Override
     public Schema getSchema(String name) {
-        return new PostgreSQLSchema(jdbcTemplate, this, name);
+        return new PostgreSQLSchema(jdbcTemplate, this, name.trim());
     }
 
     @Override


### PR DESCRIPTION
The issue came while trying to detect schema in PostgreSQLDbSupport.getOriginalSchema() with an from originalSchema set with value: '"$user", public'.
I was ending with a schema named " public" (with a leading space).
The trim could either be done in PostgreSQLDbSupport.getOriginalSchema(), but probably twice, or just once in getSchema().