### PR TITLE
Added ability to set Java system properties from the command line tool

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -239,6 +239,7 @@ public class Main {
         LOG.info("encoding                     : Encoding of sql migrations");
         LOG.info("placeholderReplacement       : Whether placeholders should be replaced");
         LOG.info("placeholders                 : Placeholders to replace in sql migrations");
+        LOG.info("systemProperties             : System properties to set in Flyway's JVM at runtime");
         LOG.info("placeholderPrefix            : Prefix of every placeholder");
         LOG.info("placeholderSuffix            : Suffix of every placeholder");
         LOG.info("target                       : Target version up to which Flyway should use migrations");

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -78,6 +78,11 @@ public class Flyway implements FlywayConfiguration {
     private static final String PLACEHOLDERS_PROPERTY_PREFIX = "flyway.placeholders.";
 
     /**
+     * Property name prefix for system properties that are configured through properties.
+     */
+    private static final String SYSTEM_PROPERTY_PREFIX = "flyway.systemProperties.";
+
+    /**
      * The locations to scan recursively for migrations.
      * <p/>
      * <p>The location type is determined by its prefix.
@@ -1277,6 +1282,12 @@ public class Flyway implements FlywayConfiguration {
                 String placeholderName = propertyName.substring(PLACEHOLDERS_PROPERTY_PREFIX.length());
                 String placeholderValue = entry.getValue();
                 placeholdersFromProps.put(placeholderName, placeholderValue);
+                iterator.remove();
+            } else if (propertyName.startsWith(SYSTEM_PROPERTY_PREFIX)
+                    && propertyName.length() > SYSTEM_PROPERTY_PREFIX.length()) {
+                String systemPropertyName = propertyName.substring(SYSTEM_PROPERTY_PREFIX.length());
+                String systemPropertyValue = entry.getValue();
+                System.setProperty(systemPropertyName, systemPropertyValue);
                 iterator.remove();
             }
         }

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -107,6 +107,19 @@ public class FlywaySmallTest {
     }
 
     @Test
+    public void configureSystemProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("flyway.systemProperties.my.system.property", "myvalue");
+        properties.setProperty("flyway.systemProperties.my.other.system.property", "myothervalue");
+
+        Flyway flyway = new Flyway();
+        flyway.configure(properties);
+
+        assertEquals(System.getProperty("my.system.property"), "myvalue");
+        assertEquals(System.getProperty("my.other.system.property"), "myothervalue");
+    }
+
+    @Test
     public void configurePlaceholders() {
         Flyway flyway = new Flyway();
         flyway.getPlaceholders().put("mykey", "myvalue");


### PR DESCRIPTION
Implementation for issue #1200. The command line tool can set system properties either through the use of the `-systemProperties.myproperty=myvalue` command line argument or by setting `flyway.systemProperties.myproperty=myvalue` in the configuration file.
