### PR TITLE
Enhancement for #724: Prompt for user/password if property exists but is empty (for default .conf setup).

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -410,21 +410,22 @@ public class Main {
      */
     private static void promptForCredentialsIfMissing(Properties properties) {
         Console console = System.console();
+
         if (console == null) {
             // We are running in an automated build. Prompting is not possible.
             return;
         }
 
-        if (!properties.containsKey("flyway.url")) {
+        if (!properties.containsKey("flyway.url") || ((String)properties.get("flyway.url")).isEmpty()) {
             // URL is not set. We are doomed for failure anyway.
             return;
         }
 
-        if (!properties.containsKey("flyway.user")) {
+        if (!properties.containsKey("flyway.user") || ((String)properties.get("flyway.user")).isEmpty()) {
             properties.put("flyway.user", console.readLine("Database user: "));
         }
 
-        if (!properties.containsKey("flyway.password")) {
+        if (!properties.containsKey("flyway.password") || ((String)properties.get("flyway.password")).isEmpty()) {
             char[] password = console.readPassword("Database password: ");
             properties.put("flyway.password", password == null ? "" : String.valueOf(password));
         }


### PR DESCRIPTION
The default flyway.conf configuration has the following defaults:

```
# User to use to connect to the database (default: <<null>>)
flyway.user=

# Password to use to connect to the database (default: <<null>>)
flyway.password=
```

The code would not prompt for username/password in this case because the original check was only looking for flyway.user or flyway.password in the property map, but didn't account for empty values.