### PR TITLE
Support for multiple databases/targets in Gradle

### DIFF
--- a/flyway-gradle-plugin-largetest/src/test/java/org/flywaydb/gradle/largetest/GradleLargeTest.java
+++ b/flyway-gradle-plugin-largetest/src/test/java/org/flywaydb/gradle/largetest/GradleLargeTest.java
@@ -49,7 +49,7 @@ public class GradleLargeTest {
     @Test
     public void error() throws Exception {
         String stdOut = runGradle(0, "error", "clean", "flywayMigrate");
-        assertTrue(stdOut.contains("Successfully validated 0 migrations"));
+        assertTrue(stdOut.contains("No migration necessary."));
     }
 
     /**

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayContainer.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayContainer.java
@@ -1,0 +1,11 @@
+package org.flywaydb.gradle;
+
+public class FlywayContainer extends FlywayExtensionBase {
+    /** The description used to identify instances of the container */
+    public String name;
+
+    /** The required constructor for Gradle containers */
+    public FlywayContainer(String name) {
+        this.name = name;
+    }
+}

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayCreator.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayCreator.java
@@ -1,0 +1,174 @@
+package org.flywaydb.gradle;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.gradle.api.Project;
+
+import java.util.*;
+
+public class FlywayCreator {
+
+    private static final String PLACEHOLDERS_PROPERTY_PREFIX = "flyway.placeholders.";
+
+    public static Flyway create(Project project, FlywayExtensionBase taskExtension, FlywayExtensionBase localExtension, FlywayExtension masterExtension) {
+        Map<String, String> conf = new HashMap<String, String>();
+        putIfSet(conf, "driver", taskExtension.driver, localExtension.driver, masterExtension.driver);
+        putIfSet(conf, "url", taskExtension.url, localExtension.url, masterExtension.url);
+        putIfSet(conf, "user", taskExtension.user, localExtension.user, masterExtension.user);
+        putIfSet(conf, "password", taskExtension.password, localExtension.password, masterExtension.password);
+        putIfSet(conf, "table", taskExtension.table, localExtension.table, masterExtension.table);
+        putIfSet(conf, "baselineVersion", taskExtension.baselineVersion, localExtension.baselineVersion, masterExtension.baselineVersion);
+        putIfSet(conf, "baselineDescription", taskExtension.baselineDescription, localExtension.baselineDescription, masterExtension.baselineDescription);
+        putIfSet(conf, "sqlMigrationPrefix", taskExtension.sqlMigrationPrefix, masterExtension.sqlMigrationPrefix, masterExtension.sqlMigrationPrefix);
+        putIfSet(conf, "repeatableSqlMigrationPrefix", taskExtension.repeatableSqlMigrationPrefix, masterExtension.repeatableSqlMigrationPrefix, masterExtension.repeatableSqlMigrationPrefix);
+        putIfSet(conf, "sqlMigrationSeparator", taskExtension.sqlMigrationSeparator, localExtension.sqlMigrationSeparator, masterExtension.sqlMigrationSeparator);
+        putIfSet(conf, "sqlMigrationSuffix", taskExtension.sqlMigrationSuffix, localExtension.sqlMigrationSuffix, masterExtension.sqlMigrationSuffix);
+        putIfSet(conf, "encoding", taskExtension.encoding, localExtension.encoding, masterExtension.encoding);
+        putIfSet(conf, "placeholderReplacement", taskExtension.placeholderReplacement, localExtension.placeholderReplacement, masterExtension.placeholderReplacement);
+        putIfSet(conf, "placeholderPrefix", taskExtension.placeholderPrefix, localExtension.placeholderPrefix, masterExtension.placeholderPrefix);
+        putIfSet(conf, "placeholderSuffix", taskExtension.placeholderSuffix, localExtension.placeholderSuffix, masterExtension.placeholderSuffix);
+        putIfSet(conf, "target", taskExtension.target, localExtension.target, masterExtension.target);
+        putIfSet(conf, "outOfOrder", taskExtension.outOfOrder, localExtension.outOfOrder, masterExtension.outOfOrder);
+        putIfSet(conf, "validateOnMigrate", taskExtension.validateOnMigrate, localExtension.validateOnMigrate, masterExtension.validateOnMigrate);
+        putIfSet(conf, "cleanOnValidationError", taskExtension.cleanOnValidationError, localExtension.cleanOnValidationError, masterExtension.cleanOnValidationError);
+        putIfSet(conf, "ignoreFutureMigrations", taskExtension.ignoreFutureMigrations, localExtension.ignoreFutureMigrations, masterExtension.ignoreFutureMigrations);
+        putIfSet(conf, "cleanDisabled", taskExtension.cleanDisabled, localExtension.cleanDisabled, masterExtension.cleanDisabled);
+        putIfSet(conf, "baselineOnMigrate", taskExtension.baselineOnMigrate, localExtension.baselineOnMigrate, masterExtension.baselineOnMigrate);
+        putIfSet(conf, "skipDefaultResolvers", taskExtension.skipDefaultResolvers, localExtension.skipDefaultResolvers, masterExtension.skipDefaultResolvers);
+        putIfSet(conf, "skipDefaultCallbacks", taskExtension.skipDefaultCallbacks, localExtension.skipDefaultCallbacks, masterExtension.skipDefaultCallbacks);
+        putListIfSet(conf, "schemas", taskExtension.schemas, localExtension.schemas, masterExtension.schemas, masterExtension.schemasInstruction);
+
+        conf.put("flyway.locations", Location.FILESYSTEM_PREFIX + project.getProjectDir().getAbsolutePath() + "/src/main/resources/db/migration");
+        putListIfSet(conf, "locations", taskExtension.locations,localExtension.locations,masterExtension.locations, masterExtension.locationsInstruction);
+
+        putListIfSet(conf, "resolvers", taskExtension.resolvers,localExtension.resolvers,masterExtension.resolvers, masterExtension.resolversInstruction);
+        putListIfSet(conf, "callbacks", taskExtension.callbacks,localExtension.callbacks,masterExtension.callbacks, masterExtension.callbacksInstruction);
+
+        putMapIfSet(conf, taskExtension.placeholders,localExtension.placeholders,masterExtension.placeholders, masterExtension.placeholdersInstruction);
+
+        addConfigFromProperties(conf, project.getProperties());
+        addConfigFromProperties(conf, System.getProperties());
+
+        Flyway flyway = new Flyway();
+        flyway.configure(conf);
+        return flyway;
+    }
+
+
+
+    /**
+     * Puts this property in the config if it has been set either in the task or the extension.
+     *
+     * @param config         The config.
+     * @param key            The peoperty name.
+     * @param propValue      The value in the plugin.
+     * @param extensionValue The value in the extension.
+     */
+    private static void putIfSet(Map<String, String> config, String key, Object propValue, Object extensionValue, Object masterExtensionValue) {
+        if (propValue != null) {
+            config.put("flyway." + key, propValue.toString());
+        } else if (extensionValue != null) {
+            config.put("flyway." + key, extensionValue.toString());
+        } else if (masterExtensionValue != null) {
+            config.put("flyway." + key, masterExtensionValue.toString());
+        }
+    }
+
+    private static void putListIfSet(
+            Map<String, String> config,
+            String key,
+            String[] propValue,
+            String[] extensionValue,
+            String[] masterExtensionValue,
+            ListPropertyInstruction instruction) {
+        switch (instruction){
+            case PRIORITIZE:
+                putIfSet(config,
+                        key,
+                        StringUtils.arrayToCommaDelimitedString(propValue),
+                        StringUtils.arrayToCommaDelimitedString(extensionValue),
+                        StringUtils.arrayToCommaDelimitedString(masterExtensionValue));
+                break;
+            case MERGE:
+                config.put("flyway." + key,
+                        mergeListToString(
+                                Arrays.asList(propValue, extensionValue, masterExtensionValue)));
+                break;
+        }
+    }
+
+    private static void putMapIfSet(
+            Map<String, String> config,
+            Map<Object, Object> propMap,
+            Map<Object, Object> extensionMap,
+            Map<Object, Object> masterExtensionMap,
+            ListPropertyInstruction instruction) {
+        switch (instruction){
+            case PRIORITIZE:
+                if (propMap != null) {
+                    putMap(config, PLACEHOLDERS_PROPERTY_PREFIX, propMap);
+                } else if (extensionMap != null) {
+                    putMap(config, PLACEHOLDERS_PROPERTY_PREFIX, extensionMap);
+                } else if (masterExtensionMap != null) {
+                    putMap(config, PLACEHOLDERS_PROPERTY_PREFIX, masterExtensionMap);
+                }
+                break;
+            case MERGE:
+                putMap(config,
+                        PLACEHOLDERS_PROPERTY_PREFIX,
+                        mergeMap(Arrays.asList(masterExtensionMap, extensionMap, propMap)));
+                break;
+        }
+    }
+
+    private static void putMap(Map<String, String> config, String prefix, Map<Object, Object> placeholders) {
+        for (Map.Entry<Object, Object> entry : placeholders.entrySet()) {
+            config.put(prefix + entry.getKey().toString(), entry.getValue().toString());
+        }
+    }
+
+    private static String mergeListToString(List<String[]> arraysToMerge) {
+
+        ArrayList<String> returnList = new ArrayList<String>();
+
+        for(String[] arrayToMerge : arraysToMerge) {
+            for (String mergeValue : arrayToMerge) {
+                if (!(returnList.contains(mergeValue))) {
+                    returnList.add(mergeValue);
+                }
+            }
+        }
+        return StringUtils.arrayToCommaDelimitedString(returnList.toArray(new String[0]));
+    }
+
+    private static Map<Object, Object> mergeMap(
+            List<Map<Object, Object>> mapsToMerge) {
+
+        Map<Object, Object> returnMap = new HashMap<Object, Object>();
+
+        for(Map<Object, Object> mapToMerge : mapsToMerge) {
+            returnMap.putAll(mapToMerge);
+        }
+
+        return returnMap;
+    }
+
+
+
+    private static void addConfigFromProperties(Map<String, String> config, Properties properties) {
+        for (String prop : properties.stringPropertyNames()) {
+            if (prop.startsWith("flyway.")) {
+                config.put(prop, properties.getProperty(prop));
+            }
+        }
+    }
+
+    private static void addConfigFromProperties(Map<String, String> config, Map<String, ?> properties) {
+        for (String prop : properties.keySet()) {
+            if (prop.startsWith("flyway.")) {
+                config.put(prop, properties.get(prop).toString());
+            }
+        }
+    }
+}

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -15,6 +15,8 @@
  */
 package org.flywaydb.gradle;
 
+import org.gradle.api.plugins.ExtensionContainer;
+
 import java.util.Map;
 
 /**
@@ -22,194 +24,16 @@ import java.util.Map;
  *
  * <p>More info: <a href="https://flywaydb.org/documentation/gradle">https://flywaydb.org/documentation/gradle</a></p>
  */
-public class FlywayExtension {
-    /**
-     * The fully qualified classname of the jdbc driver to use to connect to the database
-     */
-    public String driver;
+/**
+ * The flyway's configuration properties plus configurations used to determine how to
+ * apply extension containers (if they exist).
+ */
+public class FlywayExtension extends FlywayExtensionBase {
+    public ListPropertyInstruction schemasInstruction = ListPropertyInstruction.PRIORITIZE;
+    public ListPropertyInstruction locationsInstruction = ListPropertyInstruction.PRIORITIZE;
+    public ListPropertyInstruction resolversInstruction = ListPropertyInstruction.PRIORITIZE;
+    public ListPropertyInstruction placeholdersInstruction = ListPropertyInstruction.PRIORITIZE;
+    public ListPropertyInstruction callbacksInstruction = ListPropertyInstruction.PRIORITIZE;
 
-    /**
-     * The jdbc url to use to connect to the database
-     */
-    public String url;
-
-    /**
-     * The user to use to connect to the database
-     */
-    public String user;
-
-    /**
-     * The password to use to connect to the database
-     */
-    public String password;
-
-    /**
-     * The name of Flyway's metadata table
-     */
-    public String table;
-
-    /**
-     * The case-sensitive list of schemas managed by Flyway
-     */
-    public String[] schemas;
-
-    /**
-     * The version to tag an existing schema with when executing baseline. (default: 1)
-     */
-    public String baselineVersion;
-
-    /**
-     * The description to tag an existing schema with when executing baseline. (default: << Flyway Baseline >>)
-     */
-    public String baselineDescription;
-
-    /**
-     * Locations to scan recursively for migrations. The location type is determined by its prefix.
-     * (default: filesystem:src/main/resources/db/migration)
-     * <p>
-     * <tt>Unprefixed locations or locations starting with classpath:</tt>
-     * point to a package on the classpath and may contain both sql and java-based migrations.
-     * <p>
-     * <tt>Locations starting with filesystem:</tt>
-     * point to a directory on the filesystem and may only contain sql migrations.
-     */
-    public String[] locations;
-
-    /**
-     * The fully qualified class names of the custom MigrationResolvers to be used in addition (default)
-     * or as a replacement (using skipDefaultResolvers) to the built-in ones for resolving Migrations to
-     * apply.
-     * <p>(default: none)</p>
-     */
-    public String[] resolvers;
-
-    /**
-     * If set to true, default built-in resolvers will be skipped, only custom migration resolvers will be used.
-     * <p>(default: false)</p>
-     */
-    public Boolean skipDefaultResolvers;
-
-    /**
-     * The file name prefix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationPrefix;
-
-    /**
-     * The file name prefix for repeatable sql migrations (default: R).
-     * <p>
-     * <p>Repeatable sql migrations have the following file name structure: prefixSeparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to R__My_description.sql</p>
-     */
-    public String repeatableSqlMigrationPrefix;
-
-    /**
-     * The file name prefix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationSeparator;
-
-    /**
-     * The file name suffix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationSuffix;
-
-    /**
-     * The encoding of Sql migrations
-     */
-    public String encoding;
-
-    /**
-     * Placeholders to replace in Sql migrations
-     */
-    public Map<Object, Object> placeholders;
-
-    /**
-     * Whether placeholders should be replaced.
-     */
-    public Boolean placeholderReplacement;
-
-    /**
-     * The prefix of every placeholder
-     */
-    public String placeholderPrefix;
-
-    /**
-     * The suffix of every placeholder
-     */
-    public String placeholderSuffix;
-
-    /**
-     * The target version up to which Flyway should consider migrations.
-     * Migrations with a higher version number will be ignored.
-     * The special value {@code current} designates the current version of the schema.
-     */
-    public String target;
-
-    /**
-     * An array of fully qualified FlywayCallback class implementations
-     */
-    public String[] callbacks;
-
-    /**
-     * If set to true, default built-in callbacks will be skipped, only custom migration callbacks will be used.
-     * <p>(default: false)</p>
-     */
-    public Boolean skipDefaultCallbacks;
-
-    /**
-     * Allows migrations to be run "out of order"
-     */
-    public Boolean outOfOrder;
-
-    /**
-     * Whether to automatically call validate or not when running migrate. (default: true)
-     */
-    public Boolean validateOnMigrate;
-
-    /**
-     * Whether to automatically call clean or not when a validation error occurs
-     */
-    public Boolean cleanOnValidationError;
-
-    /**
-     * Ignore future migrations when reading the metadata table. These are migrations that were performed by a
-     * newer deployment of the application that are not yet available in this version. For example: we have migrations
-     * available on the classpath up to version 3.0. The metadata table indicates that a migration to version 4.0
-     * (unknown to us) has already been applied. Instead of bombing out (fail fast) with an exception, a
-     * warning is logged and Flyway continues normally. This is useful for situations where one must be able to redeploy
-     * an older version of the application after the database has been migrated by a newer one. (default: {@code true})
-     */
-    public Boolean ignoreFutureMigrations;
-
-    /**
-     * Whether to disable clean. (default: {@code false})
-     * <p>This is especially useful for production environments where running clean can be quite a career limiting move.</p>
-     */
-    public Boolean cleanDisabled;
-
-    /**
-     * <p>
-     * Whether to automatically call baseline when migrate is executed against a non-empty schema with no metadata table.
-     * This schema will then be baselined with the {@code baselineVersion} before executing the migrations.
-     * Only migrations above {@code baselineVersion} will then be applied.
-     * </p>
-     * <p>
-     * This is useful for initial Flyway production deployments on projects with an existing DB.
-     * </p>
-     * <p>
-     * Be careful when enabling this as it removes the safety net that ensures
-     * Flyway does not migrate the wrong database in case of a configuration mistake!
-     * </p>
-     *
-     * @param baselineOnMigrate {@code true} if baseline should be called on migrate for non-empty schemas, {@code false} if not. (default: {@code false})
-     */
-    public Boolean baselineOnMigrate;
+    public ExtensionContainer extensions;
 }

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtensionBase.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtensionBase.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.gradle;
+
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
+
+import java.util.Map;
+
+/**
+ * The basic set of flyway configuration properties.
+ *
+ * <p>More info: <a href="https://flywaydb.org/documentation/gradle">https://flywaydb.org/documentation/gradle</a></p>
+ */
+public class FlywayExtensionBase {
+    /**
+     * The fully qualified classname of the jdbc driver to use to connect to the database
+     */
+    public String driver;
+
+    /**
+     * The jdbc url to use to connect to the database
+     */
+    public String url;
+
+    /**
+     * The user to use to connect to the database
+     */
+    public String user;
+
+    /**
+     * The password to use to connect to the database
+     */
+    public String password;
+
+    /**
+     * The name of Flyway's metadata table
+     */
+    public String table;
+
+    /**
+     * The case-sensitive list of schemas managed by Flyway
+     */
+    public String[] schemas;
+
+    /**
+     * The version to tag an existing schema with when executing baseline. (default: 1)
+     */
+    public String baselineVersion;
+
+    /**
+     * The description to tag an existing schema with when executing baseline. (default: << Flyway Baseline >>)
+     */
+    public String baselineDescription;
+
+    /**
+     * Locations to scan recursively for migrations. The location type is determined by its prefix.
+     * (default: filesystem:src/main/resources/db/migration)
+     * <p>
+     * <tt>Unprefixed locations or locations starting with classpath:</tt>
+     * point to a package on the classpath and may contain both sql and java-based migrations.
+     * <p>
+     * <tt>Locations starting with filesystem:</tt>
+     * point to a directory on the filesystem and may only contain sql migrations.
+     */
+    public String[] locations;
+
+    /**
+     * The fully qualified class names of the custom MigrationResolvers to be used in addition (default)
+     * or as a replacement (using skipDefaultResolvers) to the built-in ones for resolving Migrations to
+     * apply.
+     * <p>(default: none)</p>
+     */
+    public String[] resolvers;
+
+    /**
+     * If set to true, default built-in resolvers will be skipped, only custom migration resolvers will be used.
+     * <p>(default: false)</p>
+     */
+    public Boolean skipDefaultResolvers;
+
+    /**
+     * The file name prefix for Sql migrations
+     * <p>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     */
+    public String sqlMigrationPrefix;
+
+    /**
+     * The file name prefix for repeatable sql migrations (default: R).
+     * <p>
+     * <p>Repeatable sql migrations have the following file name structure: prefixSeparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to R__My_description.sql</p>
+     */
+    public String repeatableSqlMigrationPrefix;
+
+    /**
+     * The file name prefix for Sql migrations
+     * <p>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     */
+    public String sqlMigrationSeparator;
+
+    /**
+     * The file name suffix for Sql migrations
+     * <p>
+     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
+     * which using the defaults translates to V1_1__My_description.sql</p>
+     */
+    public String sqlMigrationSuffix;
+
+    /**
+     * The encoding of Sql migrations
+     */
+    public String encoding;
+
+    /**
+     * Placeholders to replace in Sql migrations
+     */
+    public Map<Object, Object> placeholders;
+
+    /**
+     * Whether placeholders should be replaced.
+     */
+    public Boolean placeholderReplacement;
+
+    /**
+     * The prefix of every placeholder
+     */
+    public String placeholderPrefix;
+
+    /**
+     * The suffix of every placeholder
+     */
+    public String placeholderSuffix;
+
+    /**
+     * The target version up to which Flyway should consider migrations.
+     * Migrations with a higher version number will be ignored.
+     * The special value {@code current} designates the current version of the schema.
+     */
+    public String target;
+
+    /**
+     * An array of fully qualified FlywayCallback class implementations
+     */
+    public String[] callbacks;
+
+    /**
+     * If set to true, default built-in callbacks will be skipped, only custom migration callbacks will be used.
+     * <p>(default: false)</p>
+     */
+    public Boolean skipDefaultCallbacks;
+
+    /**
+     * Allows migrations to be run "out of order"
+     */
+    public Boolean outOfOrder;
+
+    /**
+     * Whether to automatically call validate or not when running migrate. (default: true)
+     */
+    public Boolean validateOnMigrate;
+
+    /**
+     * Whether to automatically call clean or not when a validation error occurs
+     */
+    public Boolean cleanOnValidationError;
+
+    /**
+     * Ignore future migrations when reading the metadata table. These are migrations that were performed by a
+     * newer deployment of the application that are not yet available in this version. For example: we have migrations
+     * available on the classpath up to version 3.0. The metadata table indicates that a migration to version 4.0
+     * (unknown to us) has already been applied. Instead of bombing out (fail fast) with an exception, a
+     * warning is logged and Flyway continues normally. This is useful for situations where one must be able to redeploy
+     * an older version of the application after the database has been migrated by a newer one. (default: {@code true})
+     */
+    public Boolean ignoreFutureMigrations;
+
+    /**
+     * Whether to disable clean. (default: {@code false})
+     * <p>This is especially useful for production environments where running clean can be quite a career limiting move.</p>
+     */
+    public Boolean cleanDisabled;
+
+    /**
+     * <p>
+     * Whether to automatically call baseline when migrate is executed against a non-empty schema with no metadata table.
+     * This schema will then be baselined with the {@code baselineVersion} before executing the migrations.
+     * Only migrations above {@code baselineVersion} will then be applied.
+     * </p>
+     * <p>
+     * This is useful for initial Flyway production deployments on projects with an existing DB.
+     * </p>
+     * <p>
+     * Be careful when enabling this as it removes the safety net that ensures
+     * Flyway does not migrate the wrong database in case of a configuration mistake!
+     * </p>
+     *
+     * @param baselineOnMigrate {@code true} if baseline should be called on migrate for non-empty schemas, {@code false} if not. (default: {@code false})
+     */
+    public Boolean baselineOnMigrate;
+}

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayPlugin.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayPlugin.java
@@ -30,7 +30,8 @@ import org.gradle.api.Project;
  */
 public class FlywayPlugin implements Plugin<Project> {
     public void apply(Project project) {
-        project.getExtensions().create("flyway", FlywayExtension.class);
+        FlywayExtension flyway = project.getExtensions().create("flyway", FlywayExtension.class);
+        flyway.extensions.add("databases", project.container(FlywayContainer.class));
         project.getTasks().create("flywayClean", FlywayCleanTask.class);
         project.getTasks().create("flywayBaseline", FlywayBaselineTask.class);
         project.getTasks().create("flywayMigrate", FlywayMigrateTask.class);

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/ListPropertyInstruction.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/ListPropertyInstruction.java
@@ -1,0 +1,6 @@
+package org.flywaydb.gradle;
+
+public enum ListPropertyInstruction {
+    PRIORITIZE,
+    MERGE
+}

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -21,17 +21,16 @@ import org.flywaydb.core.internal.util.ClassUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.flywaydb.core.internal.util.UrlUtils;
-import org.flywaydb.gradle.FlywayExtension;
+import org.flywaydb.gradle.*;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * A base class for all flyway tasks.
@@ -45,201 +44,14 @@ abstract class AbstractFlywayTask extends DefaultTask {
     /**
      * The flyway {} block in the build script.
      */
-    protected FlywayExtension extension;
-    /**
-     * The fully qualified classname of the jdbc driver to use to connect to the database
-     */
-    public String driver;
+    protected FlywayExtension masterExtension;
 
-    /**
-     * The jdbc url to use to connect to the database
-     */
-    public String url;
-
-    /**
-     * The user to use to connect to the database
-     */
-    public String user;
-
-    /**
-     * The password to use to connect to the database
-     */
-    public String password;
-
-    /**
-     * The name of Flyway's metadata table
-     */
-    public String table;
-
-    /**
-     * The case-sensitive list of schemas managed by Flyway
-     */
-    public String[] schemas;
-
-    /**
-     * The version to tag an existing schema with when executing baseline. (default: 1)
-     */
-    public String baselineVersion;
-
-    /**
-     * The description to tag an existing schema with when executing baseline. (default: << Flyway Baseline >>)
-     */
-    public String baselineDescription;
-
-    /**
-     * Locations to scan recursively for migrations. The location type is determined by its prefix.
-     * (default: filesystem:src/main/resources/db/migration)
-     * <p>
-     * <tt>Unprefixed locations or locations starting with classpath:</tt>
-     * point to a package on the classpath and may contain both sql and java-based migrations.
-     * <p>
-     * <tt>Locations starting with filesystem:</tt>
-     * point to a directory on the filesystem and may only contain sql migrations.
-     */
-    public String[] locations;
-
-    /**
-     * The fully qualified class names of the custom MigrationResolvers to be used in addition (default)
-     * or as a replacement (using skipDefaultResolvers) to the built-in ones for resolving Migrations to
-     * apply.
-     * <p>(default: none)</p>
-     */
-    public String[] resolvers;
-
-    /**
-     * If set to true, default built-in resolvers will be skipped, only custom migration resolvers will be used.
-     * <p>(default: false)</p>
-     */
-    public Boolean skipDefaultResolvers;
-
-    /**
-     * The file name prefix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationPrefix;
-
-    /**
-     * The file name prefix for repeatable sql migrations (default: R).
-     * <p>
-     * <p>Repeatable sql migrations have the following file name structure: prefixSeparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to R__My_description.sql</p>
-     */
-    public String repeatableSqlMigrationPrefix;
-
-    /**
-     * The file name prefix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationSeparator;
-
-    /**
-     * The file name suffix for Sql migrations
-     * <p>
-     * <p>Sql migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
-     * which using the defaults translates to V1_1__My_description.sql</p>
-     */
-    public String sqlMigrationSuffix;
-
-    /**
-     * The encoding of Sql migrations
-     */
-    public String encoding;
-
-    /**
-     * Placeholders to replace in Sql migrations
-     */
-    public Map<Object, Object> placeholders;
-
-    /**
-     * Whether placeholders should be replaced.
-     */
-    public Boolean placeholderReplacement;
-
-    /**
-     * The prefix of every placeholder
-     */
-    public String placeholderPrefix;
-
-    /**
-     * The suffix of every placeholder
-     */
-    public String placeholderSuffix;
-
-    /**
-     * The target version up to which Flyway should consider migrations.
-     * Migrations with a higher version number will be ignored.
-     * The special value {@code current} designates the current version of the schema.
-     */
-    public String target;
-
-    /**
-     * An array of fully qualified FlywayCallback class implementations
-     */
-    public String[] callbacks;
-
-    /**
-     * If set to true, default built-in callbacks will be skipped, only custom migration callbacks will be used.
-     * <p>(default: false)</p>
-     */
-    public Boolean skipDefaultCallbacks;
-
-    /**
-     * Allows migrations to be run "out of order"
-     */
-    public Boolean outOfOrder;
-
-    /**
-     * Whether to automatically call validate or not when running migrate. (default: true)
-     */
-    public Boolean validateOnMigrate;
-
-    /**
-     * Whether to automatically call clean or not when a validation error occurs
-     */
-    public Boolean cleanOnValidationError;
-
-    /**
-     * Ignore future migrations when reading the metadata table. These are migrations that were performed by a
-     * newer deployment of the application that are not yet available in this version. For example: we have migrations
-     * available on the classpath up to version 3.0. The metadata table indicates that a migration to version 4.0
-     * (unknown to us) has already been applied. Instead of bombing out (fail fast) with an exception, a
-     * warning is logged and Flyway continues normally. This is useful for situations where one must be able to redeploy
-     * an older version of the application after the database has been migrated by a newer one. (default: {@code true})
-     */
-    public Boolean ignoreFutureMigrations;
-
-    /**
-     * Whether to disable clean. (default: {@code false})
-     * <p>This is especially useful for production environments where running clean can be quite a career limiting move.</p>
-     */
-    public Boolean cleanDisabled;
-
-    /**
-     * <p>
-     * Whether to automatically call baseline when migrate is executed against a non-empty schema with no metadata table.
-     * This schema will then be baselined with the {@code baselineVersion} before executing the migrations.
-     * Only migrations above {@code baselineVersion} will then be applied.
-     * </p>
-     * <p>
-     * This is useful for initial Flyway production deployments on projects with an existing DB.
-     * </p>
-     * <p>
-     * Be careful when enabling this as it removes the safety net that ensures
-     * Flyway does not migrate the wrong database in case of a configuration mistake!
-     * </p>
-     *
-     * @param baselineOnMigrate {@code true} if baseline should be called on migrate for non-empty schemas, {@code false} if not. (default: {@code false})
-     */
-    public Boolean baselineOnMigrate;
+    public FlywayExtension taskExtension = new FlywayExtension();
 
     public AbstractFlywayTask() {
         super();
         setGroup("Flyway");
-        extension = (FlywayExtension) getProject().getExtensions().getByName("flyway");
+        masterExtension = (FlywayExtension) getProject().getExtensions().getByName("flyway");
     }
 
     @TaskAction
@@ -265,7 +77,27 @@ abstract class AbstractFlywayTask extends DefaultTask {
                 }
             }
 
-            return run(createFlyway());
+            NamedDomainObjectContainer container = (NamedDomainObjectContainer) masterExtension.extensions.findByName("databases");
+            if (0 == container.size()) {
+                try {
+                    run(FlywayCreator.create(getProject(), taskExtension, masterExtension, masterExtension));
+                } catch (Exception e) {
+                    handleException(e);
+                }
+            } else {
+                for (Iterator iterator = container.iterator(); iterator.hasNext();) {
+                    FlywayContainer flywayLocal = (FlywayContainer) iterator.next();
+                    getLogger().info("Executing ${this.getName()} for ${flywayLocal.name}");
+                    try {
+                        run(flywayLocal.name, FlywayCreator.create(getProject(), taskExtension, flywayLocal, masterExtension));
+                    } catch (Exception e) {
+                        throw new FlywayException(
+                                "Error occurred while executing ${this.getName()} for ${flywayLocal.name}", e);
+                    }
+                }
+            }
+
+            return null;
         } catch (Exception e) {
             handleException(e);
             return null;
@@ -277,78 +109,8 @@ abstract class AbstractFlywayTask extends DefaultTask {
      */
     protected abstract Object run(Flyway flyway);
 
-    /**
-     * Creates a new, configured flyway instance
-     */
-    private Flyway createFlyway() {
-        Map<String, String> conf = new HashMap<String, String>();
-        System.out.println(this);
-        System.out.println(extension);
-        putIfSet(conf, "driver", driver, extension.driver);
-        putIfSet(conf, "url", url, extension.url);
-        putIfSet(conf, "user", user, extension.user);
-        putIfSet(conf, "password", password, extension.password);
-        putIfSet(conf, "table", table, extension.table);
-        putIfSet(conf, "baselineVersion", baselineVersion, extension.baselineVersion);
-        putIfSet(conf, "baselineDescription", baselineDescription, extension.baselineDescription);
-        putIfSet(conf, "sqlMigrationPrefix", sqlMigrationPrefix, extension.sqlMigrationPrefix);
-        putIfSet(conf, "repeatableSqlMigrationPrefix", repeatableSqlMigrationPrefix, extension.repeatableSqlMigrationPrefix);
-        putIfSet(conf, "sqlMigrationSeparator", sqlMigrationSeparator, extension.sqlMigrationSeparator);
-        putIfSet(conf, "sqlMigrationSuffix", sqlMigrationSuffix, extension.sqlMigrationSuffix);
-        putIfSet(conf, "encoding", encoding, extension.encoding);
-        putIfSet(conf, "placeholderReplacement", placeholderReplacement, extension.placeholderReplacement);
-        putIfSet(conf, "placeholderPrefix", placeholderPrefix, extension.placeholderPrefix);
-        putIfSet(conf, "placeholderSuffix", placeholderSuffix, extension.placeholderSuffix);
-        putIfSet(conf, "target", target, extension.target);
-        putIfSet(conf, "outOfOrder", outOfOrder, extension.outOfOrder);
-        putIfSet(conf, "validateOnMigrate", validateOnMigrate, extension.validateOnMigrate);
-        putIfSet(conf, "cleanOnValidationError", cleanOnValidationError, extension.cleanOnValidationError);
-        putIfSet(conf, "ignoreFutureMigrations", ignoreFutureMigrations, extension.ignoreFutureMigrations);
-        putIfSet(conf, "cleanDisabled", cleanDisabled, extension.cleanDisabled);
-        putIfSet(conf, "baselineOnMigrate", baselineOnMigrate, extension.baselineOnMigrate);
-        putIfSet(conf, "skipDefaultResolvers", skipDefaultResolvers, extension.skipDefaultResolvers);
-        putIfSet(conf, "skipDefaultCallbacks", skipDefaultCallbacks, extension.skipDefaultCallbacks);
-        putIfSet(conf, "schemas", StringUtils.arrayToCommaDelimitedString(schemas), StringUtils.arrayToCommaDelimitedString(extension.schemas));
-
-        conf.put("flyway.locations", Location.FILESYSTEM_PREFIX + getProject().getProjectDir().getAbsolutePath() + "/src/main/resources/db/migration");
-        putIfSet(conf, "locations", StringUtils.arrayToCommaDelimitedString(locations), StringUtils.arrayToCommaDelimitedString(extension.locations));
-
-        putIfSet(conf, "resolvers", StringUtils.arrayToCommaDelimitedString(resolvers), StringUtils.arrayToCommaDelimitedString(extension.resolvers));
-        putIfSet(conf, "callbacks", StringUtils.arrayToCommaDelimitedString(callbacks), StringUtils.arrayToCommaDelimitedString(extension.callbacks));
-
-        if (placeholders != null) {
-            for (Map.Entry<Object, Object> entry : placeholders.entrySet()) {
-                conf.put(PLACEHOLDERS_PROPERTY_PREFIX + entry.getKey().toString(), entry.getValue().toString());
-            }
-        }
-        if (extension.placeholders != null) {
-            for (Map.Entry<Object, Object> entry : extension.placeholders.entrySet()) {
-                conf.put(PLACEHOLDERS_PROPERTY_PREFIX + entry.getKey().toString(), entry.getValue().toString());
-            }
-        }
-
-        addConfigFromProperties(conf, getProject().getProperties());
-        addConfigFromProperties(conf, System.getProperties());
-
-        Flyway flyway = new Flyway();
-        flyway.configure(conf);
-        return flyway;
-    }
-
-    private static void addConfigFromProperties(Map<String, String> config, Properties properties) {
-        for (String prop : properties.stringPropertyNames()) {
-            if (prop.startsWith("flyway.")) {
-                config.put(prop, properties.getProperty(prop));
-            }
-        }
-    }
-
-    private static void addConfigFromProperties(Map<String, String> config, Map<String, ?> properties) {
-        for (String prop : properties.keySet()) {
-            if (prop.startsWith("flyway.")) {
-                config.put(prop, properties.get(prop).toString());
-            }
-        }
+    protected Object run(String name, Flyway flyway) {
+        return this.run(flyway);
     }
 
     /**
@@ -372,22 +134,6 @@ abstract class AbstractFlywayTask extends DefaultTask {
             return collectMessages(throwable.getCause(), message);
         }
         return message;
-    }
-
-    /**
-     * Puts this property in the config if it has been set either in the task or the extension.
-     *
-     * @param config         The config.
-     * @param key            The peoperty name.
-     * @param propValue      The value in the plugin.
-     * @param extensionValue The value in the extension.
-     */
-    private void putIfSet(Map<String, String> config, String key, Object propValue, Object extensionValue) {
-        if (propValue != null) {
-            config.put("flyway." + key, propValue.toString());
-        } else if (extensionValue != null) {
-            config.put("flyway." + key, extensionValue.toString());
-        }
     }
 
     private boolean isJavaProject() {

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayInfoTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayInfoTask.java
@@ -29,4 +29,10 @@ public class FlywayInfoTask extends AbstractFlywayTask {
         System.out.println(MigrationInfoDumper.dumpToAsciiTable(flyway.info().all()));
         return null;
     }
+
+    @Override
+    protected Object run(String name, Flyway flyway) {
+        System.out.println("FlywayInfo for " + name);
+        return this.run(flyway);
+    }
 }


### PR DESCRIPTION
This is a stepping stone to resolving #738. While the feature requested is not yet implemented, the ability to support multiple configurations in a single run will enable us to eventually run tasks for the individual configurations separately.

Care was taken in this implementation to not change the existing behavior of the Gradle plugin. The simplest case still works.

If multiple databases are configured, then the "master" properties become defaults that are used only if the individual databases do not have a value assigned to the property.

Additionally, there are now "instruction" properties that correspond to each of the array/map properties. These allow the user to change the default "prioritization" behavior to a "merge" behavior. When set to "merge" properties set in different levels are combined, rather that taken in the order they are found. For instance, with the placeholders Instruction set to "merge", if you specify "flyway.placeholders.stub_a=a" as a environment variable and "placeholders['stub_b':b']" in the build.gradle file, both placeholders will be resolved (as opposed to the current implementation, where only "stub_a" would be resolved).
