### PR TITLE
#1259: Support for SAP (Sybase) SQL Anywhere

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
@@ -32,6 +32,7 @@ import org.flywaydb.core.internal.dbsupport.saphana.SapHanaDbSupport;
 import org.flywaydb.core.internal.dbsupport.solid.SolidDbSupport;
 import org.flywaydb.core.internal.dbsupport.sqlite.SQLiteDbSupport;
 import org.flywaydb.core.internal.dbsupport.sqlserver.SQLServerDbSupport;
+import org.flywaydb.core.internal.dbsupport.sybase.asa.SybaseASADbSupport;
 import org.flywaydb.core.internal.dbsupport.sybase.ase.SybaseASEDbSupport;
 import org.flywaydb.core.internal.dbsupport.vertica.VerticaDbSupport;
 import org.flywaydb.core.internal.util.logging.Log;
@@ -134,6 +135,12 @@ public class DbSupportFactory {
         if (databaseProductName.startsWith("ASE") || databaseProductName.startsWith("Adaptive")) {
         	return new SybaseASEDbSupport(connection);
         }
+
+        // Sybase SQL Anywhere support
+		if (databaseProductName.startsWith("SQL Anywhere")) {
+			return new SybaseASADbSupport(connection);
+		}
+
         if (databaseProductName.startsWith("HDB")) {
         	return new SapHanaDbSupport(connection);
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASADbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASADbSupport.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.sybase.asa;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.sybase.ase.SybaseASEDbSupport;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.flywaydb.core.internal.util.logging.LogFactory;
+
+/**
+ * Sybase SQL Anywhere specific support
+ *
+ */
+public class SybaseASADbSupport extends SybaseASEDbSupport {
+
+	private static final Log LOG = LogFactory.getLog(SybaseASADbSupport.class);
+
+	public SybaseASADbSupport(Connection connection) {
+		super(connection, Types.INTEGER);
+    }
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.flywaydb.core.internal.dbsupport.DbSupport#getSchema(java.lang.
+	 * String)
+	 */
+	@Override
+	public Schema getSchema(String name) {
+		// Sybase does not support schema and changing user on the fly. Always
+		// return a schema that does not exist
+		Schema schema = new SybaseASASchema(jdbcTemplate, this, name) {
+			@Override
+			protected boolean doExists() throws SQLException {
+				return false;
+			}
+
+		};
+
+		try {
+			String currentName = doGetCurrentSchemaName();
+			if (currentName.equals(name)) {
+				schema = new SybaseASASchema(jdbcTemplate, this, name);
+			}
+		} catch (SQLException e) {
+			LOG.error("Unable to obtain current schema, return non-existing schema", e);
+		}
+		return schema;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see org.flywaydb.core.internal.dbsupport.DbSupport#getDbName()
+	 */
+	@Override
+	public String getDbName() {
+		return "sybaseASA";
+	}
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASASchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASASchema.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.sybase.asa;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Table;
+import org.flywaydb.core.internal.dbsupport.sybase.ase.SybaseASESchema;
+
+/**
+ * Sybase SQL Anywhere schema (database) for flyway support
+ *
+ */
+public class SybaseASASchema extends SybaseASESchema {
+
+	public SybaseASASchema(JdbcTemplate jdbcTemplate, SybaseASADbSupport dbSupport,
+			String name) {
+		super(jdbcTemplate, dbSupport, name);
+	}
+
+	@Override
+	protected boolean doEmpty() throws SQLException {
+		// There is no schema in Sybase, check whether database is empty
+		// Check for tables, views stored procs and triggers
+		return jdbcTemplate.queryForInt(
+				"select count(*) from sysobjects ob where (ob.type='U' or ob.type = 'V' or ob.type = 'P' or ob.type = 'TR') and ob.name != 'sysquerymetrics' and ob.uid = user_id()") == 0;
+	}
+
+	@Override
+	public Table getTable(String tableName) {
+		return new SybaseASATable(jdbcTemplate, dbSupport, this, tableName);
+	}
+
+	@Override
+	protected List<String> getObjectNamesByType(String type) throws SQLException {
+		List<String> objNames = jdbcTemplate.queryForStringList(
+				"select ob.name from sysobjects ob where ob.type=? and ob.uid = user_id() order by ob.name", type);
+		return objNames;
+	}
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASATable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASATable.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *
+ */
+package org.flywaydb.core.internal.dbsupport.sybase.asa;
+
+import java.sql.SQLException;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.sybase.ase.SybaseASETable;
+
+/**
+ * Sybase SQL Anywhere table for flyway
+ *
+ */
+public class SybaseASATable extends SybaseASETable {
+
+	/**
+	 * Creates a new Sybase SQL Anywhere table.
+	 *
+	 * @param jdbcTemplate
+	 *            The Jdbc Template for communicating with the DB.
+	 * @param dbSupport
+	 *            The database-specific support.
+	 * @param schema
+	 *            The schema this table lives in.
+	 * @param name
+	 *            The name of the table.
+	 */
+	public SybaseASATable(JdbcTemplate jdbcTemplate, DbSupport dbSupport,
+			Schema schema, String name) {
+		super(jdbcTemplate, dbSupport, schema, name);
+	}
+
+
+	@Override
+	protected void doLock() throws SQLException {
+		jdbcTemplate.execute("LOCK TABLE " + this + " IN EXCLUSIVE MODE");
+
+	}
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/ase/SybaseASEDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/ase/SybaseASEDbSupport.java
@@ -35,8 +35,12 @@ public class SybaseASEDbSupport extends DbSupport {
 	private static final Log LOG = LogFactory.getLog(SybaseASEDbSupport.class);
 	
 	public SybaseASEDbSupport(Connection connection) {
-        super(new JdbcTemplate(connection, Types.NULL));
+		this(connection, Types.NULL);
     }
+
+	public SybaseASEDbSupport(Connection connection, int nullType) {
+		super(new JdbcTemplate(connection, nullType));
+	}
 
 	/* (non-Javadoc)
 	 * @see org.flywaydb.core.internal.dbsupport.DbSupport#getSchema(java.lang.String)

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/ase/SybaseASESchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sybase/ase/SybaseASESchema.java
@@ -82,7 +82,7 @@ public class SybaseASESchema extends Schema<SybaseASEDbSupport> {
 		
 		for(int i = 0; i < tableNames.size(); i++) {
 			String tableName = tableNames.get(i);
-			result[i] = new SybaseASETable(jdbcTemplate, dbSupport, this, tableName);
+			result[i] = getTable(tableName);
 		}
 		
 		return result;
@@ -99,7 +99,7 @@ public class SybaseASESchema extends Schema<SybaseASEDbSupport> {
 	 * @throws SQLException
 	 */
 	private List<String> retrieveAllTableNames() throws SQLException {
-		List<String> objNames = jdbcTemplate.queryForStringList("select ob.name from sysobjects ob where ob.type=? order by ob.name", "U");
+		List<String> objNames = getObjectNamesByType("U");
 		
 		return objNames;
 	}
@@ -107,7 +107,7 @@ public class SybaseASESchema extends Schema<SybaseASEDbSupport> {
 	private void dropObjects(String sybaseObjType) throws SQLException {
 		
 		//Getting the table names
-		List<String> objNames = jdbcTemplate.queryForStringList("select ob.name from sysobjects ob where ob.type=? order by ob.name", sybaseObjType);
+		List<String> objNames = getObjectNamesByType(sybaseObjType);
 		
 		//for each table, drop it
 		for (String name : objNames) {
@@ -129,6 +129,12 @@ public class SybaseASESchema extends Schema<SybaseASEDbSupport> {
 			jdbcTemplate.execute(sql + name);
 			
 		}
+	}
+
+	protected List<String> getObjectNamesByType(String type) throws SQLException {
+		List<String> objNames = jdbcTemplate
+				.queryForStringList("select ob.name from sysobjects ob where ob.type=? order by ob.name", type);
+		return objNames;
 	}
 
 }

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/sybaseASA/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/sybaseASA/createMetaDataTable.sql
@@ -1,0 +1,40 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${table} (
+    installed_rank INT NOT NULL,
+    version VARCHAR(50),
+    description VARCHAR(200) NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    script VARCHAR(1000) NOT NULL,
+    checksum INT NULL,
+    installed_by VARCHAR(100) NOT NULL,
+    installed_on datetime DEFAULT getDate() NOT NULL,
+    execution_time INT NOT NULL,
+    success decimal NOT NULL,
+    PRIMARY KEY (installed_rank)
+)
+go
+
+CREATE INDEX ${table}_vr_idx ON ${table} (version)
+go
+
+CREATE INDEX ${table}_ir_idx ON ${table} (installed_rank)
+go
+
+CREATE INDEX ${table}_s_idx ON ${table} (success)
+go
+

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASAMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sybase/asa/SybaseASAMigrationMediumTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *
+ */
+package org.flywaydb.core.internal.dbsupport.sybase.asa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.MigrationInfoService;
+import org.flywaydb.core.api.MigrationState;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.internal.dbsupport.FlywaySqlScriptException;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.flywaydb.core.migration.MigrationTestCase;
+import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test to demonstrate the migration functionality using Sybase Sql Anywhere with the JConnect driver.
+ *
+ */
+@Category(DbCategory.SybaseASE.class)
+public class SybaseASAMigrationMediumTest extends MigrationTestCase {
+
+	protected static final String BASEDIR = "migration/dbsupport/sybaseASE/sql";
+
+    @Override
+    protected DataSource createDataSource(Properties customProperties) {
+		String user = customProperties.getProperty("sybase.user", "dba");
+		String password = customProperties.getProperty("sybase.password", "sql");
+		String url = customProperties.getProperty("sybase.jconnect_url", "jdbc:sybase:Tds:localhost:2638/flyway_test");
+
+		return new DriverDataSource(Thread.currentThread().getContextClassLoader(), "com.sybase.jdbc4.jdbc.SybDriver",
+				url, user, password);
+    }
+
+	@Override
+	protected String getQuoteLocation() {
+		//Sybase does not support quoting table names
+		return getValidateLocation();
+	}
+
+	@Ignore("Table quote is not supported in sybase.")
+	@Override
+	public void quotesAroundTableName() {
+	}
+
+	@Override
+    public void outOfOrderMultipleRankIncrease() {
+        flyway.setLocations(BASEDIR);
+        flyway.migrate();
+
+        flyway.setLocations(BASEDIR, "migration/dbsupport/sybaseASE/outoforder");
+        flyway.setOutOfOrder(true);
+        flyway.migrate();
+
+		MigrationInfoService info = flyway.info();
+		MigrationInfo[] all = info.all();
+		// Difference to ASE. 5th applied migration is out of order not second.
+		// Should also fail in ASE?
+		MigrationState state = all[4].getState();
+		assertEquals(org.flywaydb.core.api.MigrationState.OUT_OF_ORDER, state);
+    }
+
+	@Override
+    public void subDir() {
+        flyway.setLocations("migration/dbsupport/sybaseASE/subdir");
+        assertEquals(3, flyway.migrate());
+    }
+
+	@Override
+    @Ignore("Not supported on Sybase ASE Server")
+    public void setCurrentSchema() throws Exception {
+        //Skip
+    }
+
+	@Override
+	@Ignore("Schema reference is not supported on Sybase ASE server")
+	public void migrateMultipleSchemas() throws Exception {
+		//Skip
+	}
+
+	@Override
+	@Ignore("Table name quote is not supported on Sybase ASE server")
+    public void quote() throws Exception {
+        //skip
+    }
+
+	@Override
+    public void failedMigration() throws Exception {
+        String tableName = "before_the_error";
+
+        flyway.setLocations("migration/dbsupport/sybaseASE/failed");
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put("tableName", dbSupport.quote(tableName));
+        flyway.setPlaceholders(placeholders);
+
+        try {
+            flyway.migrate();
+            fail();
+        } catch (FlywaySqlScriptException e) {
+            // root cause of exception must be defined, and it should be FlywaySqlScriptException
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof SQLException);
+            // and make sure the failed statement was properly recorded
+            // It is line 22 as a go statement is added for Sybase
+            assertEquals(22, e.getLineNumber());
+            String statement = e.getStatement();
+            if (statement.indexOf('\n') != -1) {
+            	statement = statement.replace("\n", "");
+            }
+            assertEquals("THIS IS NOT VALID SQL", statement);
+        }
+
+        MigrationInfo migration = flyway.info().current();
+        assertEquals(
+                dbSupport.supportsDdlTransactions(),
+                !dbSupport.getSchema(dbSupport.getCurrentSchemaName()).getTable(tableName).exists());
+        if (dbSupport.supportsDdlTransactions()) {
+            assertNull(migration);
+        } else {
+            MigrationVersion version = migration.getVersion();
+            assertEquals("1", version.toString());
+            assertEquals("Should Fail", migration.getDescription());
+            assertEquals(MigrationState.FAILED, migration.getState());
+            assertEquals(1, flyway.info().applied().length);
+        }
+    }
+
+	//Location override the parent test cases begins
+
+	@Override
+	protected String getBasedir() {
+		return BASEDIR;
+	}
+
+	@Override
+	protected String getFutureFailedLocation() {
+		return "migration/dbsupport/sybaseASE/future_failed";
+	}
+
+	@Override
+	protected String getValidateLocation() {
+		return "migration/dbsupport/sybaseASE/validate";
+	}
+
+	@Override
+	protected String getSemiColonLocation() {
+		return "migration/dbsupport/sybaseASE/semicolon";
+	}
+
+	@Override
+	protected String getCommentLocation() {
+		return "migration/dbsupport/sybaseASE/comment";
+	}
+
+    @Ignore("Not needed as Sybase ASE support was first introduced in Flyway 4.0")
+    @Override
+    public void upgradeMetadataTableTo40Format() throws Exception {
+    }
+}


### PR DESCRIPTION
Pull Request to address issue #1259 .

The implementation is based on the SAP (Sybase) ASE implentation. The databases are similar in structure and syntax. I needed to make minor modifications to the ASE Database Support to make it reuseable. The major difference is that when you use SQL Anywhere as Database admin (dba account) the Flyway clean also droped essential system/metadata tables. Therefore, only tables that are created by the current user are considered, when analysing the database, which excludes the system/metadata tables

I could just tested it on SQL Anywhere 12.0. The database is only slowly developed and I don't expect any problems with newer versions.

The implementation can be tested using the [SAP SQL Anywhere Developer Edition](http://scn.sap.com/community/sql-anywhere). An empty database (flyway_test) needs to be created. The Developer Edition should also include the jdbc driver.

There are currently two problems: 
- SQL Anywhere can be used with an odbc-based driver or a preferred pure jdbc driver (jconnect). The problem is the jconnect driver is not public and I couldn't figure out the correct group/artifactId. We are using an internal artifact. So I didn't add a dependency to the driver to the pom.
- The contribution guidelines mention the documentation needs to be updated, but what exactly needs to be done.

This is my first open soure contribution. I hope I didn't forgot anything essential.
