### PR TITLE
#1265 fix upgrade metadata table for Derby

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/derby/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/derby/upgradeMetaDataTable.sql
@@ -18,6 +18,6 @@ DROP INDEX "${schema}"."${table}_vr_idx";
 DROP INDEX "${schema}"."${table}_ir_idx";
 ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
 ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${table}_pk";
-ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" DROP NOT NULL;
+ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" NOT NULL;
 ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
 UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';


### PR DESCRIPTION
The problem is that Derby has no command ALTER COLUMN column-name DROP NOT NULL
But it has ALTER COLUMN column-name NOT NULL