### PR TITLE
Fixed bug in properties configuration. 

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1162,6 +1162,10 @@ public class Flyway implements FlywayConfiguration {
         if (locationsProp != null) {
             setLocations(StringUtils.tokenizeToStringArray(locationsProp, ","));
         }
+        String placeholderReplacement = getValueAndRemoveEntry(props, "flyway.placeholderReplacement");
+        if(placeholderReplacement != null){
+            setPlaceholderReplacement(Boolean.parseBoolean(placeholderReplacement));
+        }
         String placeholderPrefixProp = getValueAndRemoveEntry(props, "flyway.placeholderPrefix");
         if (placeholderPrefixProp != null) {
             setPlaceholderPrefix(placeholderPrefixProp);


### PR DESCRIPTION
The property flyway.placeholderReplacement wasn't being handled correctly in flyway-core.

If we use the maven plugin the property is set and the behaviour is the expected. Otherwise, don't.