### PR TITLE
Command line interface does not work without "drivers" folder present #1218 

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -285,10 +285,10 @@ public class Main {
         // see javadoc of listFiles(): null if given path is not a real directory
         if (files == null) {
             LOG.debug("Directory for Jdbc Drivers not found: " + driversDir.getAbsolutePath());
-        }
-
-        for (File file : files) {
-            addJarOrDirectoryToClasspath(file.getPath());
+        }else{
+            for (File file : files) {
+                addJarOrDirectoryToClasspath(file.getPath());
+            }
         }
     }
 

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -317,8 +317,7 @@ public class Main {
 
             // see javadoc of listFiles(): null if given path is not a real directory
             if (files == null) {
-                LOG.error("Directory for Java Migrations not found: " + dirName);
-                System.exit(1);
+                LOG.debug("Directory for Java Migrations not found: " + dirName);
             }
 
             for (File file : files) {

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -284,8 +284,7 @@ public class Main {
 
         // see javadoc of listFiles(): null if given path is not a real directory
         if (files == null) {
-            LOG.error("Directory for Jdbc Drivers not found: " + driversDir.getAbsolutePath());
-            System.exit(1);
+            LOG.debug("Directory for Jdbc Drivers not found: " + driversDir.getAbsolutePath());
         }
 
         for (File file : files) {


### PR DESCRIPTION
Allow the command line interface to work without the "drivers" folder. the drivers are search in path "flyway.jarDirs" and in classpath.