### PR TITLE
add an autoUpdateMetaDataTable property

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -252,6 +252,18 @@ public class Flyway implements FlywayConfiguration {
     private boolean outOfOrder;
 
     /**
+     * Whether the metadata table should be automatically updated to the most recent format.
+     * <p>
+     * This is useful for some Flyway production deployments that run updates offline.
+     * </p>
+     * <p>
+     * Be careful when disabling this since it allows Flyway to run with an outdated metadata table
+     * which will cause most methods to fail. (default: {@code true})
+     * </p>
+     */
+    private boolean autoUpdateMetaDataTable = true;
+
+    /**
      * This is a list of custom callbacks that fire before and after tasks are executed.  You can
      * add as many custom callbacks as you want. (default: none)
      */
@@ -481,6 +493,21 @@ public class Flyway implements FlywayConfiguration {
      */
     public boolean isOutOfOrder() {
         return outOfOrder;
+    }
+
+    /**
+     * Whether the metadata table should be automatically updated to the most recent format.
+     * <p>
+     * This is useful for some Flyway production deployments that run updates offline.
+     * </p>
+     * <p>
+     * Be careful when disabling this since it allows Flyway to run with an outdated metadata table
+     * which will cause most methods to fail.
+     * </p>
+     * @return {@code true} if metadata table should be automatically updated when any statement is executed, {@code false} if not. (default: {@code true})
+     */
+    public boolean isAutoUpdateMetaDataTable() {
+        return autoUpdateMetaDataTable;
     }
 
     @Override
@@ -834,6 +861,22 @@ public class Flyway implements FlywayConfiguration {
         this.outOfOrder = outOfOrder;
     }
 
+
+    /**
+     * Disable automatically updating the metadata table to the most recent format when a statement is executed.
+     * <p>
+     * This is useful for some Flyway production deployments that run updates offline.
+     * </p>
+     * <p>
+     * Be careful when disabling this since it allows Flyway to run with an outdated metadata table
+     * which will cause most methods to fail.
+     * </p>
+     *
+     * @param autoUpdateMetaDataTable {@code true} if metadata table should be automatically updated when any statement is executed, {@code false} if not. (default: {@code false})
+     */
+    public void setAutoUpdateMetaDataTable(boolean autoUpdateMetaDataTable) {
+        this.autoUpdateMetaDataTable = autoUpdateMetaDataTable;
+    }
     /**
      * Gets the callbacks for lifecycle notifications.
      *
@@ -1238,6 +1281,10 @@ public class Flyway implements FlywayConfiguration {
         if (outOfOrderProp != null) {
             setOutOfOrder(Boolean.parseBoolean(outOfOrderProp));
         }
+        String autoUpdateMetaDataTableProp = getValueAndRemoveEntry(props, "flyway.autoUpdateMetaDataTable");
+        if (autoUpdateMetaDataTableProp != null) {
+            setAutoUpdateMetaDataTable(Boolean.parseBoolean(autoUpdateMetaDataTableProp));
+        }
         String resolversProp = getValueAndRemoveEntry(props, "flyway.resolvers");
         if (StringUtils.hasLength(resolversProp)) {
             setResolversAsClassNames(StringUtils.tokenizeToStringArray(resolversProp, ","));
@@ -1353,7 +1400,7 @@ public class Flyway implements FlywayConfiguration {
 
             FlywayCallback[] flywayCallbacksArray = flywayCallbacks.toArray(new FlywayCallback[flywayCallbacks.size()]);
             MetaDataTable metaDataTable = new MetaDataTableImpl(dbSupport, schemas[0].getTable(table));
-            if (metaDataTable.upgradeIfNecessary()) {
+            if (metaDataTable.upgradeIfNecessary(autoUpdateMetaDataTable)) {
                 new DbRepair(dbSupport, connectionMetaDataTable, schemas[0], migrationResolver, metaDataTable, flywayCallbacksArray).repairChecksums();
                 LOG.info("Metadata table " + table + " successfully upgraded to the Flyway 4.0 format.");
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTable.java
@@ -110,5 +110,5 @@ public interface MetaDataTable {
      *
      * @return {@code true} if it was upgraded.
      */
-    boolean upgradeIfNecessary();
+    boolean upgradeIfNecessary(boolean autoUpdateMetaDataTable);
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
@@ -64,20 +64,25 @@ public class MetaDataTableImpl implements MetaDataTable {
     }
 
     @Override
-    public boolean upgradeIfNecessary() {
+    public boolean upgradeIfNecessary(boolean autoUpdateMetaDataTable) {
         if (table.exists() && table.hasColumn("version_rank")) {
-            LOG.info("Upgrading metadata table " + table + " to the Flyway 4.0 format ...");
-            String resourceName = "org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/upgradeMetaDataTable.sql";
-            String source = new ClassPathResource(resourceName, getClass().getClassLoader()).loadAsString("UTF-8");
+            if (autoUpdateMetaDataTable) {
+                LOG.info("Upgrading metadata table " + table + " to the Flyway 4.0 format ...");
+                String resourceName = "org/flywaydb/core/internal/dbsupport/" + dbSupport.getDbName() + "/upgradeMetaDataTable.sql";
+                String source = new ClassPathResource(resourceName, getClass().getClassLoader()).loadAsString("UTF-8");
 
-            Map<String, String> placeholders = new HashMap<String, String>();
-            placeholders.put("schema", table.getSchema().getName());
-            placeholders.put("table", table.getName());
-            String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
+                Map<String, String> placeholders = new HashMap<String, String>();
+                placeholders.put("schema", table.getSchema().getName());
+                placeholders.put("table", table.getName());
+                String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
-            sqlScript.execute(jdbcTemplate);
-            return true;
+                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+                sqlScript.execute(jdbcTemplate);
+                return true;
+            } else {
+                LOG.warn("Metadata table " + table + " has not been updated to the Flyway 4.0 format" +
+                    "and autoUpdateMetaDataTable has been disabled. Flyway may not perform as expected.");
+            }
         }
         return false;
     }


### PR DESCRIPTION
Add an autoUpdateMetaDataTable property that determines whether Flyway should automatically update the schema_version table to the latest format.   

We need this for some of our databases that get updated offline but still use Flyway to determine whether migrations are up-to-date.  I don't expect many of the Flyway methods to work with the old schema_version table but it will be useful to have Flyway fail and not have attempted to modify the schema_version table to the new version. 