### PR TITLE
Included abstract base classes for resolvers and migrations 

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/callback/BaseFlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/callback/BaseFlywayCallback.java
@@ -16,14 +16,26 @@
 package org.flywaydb.core.api.callback;
 
 import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 
 import java.sql.Connection;
 
 /**
  * Convenience base no-op implementation of FlywayCallback. Extend this class if you want to implement just a few
  * callback methods without having to provide no-op methods yourself.
+ *
+ * <p>This implementation also provides direct access to the {@link FlywayConfiguration} as field.</p>
  */
-public abstract class BaseFlywayCallback implements FlywayCallback {
+public abstract class BaseFlywayCallback implements FlywayCallback, ConfigurationAware {
+
+    protected FlywayConfiguration flywayConfiguration;
+
+    @Override
+    public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+    }
+
     @Override
     public void beforeClean(Connection connection) {
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
@@ -16,17 +16,20 @@
 package org.flywaydb.core.api.callback;
 
 import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 
 import java.sql.Connection;
 
 /**
  * This is the main callback interface that should be implemented to get access to flyway lifecycle notifications.
  * Simply add code to the callback method you are interested in having. A convenience implementation will all methods
- * doing nothing is provided with {@link BaseFlywayCallback}.
+ * doing nothing is provided with {@link BaseFlywayCallback}. To ensure backward compatibility, you are encouraged
+ * to subclass that class instead of implementing this interface directly.
  *
- * <p>If a callback also implements the {@link org.flywaydb.core.api.configuration.ConfigurationAware} interface,
+ * <p>If a callback also implements the {@link ConfigurationAware} interface,
  * a {@link org.flywaydb.core.api.configuration.FlywayConfiguration} object will automatically be injected before
- * calling any methods, giving the callback access to the core flyway configuration.</p>
+ * calling any methods, giving the callback access to the core flyway configuration. {@link BaseFlywayCallback}
+ * already implements {@link ConfigurationAware}</p>
  *
  * <p>Each callback method will run within its own transaction.</p>
  * 

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/BaseJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/BaseJdbcMigration.java
@@ -1,0 +1,19 @@
+package org.flywaydb.core.api.migration.jdbc;
+
+import org.flywaydb.core.api.configuration.ConfigurationAware;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
+
+/**
+ * Convenience implementation if {@link JdbcMigration}. {@link ConfigurationAware#setFlywayConfiguration(FlywayConfiguration)}
+ * is implemented by storing the configuration in a field. It is encouraged to subclass this class instead of implementing
+ * JdbcMigration directly, to guard against possible API additions in future major releases of Flyway.
+ */
+public abstract class BaseJdbcMigration implements JdbcMigration, ConfigurationAware {
+
+    protected FlywayConfiguration flywayConfiguration;
+
+    @Override
+    public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
@@ -27,6 +27,8 @@ import java.sql.Connection;
  * <p>When the JdbcMigration implements {@link org.flywaydb.core.api.configuration.ConfigurationAware},
  * the master {@link org.flywaydb.core.api.configuration.FlywayConfiguration} is automatically injected upon creation,
  * which is especially useful for getting placeholder and schema information.</p>
+ *
+ * It is encouraged not to implement this interface directly, sublass {@link JdbcMigration} instead.
  */
 public interface JdbcMigration {
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/BaseSpringJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/BaseSpringJdbcMigration.java
@@ -1,0 +1,19 @@
+package org.flywaydb.core.api.migration.spring;
+
+import org.flywaydb.core.api.configuration.ConfigurationAware;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
+
+/**
+ * Convenience implementation if {@link SpringJdbcMigration}. {@link ConfigurationAware#setFlywayConfiguration(FlywayConfiguration)}
+ * is implemented by storing the configuration in a field. It is encouraged to subclass this class instead of implementing
+ * SpringJdbcMigration directly, to guard against possible API additions in future major releases of Flyway.
+ */
+public abstract class BaseSpringJdbcMigration implements SpringJdbcMigration, ConfigurationAware {
+
+    protected FlywayConfiguration flywayConfiguration;
+
+    @Override
+    public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/SpringJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/SpringJdbcMigration.java
@@ -27,6 +27,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * <p>When the JdbcMigration implements {@link org.flywaydb.core.api.configuration.ConfigurationAware},
  * the master {@link org.flywaydb.core.api.configuration.FlywayConfiguration} is automatically injected upon creation,
  * which is especially useful for getting placeholder and schema information.</p>
+ *
+ * It is encouraged not to implement this interface directly, subclass {@link BaseSpringJdbcMigration} instead.
  */
 public interface SpringJdbcMigration {
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/resolver/BaseMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/resolver/BaseMigrationResolver.java
@@ -1,0 +1,18 @@
+package org.flywaydb.core.api.resolver;
+
+import org.flywaydb.core.api.configuration.ConfigurationAware;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
+
+/**
+ * Base implementation of {@link MigrationResolver} that handles configuration injections by storing the
+ * configuration object in a field.
+ */
+public abstract class BaseMigrationResolver implements MigrationResolver, ConfigurationAware {
+
+    protected FlywayConfiguration flywayConfiguration;
+
+    @Override
+    public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
+        this.flywayConfiguration = flywayConfiguration;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/resolver/MigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/resolver/MigrationResolver.java
@@ -27,6 +27,9 @@ import java.util.Collection;
  * a {@link org.flywaydb.core.api.configuration.FlywayConfiguration} object will automatically be injected before
  * calling {@link #resolveMigrations()}, giving the resolver access to the core flyway configuration, which provides
  * useful data like resolve locations or placeholder configuration.</p>
+ *
+ * An abstract implementation is provided in {@link BaseMigrationResolver} which handles the storing of the
+ * configuration. It is encouraged to subclass that class instead of implementing this interface directly.
  */
 public interface MigrationResolver {
     /**


### PR DESCRIPTION
already implementing ConfigurationAware.

Changed javadoc to encourage usage of the abstract classes instead of implementing the interfaces directly.

Rationale: It makes sense to always implement ConfigurationAware, using a separate interface is basically to provide backward compatibility. Also, by using the abstract classes, we could transparently include new methods without breaking existing Migrations/Resolvers/Callbacks.