### PR TITLE
Allow commandline client to specify placeholderReplacement

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1162,6 +1162,10 @@ public class Flyway implements FlywayConfiguration {
         if (locationsProp != null) {
             setLocations(StringUtils.tokenizeToStringArray(locationsProp, ","));
         }
+        String placeholderReplacementProp = getValueAndRemoveEntry(props, "flyway.placeholderReplacement");
+        if (placeholderReplacementProp != null) {
+            setPlaceholderReplacement(Boolean.parseBoolean(placeholderReplacementProp));
+        }
         String placeholderPrefixProp = getValueAndRemoveEntry(props, "flyway.placeholderPrefix");
         if (placeholderPrefixProp != null) {
             setPlaceholderPrefix(placeholderPrefixProp);

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -123,6 +123,18 @@ public class FlywaySmallTest {
     }
 
     @Test
+    public void configurePlaceholderReplacement() {
+        Flyway flyway = new Flyway();
+        flyway.configure(new Properties());
+        assertTrue(flyway.isPlaceholderReplacement());
+
+        Properties properties = new Properties();
+        properties.setProperty("flyway.placeholderReplacement", "false");
+        flyway.configure(properties);
+        assertFalse(flyway.isPlaceholderReplacement());
+    }
+
+    @Test
     public void configureCustomMigrationResolvers() {
         Properties properties = new Properties();
         properties.setProperty("flyway.resolvers", MyCustomMigrationResolver.class.getName());


### PR DESCRIPTION
currently there's no way to actually set `placeholderReplacement` to false when invoking flyway via the commandline client, or at least I couldn't figure it out.

I think the documentation already includes this parameter in it.