### PR TITLE
#1211 Postgres upper case schema fix

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -120,13 +120,13 @@ public class PostgreSQLDbSupport extends DbSupport {
     }
 
     public String unQuote(final String quoted) {
-    	if (quoted==null||quoted.length()<=2) {
-    		return quoted;
-    	}
-    	String result = quoted.startsWith("\"")?quoted.substring(1):quoted;
-    	return result.endsWith("\"")?result.substring(0,result.length()-1):result;
+        if (quoted == null || quoted.length() <= 2) {
+            return quoted;
+        }
+        String result = quoted.startsWith("\"") ? quoted.substring(1) : quoted;
+        return result.endsWith("\"") ? result.substring(0, result.length() - 1) : result;
     }
-    
+
     @Override
     public Schema getSchema(String name) {
         return new PostgreSQLSchema(jdbcTemplate, this, name);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -119,7 +119,15 @@ public class PostgreSQLDbSupport extends DbSupport {
         return "\"" + StringUtils.replaceAll(identifier, "\"", "\"\"") + "\"";
     }
 
-    public String unQuote(final String quoted) {
+    /**
+     * unQuote
+     *
+     * Remove the quotes from the beginning and end of a given string. If the provided string isn't quoted, it will be returned unchanged.
+     *
+     * @param quoted
+     * @return the quoted string without a leading and trailing "
+     */
+    String unQuote(final String quoted) {
         if (quoted == null || quoted.length() <= 2) {
             return quoted;
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
@@ -69,7 +69,7 @@ public class PostgreSQLDbSupport extends DbSupport {
 
     @Override
     protected String doGetCurrentSchemaName() throws SQLException {
-        return jdbcTemplate.queryForString("SHOW search_path");
+        return unQuote(jdbcTemplate.queryForString("SHOW search_path"));
     }
 
     @Override
@@ -119,6 +119,14 @@ public class PostgreSQLDbSupport extends DbSupport {
         return "\"" + StringUtils.replaceAll(identifier, "\"", "\"\"") + "\"";
     }
 
+    public String unQuote(final String quoted) {
+    	if (quoted==null||quoted.length()<=2) {
+    		return quoted;
+    	}
+    	String result = quoted.startsWith("\"")?quoted.substring(1):quoted;
+    	return result.endsWith("\"")?result.substring(0,result.length()-1):result;
+    }
+    
     @Override
     public Schema getSchema(String name) {
         return new PostgreSQLSchema(jdbcTemplate, this, name);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,9 +31,6 @@ public class PostgreSQLDbSupportSmallTest {
     public void undoQuote() {
         PostgreSQLDbSupport dbSupport = new PostgreSQLDbSupport(null);
         assertEquals("abc", dbSupport.unQuote("\"abc\""));
-        assertEquals("abc", dbSupport.unQuote("abc\""));
-        assertEquals("abc", dbSupport.unQuote("\"abc"));
-        assertEquals("a\"b\"c", dbSupport.unQuote("a\"b\"c"));
-        assertEquals("a\"b\"c", dbSupport.unQuote("\"a\"b\"c"));
+        assertEquals("abc", dbSupport.unQuote("abc"));
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
@@ -26,4 +26,14 @@ public class PostgreSQLDbSupportSmallTest {
         assertEquals("\"abc\"", dbSupport.doQuote("abc"));
         assertEquals("\"a\"\"b\"\"c\"", dbSupport.doQuote("a\"b\"c"));
     }
+    
+    @Test
+    public void undoQuote() {
+        PostgreSQLDbSupport dbSupport = new PostgreSQLDbSupport(null);
+        assertEquals("abc", dbSupport.unQuote("\"abc\""));
+        assertEquals("abc", dbSupport.unQuote("abc\""));
+        assertEquals("abc", dbSupport.unQuote("\"abc"));
+        assertEquals("a\"b\"c", dbSupport.unQuote("a\"b\"c"));
+        assertEquals("a\"b\"c", dbSupport.unQuote("\"a\"b\"c"));
+    }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupportSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ public class PostgreSQLDbSupportSmallTest {
         assertEquals("\"abc\"", dbSupport.doQuote("abc"));
         assertEquals("\"a\"\"b\"\"c\"", dbSupport.doQuote("a\"b\"c"));
     }
-    
+
     @Test
     public void undoQuote() {
         PostgreSQLDbSupport dbSupport = new PostgreSQLDbSupport(null);


### PR DESCRIPTION
Remove the quotes from a schema name returned by the doGetCurrentSchemaName  in PostgreSQLDbSupport. 
