### PR TITLE
Fixed flyway 4.0 upgrade for Redshift (it does not support alter column)

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/redshift/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/redshift/upgradeMetaDataTable.sql
@@ -16,6 +16,11 @@
 
 ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
 ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${table}_pk";
-ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" DROP NOT NULL;
+ALTER TABLE "${schema}"."${table}" ADD COLUMN "version_temp" VARCHAR(50) NULL;
+UPDATE "${schema}"."${table}" SET "version_temp"="version";
+ALTER TABLE "${schema}"."${table}" DROP COLUMN "version";
+ALTER TABLE "${schema}"."${table}" ADD COLUMN "version" VARCHAR(50) NULL;
+UPDATE "${schema}"."${table}" SET "version"="version_temp";
+ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_temp";
 ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
 UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';


### PR DESCRIPTION
@axelfontaine 

I fixed the flyway 4 metadata upgrade for Redshift. Redshift does not support ALTER COLUMN, so we have to create new columns and copy the data instead.