### PR TITLE
Postgres clean drop all types

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
@@ -112,9 +112,6 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDbSupport> {
             jdbcTemplate.execute(statement);
         }
 
-        for (Type type : allTypes()) {
-            type.drop();
-        }
     }
 
     /**


### PR DESCRIPTION
This is a followup of previous PR for #1190. I don't know what happened but this change - described in https://github.com/flyway/flyway/pull/1157#issuecomment-174353875 - has been lost.

Tests runned and passed.