### PR TITLE
Fix update checksum query for Phoenix. Resolves #1262

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateChecksum.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/phoenix/updateChecksum.sql
@@ -16,10 +16,9 @@
 
 
 -- Update checksum for a version
-UPSERT INTO "${schema}"."${table}" (
-    "version",
-    "checksum"
-) VALUES (
-     '${version_val}',
-     ${checksum_val}
-);
+UPSERT INTO "${schema}"."${table}" ("installed_rank", "checksum")
+SELECT
+    "installed_rank",
+    ${checksum_val}
+FROM "${schema}"."${table}"
+WHERE "version" = '${version_val}';


### PR DESCRIPTION
Re-work the updateChecksum.sql for Phoenix to work with the modified table schema.