### PR TITLE
Add support for PostgresPlus Advanced Server

### DIFF
--- a/createDBs.cmd
+++ b/createDBs.cmd
@@ -33,6 +33,10 @@ echo PostgreSQL...
 set PGPASSWORD=flyway
 psql -Upostgres < flyway-core/src/test/resources/migration/dbsupport/postgresql/createDatabase.sql
 
+echo PostgresPlus
+set PGPASSWORD=flyway
+psql -Uenterprisedb < flyway-core/src/test/resources/migration/dbsupport/postgresql/createDatabase.sql
+
 echo SQL Server...
 sqlcmd -U sa -P flyway -S localhost\SQLExpress -i flyway-core\src\test\resources\migration\dbsupport\sqlserver\createDatabase.sql
 

--- a/dropDBs.cmd
+++ b/dropDBs.cmd
@@ -31,7 +31,11 @@ mysql -uroot -pflyway -P3333 < flyway-core/src/test/resources/migration/dbsuppor
 
 echo PostgreSQL...
 set PGPASSWORD=flyway
-psql -Upostgres < flyway-core/src/test/resources/migration/dbsupport/postgresql/dropDatabase.sql
+psql -Upostgres < flyway-core/src/test/resources/migration/dbsupport/edb/dropDatabase.sql
+
+echo PostgresPlus...
+set PGPASSWORD=flyway
+psql -Uenterprisedb < flyway-core/src/test/resources/migration/dbsupport/postgresplus/dropDatabase.sql
 
 echo SQL Server...
 sqlcmd -U sa -P flyway -S localhost\SQLExpress -i flyway-core\src\test\resources\migration\dbsupport\sqlserver\dropDatabase.sql

--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -26,7 +26,7 @@
         </license>
     </licenses>
     <properties>
-        <jreversion>1.8.0_74</jreversion>
+        <jreversion>1.8.0_77</jreversion>
     </properties>
     <dependencies>
         <dependency>

--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -349,6 +349,30 @@
             </build>
         </profile>
         <profile>
+            <id>PostgresPlusTest</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.edb</groupId>
+                    <artifactId>edb-jdbc17</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!-- exclude all but PostgresPlus -->
+                            <excludedGroups>org.flywaydb.core.DbCategory$DB2,org.flywaydb.core.DbCategory$Oracle,org.flywaydb.core.DbCategory$SQLServer,org.flywaydb.core.DbCategory$ContributorSupportedDB,org.flywaydb.core.DbCategory$OpenSourceDB,org.flywaydb.core.DbCategory$Derby,org.flywaydb.core.DbCategory$H2,org.flywaydb.core.DbCategory$HSQL,org.flywaydb.core.DbCategory$SQLite,org.flywaydb.core.DbCategory$Phoenix</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>VerticaRedshiftDBTest</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DbSupportFactory.java
@@ -24,6 +24,7 @@ import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
 import org.flywaydb.core.internal.dbsupport.mysql.MySQLDbSupport;
 import org.flywaydb.core.internal.dbsupport.oracle.OracleDbSupport;
 import org.flywaydb.core.internal.dbsupport.phoenix.PhoenixDbSupport;
+import org.flywaydb.core.internal.dbsupport.postgresplus.PostgresPlusDbSupport;
 import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLDbSupport;
 import org.flywaydb.core.internal.dbsupport.redshift.RedshfitDbSupportViaPostgreSQLDriver;
 import org.flywaydb.core.internal.dbsupport.redshift.RedshfitDbSupportViaRedshiftDriver;
@@ -92,6 +93,9 @@ public class DbSupportFactory {
         }
         if (databaseProductName.startsWith("Oracle")) {
             return new OracleDbSupport(connection);
+        }
+        if (databaseProductName.startsWith("EnterpriseDB")) {
+            return new PostgresPlusDbSupport(connection);
         }
         if (databaseProductName.startsWith("PostgreSQL 8")) {
             // Redshift reports a databaseProductName of "PostgreSQL 8.0", and it uses the same JDBC driver,

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusDbSupport.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.postgresql.copy.CopyManager;
+import org.postgresql.core.BaseConnection;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Oracle-specific support.
+ */
+public class PostgresPlusDbSupport extends DbSupport {
+    /**
+     * Creates a new instance.
+     *
+     * @param connection The connection to use.
+     */
+    public PostgresPlusDbSupport(Connection connection) {
+        super(new JdbcTemplate(connection, Types.NULL));
+    }
+
+    public String getDbName() {
+        return "postgresplus";
+    }
+
+    public String getCurrentUserFunction() {
+        return "current_user";
+    }
+
+    @Override
+    public Schema getOriginalSchema() {
+        if (originalSchema == null) {
+            return null;
+        }
+
+        String result = originalSchema.replace(doQuote("$user"), "").trim();
+        if (result.startsWith(",")) {
+            result = result.substring(1);
+        }
+        if (result.contains(",")) {
+            result = result.substring(0, result.indexOf(","));
+        }
+        return getSchema(result.trim());
+    }
+
+    @Override
+    protected String doGetCurrentSchemaName() throws SQLException {
+        return jdbcTemplate.queryForString("SHOW search_path");
+    }
+
+    @Override
+    public void changeCurrentSchemaTo(Schema schema) {
+        if (schema.getName().equals(originalSchema) || originalSchema.startsWith(schema.getName() + ",") || !schema.exists()) {
+            return;
+        }
+
+        try {
+            if (StringUtils.hasText(originalSchema)) {
+                doChangeCurrentSchemaTo(schema.toString() + "," + originalSchema);
+            } else {
+                doChangeCurrentSchemaTo(schema.toString());
+            }
+        } catch (SQLException e) {
+            throw new FlywayException("Error setting current schema to " + schema, e);
+        }
+    }
+
+    @Override
+    protected void doChangeCurrentSchemaTo(String schema) throws SQLException {
+        if (!StringUtils.hasLength(schema)) {
+            jdbcTemplate.execute("SELECT set_config('search_path', '', false)");
+            return;
+        }
+        jdbcTemplate.execute("SET search_path = " + schema);
+    }
+
+    public boolean supportsDdlTransactions() {
+        return true;
+    }
+
+    public String getBooleanTrue() {
+        return "TRUE";
+    }
+
+    public String getBooleanFalse() {
+        return "FALSE";
+    }
+
+    public SqlStatementBuilder createSqlStatementBuilder() {
+        return new PostgresPlusSqlStatementBuilder();
+    }
+
+    @Override
+    public String doQuote(String identifier) {
+        return "\"" + StringUtils.replaceAll(identifier, "\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new PostgresPlusSchema(jdbcTemplate, this, name);
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+
+    @Override
+    public void executePgCopy(Connection connection, String sql) throws SQLException {
+        int split = sql.indexOf(";");
+        String statement = sql.substring(0, split);
+        String data = sql.substring(split + 1).trim();
+
+        CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+        try {
+            copyManager.copyIn(statement, new StringReader(data));
+        } catch (IOException e) {
+            throw new SQLException("Unable to execute COPY operation", e);
+        }
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSchema.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+import org.flywaydb.core.internal.dbsupport.Type;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * PostgresPlus implementation of Schema.
+ */
+public class PostgresPlusSchema extends Schema<PostgresPlusDbSupport> {
+
+    /**
+     * Creates a new PostgresPlus schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport    The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public PostgresPlusSchema(JdbcTemplate jdbcTemplate, PostgresPlusDbSupport dbSupport, String name) {
+        super(jdbcTemplate, dbSupport, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM pg_namespace WHERE nspname=?", name) > 0;
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        int objectCount = jdbcTemplate.queryForInt(
+                "SELECT count(*) FROM information_schema.tables WHERE table_schema=? AND table_type='BASE TABLE'",
+                name);
+        return objectCount == 0;
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        jdbcTemplate.execute("CREATE SCHEMA " + dbSupport.quote(name));
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP SCHEMA " + dbSupport.quote(name) + " CASCADE");
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        int databaseMajorVersion = jdbcTemplate.getMetaData().getDatabaseMajorVersion();
+        int databaseMinorVersion = jdbcTemplate.getMetaData().getDatabaseMinorVersion();
+
+        if ((databaseMajorVersion > 9) || ((databaseMajorVersion == 9) && (databaseMinorVersion >= 3))) {
+            // PostgreSQL 9.3 and newer only
+            for (String statement : generateDropStatementsForMaterializedViews()) {
+                jdbcTemplate.execute(statement);
+            }
+        }
+
+        for (String statement : generateDropStatementsForPackages()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForViews()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (Table table : allTables()) {
+            table.drop();
+        }
+
+        for (String statement : generateDropStatementsForSequences()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForBaseTypes(true)) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForAggregates()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForRoutines()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForEnums()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForDomains()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForBaseTypes(false)) {
+            jdbcTemplate.execute(statement);
+        }
+
+    }
+
+    /**
+     * Generates the statements for dropping the sequences in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForSequences() throws SQLException {
+        List<String> sequenceNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema=?", name);
+
+        List<String> statements = new ArrayList<String>();
+        for (String sequenceName : sequenceNames) {
+            statements.add("DROP SEQUENCE IF EXISTS " + dbSupport.quote(name, sequenceName));
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the types in this schema.
+     *
+     * @param recreate Flag indicating whether the types should be recreated. Necessary for type-function chicken and egg problem.
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForBaseTypes(boolean recreate) throws SQLException {
+
+        List<Map<String, String>> rows =
+                jdbcTemplate.queryForList(
+                "select typname, typcategory from pg_catalog.pg_type t "
+                + "where (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid)) and "
+                + "NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid) and "
+                + "t.typnamespace in (select oid from pg_catalog.pg_namespace where nspname = ?)",
+                name);
+
+        List<String> statements = new ArrayList<String>();
+        for (Map<String, String> row : rows) {
+            statements.add("DROP TYPE IF EXISTS " + dbSupport.quote(name, row.get("typname")) + " CASCADE");
+        }
+
+        if (recreate) {
+            for (Map<String, String> row : rows) {
+                // Only recreate Pseudo-types (P) and User-defined types (U)
+                if (Arrays.asList("P", "U").contains(row.get("typcategory"))) {
+                    statements.add("CREATE TYPE " + dbSupport.quote(name, row.get("typname")));
+                }
+            }
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the aggregates in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForAggregates() throws SQLException {
+        List<Map<String, String>> rows =
+                jdbcTemplate.queryForList(
+                        "SELECT proname, oidvectortypes(proargtypes) AS args "
+                                + "FROM pg_proc INNER JOIN pg_namespace ns ON (pg_proc.pronamespace = ns.oid) "
+                                + "WHERE pg_proc.proisagg = true AND ns.nspname = ?",
+                        name
+                );
+
+        List<String> statements = new ArrayList<String>();
+        for (Map<String, String> row : rows) {
+            statements.add("DROP AGGREGATE IF EXISTS " + dbSupport.quote(name, row.get("proname")) + "(" + row.get("args") + ") CASCADE");
+        }
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the routines in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForRoutines() throws SQLException {
+        List<Map<String, String>> rows =
+                jdbcTemplate.queryForList(
+                // Search for all functions
+                        "SELECT proname, oidvectortypes(proargtypes) AS args "
+                                + "FROM pg_proc INNER JOIN pg_namespace ns ON (pg_proc.pronamespace = ns.oid) "
+                // that don't depend on an extension
+                        + "LEFT JOIN pg_depend dep ON dep.objid = pg_proc.oid AND dep.deptype = 'e' "
+                        + "WHERE pg_proc.proisagg = false AND ns.nspname = ? AND dep.objid IS NULL",
+                        name
+                );
+
+        List<String> statements = new ArrayList<String>();
+        for (Map<String, String> row : rows) {
+            statements.add("DROP FUNCTION IF EXISTS " + dbSupport.quote(name, row.get("proname")) + "(" + row.get("args") + ") CASCADE");
+        }
+        return statements;
+    }
+
+    private List<String> generateDropStatementsForPackages() throws SQLException {
+        List<Map<String, String>> rows =
+                jdbcTemplate.queryForList(
+                        // search for all packages
+                        "SELECT edb_package.pkgname FROM edb_package "
+                        + "JOIN pg_namespace ON edb_package.pkgowner = pg_namespace.oid "
+                        + "WHERE pg_namespace.nspname = ?",
+                        name
+                );
+        List<String> statements = new ArrayList<String>();
+        for (Map<String, String> row : rows) {
+            statements.add("DROP PACKAGE " + dbSupport.quote(name, row.get("pkgname")));
+        }
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the enums in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForEnums() throws SQLException {
+        List<String> enumNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT t.typname FROM pg_catalog.pg_type t INNER JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = ? and t.typtype = 'e'", name);
+
+        List<String> statements = new ArrayList<String>();
+        for (String enumName : enumNames) {
+            statements.add("DROP TYPE " + dbSupport.quote(name, enumName));
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the domains in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForDomains() throws SQLException {
+        List<String> domainNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT domain_name FROM information_schema.domains WHERE domain_schema=?", name);
+
+        List<String> statements = new ArrayList<String>();
+        for (String domainName : domainNames) {
+            statements.add("DROP DOMAIN " + dbSupport.quote(name, domainName));
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the materialized views in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForMaterializedViews() throws SQLException {
+        List<String> viewNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT relname FROM pg_catalog.pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace"
+                                + " WHERE c.relkind = 'm' AND n.nspname = ?", name);
+
+        List<String> statements = new ArrayList<String>();
+        for (String domainName : viewNames) {
+            statements.add("DROP MATERIALIZED VIEW IF EXISTS " + dbSupport.quote(name, domainName) + " CASCADE");
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the views in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForViews() throws SQLException {
+        List<String> viewNames =
+                jdbcTemplate.queryForStringList(
+                // Search for all views
+                "SELECT relname FROM pg_catalog.pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace" +
+                        // that don't depend on an extension
+                        " LEFT JOIN pg_depend dep ON dep.objid = c.oid AND dep.deptype = 'e'" +
+                        " WHERE c.relkind = 'v' AND  n.nspname = ? AND dep.objid IS NULL",
+                name);
+        List<String> statements = new ArrayList<String>();
+        for (String domainName : viewNames) {
+            statements.add("DROP VIEW IF EXISTS " + dbSupport.quote(name, domainName) + " CASCADE");
+        }
+
+        return statements;
+    }
+
+    @Override
+    protected Table[] doAllTables() throws SQLException {
+        List<String> tableNames =
+                jdbcTemplate.queryForStringList(
+                        //Search for all the table names
+                        "SELECT t.table_name FROM information_schema.tables t" +
+                                //in this schema
+                                " WHERE table_schema=?" +
+                                //that are real tables (as opposed to views)
+                                " AND table_type='BASE TABLE'" +
+                                //and are not child tables (= do not inherit from another table).
+                                " AND NOT (SELECT EXISTS (SELECT inhrelid FROM pg_catalog.pg_inherits" +
+                                " WHERE inhrelid = (quote_ident(t.table_schema)||'.'||quote_ident(t.table_name))::regclass::oid))",
+                        name
+                );
+        //Views and child tables are excluded as they are dropped with the parent table when using cascade.
+
+        Table[] tables = new Table[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new PostgresPlusTable(jdbcTemplate, dbSupport, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new PostgresPlusTable(jdbcTemplate, dbSupport, this, tableName);
+    }
+
+    @Override
+    protected Type getType(String typeName) {
+        return new PostgresPlusType(jdbcTemplate, dbSupport, this, typeName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlStatementBuilder.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.internal.dbsupport.Delimiter;
+import org.flywaydb.core.internal.dbsupport.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * SqlStatementBuilder supporting Oracle-specific PL/SQL constructs.
+ */
+public class PostgresPlusSqlStatementBuilder extends SqlStatementBuilder {
+    /**
+     * Regex for keywords that can appear before a string literal without being separated by a space.
+     */
+    private static final Pattern KEYWORDS_BEFORE_STRING_LITERAL_REGEX = Pattern.compile("^(N|IF|ELSIF|SELECT|IMMEDIATE|RETURN|IS)('.*)");
+
+    /**
+     * Regex for keywords that can appear after a string literal without being separated by a space.
+     */
+    private static final Pattern KEYWORDS_AFTER_STRING_LITERAL_REGEX = Pattern.compile("(.*')(USING|THEN|FROM|AND|OR)(?!.)");
+
+    /**
+     * Matches $$, $BODY$, $xyz123$, ...
+     */
+    /*private -> for testing*/
+    static final String DOLLAR_QUOTE_REGEX = "(\\$[A-Za-z0-9_]*\\$).*";
+
+    /**
+     * Delimiter of PL/SQL blocks and statements.
+     */
+    private static final Delimiter SPL_DELIMITER = new Delimiter("/", true);
+
+    /**
+     * Holds the beginning of the statement.
+     */
+    private String statementStart = "";
+
+    @Override
+    protected Delimiter changeDelimiterIfNecessary(String line, Delimiter delimiter) {
+        if (line.matches("DECLARE|DECLARE\\s.*") || line.matches("BEGIN|BEGIN\\s.*")) {
+            return SPL_DELIMITER;
+        }
+
+        if (StringUtils.countOccurrencesOf(statementStart, " ") < 8) {
+            statementStart += line;
+            statementStart += " ";
+            statementStart = statementStart.replaceAll("\\s+", " ");
+        }
+
+        if (statementStart.matches("CREATE( OR REPLACE)? (FUNCTION|PROCEDURE|PACKAGE|TYPE|TRIGGER).*")) {
+            return SPL_DELIMITER;
+        }
+
+        return delimiter;
+    }
+
+    @Override
+    protected String cleanToken(String token) {
+        if (token.startsWith("'") && token.endsWith("'")) {
+            return token;
+        }
+
+        Matcher beforeMatcher = KEYWORDS_BEFORE_STRING_LITERAL_REGEX.matcher(token);
+        if (beforeMatcher.find()) {
+            token = beforeMatcher.group(2);
+        }
+
+        Matcher afterMatcher = KEYWORDS_AFTER_STRING_LITERAL_REGEX.matcher(token);
+        if (afterMatcher.find()) {
+            token = afterMatcher.group(1);
+        }
+
+        return token;
+    }
+
+    @Override
+    protected String simplifyLine(String line) {
+        String simplifiedQQuotes = StringUtils.replaceAll(StringUtils.replaceAll(line, "q'(", "q'["), ")'", "]'");
+        return super.simplifyLine(simplifiedQQuotes);
+    }
+
+    @Override
+    protected String extractAlternateOpenQuote(String token) {
+        Matcher matcher = Pattern.compile(DOLLAR_QUOTE_REGEX).matcher(token);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean canDiscard() {
+        return super.canDiscard() || statementStart.startsWith("SET DEFINE OFF");
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusTable.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+
+import java.sql.SQLException;
+
+/**
+ * PostgresPlus-specific table.
+ */
+public class PostgresPlusTable extends Table {
+    /**
+     * Creates a new PostgresPlus table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport    The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public PostgresPlusTable(JdbcTemplate jdbcTemplate, DbSupport dbSupport, Schema schema, String name) {
+        super(jdbcTemplate, dbSupport, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + dbSupport.quote(schema.getName(), name) + " CASCADE");
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return exists(null, schema, name);
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusType.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Type;
+
+import java.sql.SQLException;
+
+/**
+ * PostgreSQL-specific type.
+ */
+public class PostgresPlusType extends Type {
+    /**
+     * Creates a new PostgreSQL type.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param dbSupport    The database-specific support.
+     * @param schema       The schema this type lives in.
+     * @param name         The name of the type.
+     */
+    public PostgresPlusType(JdbcTemplate jdbcTemplate, DbSupport dbSupport, Schema schema, String name) {
+        super(jdbcTemplate, dbSupport, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TYPE " + dbSupport.quote(schema.getName(), name));
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresplus/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -286,6 +286,10 @@ public class DriverDataSource implements DataSource {
             return "oracle.jdbc.OracleDriver";
         }
 
+        if (url.startsWith("jdbc:edb:")) {
+            return "com.edb.Driver";
+        }
+
         if (url.startsWith("jdbc:phoenix")) {
             return "org.apache.phoenix.jdbc.PhoenixDriver";
         }

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/postgresplus/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/postgresplus/createMetaDataTable.sql
@@ -1,0 +1,33 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE "${schema}"."${table}" (
+    "installed_rank" INT NOT NULL,
+    "version" VARCHAR(50),
+    "description" VARCHAR(200) NOT NULL,
+    "type" VARCHAR(20) NOT NULL,
+    "script" VARCHAR(1000) NOT NULL,
+    "checksum" INTEGER,
+    "installed_by" VARCHAR(100) NOT NULL,
+    "installed_on" TIMESTAMP NOT NULL DEFAULT now(),
+    "execution_time" INTEGER NOT NULL,
+    "success" BOOLEAN NOT NULL
+) WITH (
+  OIDS=FALSE
+);
+ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
+
+CREATE INDEX "${table}_s_idx" ON "${schema}"."${table}" ("success");

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/postgresplus/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/postgresplus/upgradeMetaDataTable.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+DROP INDEX "${schema}"."${table}_vr_idx";
+DROP INDEX "${schema}"."${table}_ir_idx";
+ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
+ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${table}_pk";
+ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" DROP NOT NULL;
+ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
+UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';

--- a/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/DbCategory.java
@@ -40,6 +40,7 @@ public class DbCategory {
     public interface DB2 extends CommercialDB {}
     public interface Oracle extends CommercialDB {}
     public interface SQLServer extends CommercialDB {}
+    public interface PostgresPlus extends CommercialDB {}
 
     public interface GoogleCloudSQL extends ContributorSupportedDB {}
     public interface SapHana extends ContributorSupportedDB {}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusConcurrentMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusConcurrentMigrationMediumTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.flywaydb.core.migration.ConcurrentMigrationTestCase;
+import org.junit.experimental.categories.Category;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+/**
+ * Test to demonstrate the migration functionality using PostgresPlus.
+ */
+@Category(DbCategory.PostgresPlus.class)
+public class PostgresPlusConcurrentMigrationMediumTest extends ConcurrentMigrationTestCase {
+    @Override
+    protected DataSource createDataSource(Properties customProperties) throws Exception {
+        String user = customProperties.getProperty("postgresplus.user", "flyway");
+        String password = customProperties.getProperty("postgresplus.password", "flyway");
+        String url = customProperties.getProperty("postgresplus.url", "jdbc:edb://localhost/flyway_db");
+
+        return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, url, user, password);
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusDbSupportMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusDbSupportMediumTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLDbSupport;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.sql.DataSource;
+import java.io.File;
+import java.io.FileInputStream;
+import java.sql.Connection;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for the PostgresPlus-specific DB support.
+ */
+@SuppressWarnings({"JavaDoc"})
+@Category(DbCategory.PostgresPlus.class)
+public class PostgresPlusDbSupportMediumTest {
+
+    /**
+     * Checks that the search_path is extended and not overwritten so that objects in PUBLIC can still be found.
+     */
+    @Test
+    public void setCurrentSchema() throws Exception {
+        Connection connection = createDataSource().getConnection();
+        PostgreSQLDbSupport dbSupport = new PostgreSQLDbSupport(connection);
+        Schema schema = dbSupport.getSchema("search_path_test");
+        schema.create();
+        dbSupport.changeCurrentSchemaTo(dbSupport.getSchema("search_path_test"));
+        String searchPath = dbSupport.getJdbcTemplate().queryForString("SHOW search_path");
+        assertEquals("search_path_test, \"$user\", public", searchPath);
+        schema.drop();
+        JdbcUtils.closeConnection(connection);
+    }
+
+
+    /**
+     * Creates a datasource for use in tests.
+     *
+     * @return The new datasource.
+     */
+    private DataSource createDataSource() throws Exception {
+        File customPropertiesFile = new File(System.getProperty("user.home") + "/flyway-mediumtests.properties");
+        Properties customProperties = new Properties();
+        if (customPropertiesFile.canRead()) {
+            customProperties.load(new FileInputStream(customPropertiesFile));
+        }
+        String user = customProperties.getProperty("postgresplus.user", "flyway");
+        String password = customProperties.getProperty("postgresplus.password", "flyway");
+        String url = customProperties.getProperty("postgresplus.url", "jdbc:edb://localhost/flyway_db");
+
+        return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, url, user, password);
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusMigrationMediumTest.java
@@ -1,0 +1,487 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.MigrationType;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
+import org.flywaydb.core.migration.MigrationTestCase;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test to demonstrate the migration functionality using PostgresPlus.
+ */
+@SuppressWarnings({"JavaDoc"})
+@Category(DbCategory.PostgresPlus.class)
+public class PostgresPlusMigrationMediumTest extends MigrationTestCase {
+
+    @Override
+    protected DataSource createDataSource(Properties customProperties) throws Exception {
+        String user = customProperties.getProperty("postgresplus.user", "flyway");
+        String password = customProperties.getProperty("postgresplus.password", "flyway");
+        String url = customProperties.getProperty("postgresplus.url", "jdbc:edb://localhost/flyway_db");
+
+        return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, url, user, password);
+    }
+
+    @Override
+    protected String getQuoteLocation() {
+        return "migration/quote";
+    }
+
+    /**
+     * Tests migrations containing placeholders.
+     */
+    @Test
+    public void migrationsWithPlaceholders() throws Exception {
+        int countUserObjects1 = jdbcTemplate.queryForInt("SELECT count(*) FROM user_objects");
+
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put("tableName", "test_user");
+        flyway.setPlaceholders(placeholders);
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/placeholders");
+
+        flyway.migrate();
+        MigrationVersion version = flyway.info().current().getVersion();
+        assertEquals("1.1", version.toString());
+        assertEquals("Populate table", flyway.info().current().getDescription());
+
+        assertEquals("Mr. T triggered", jdbcTemplate.queryForString("select name from test_user"));
+
+        flyway.clean();
+
+        int countUserObjects2 = jdbcTemplate.queryForInt("SELECT count(*) FROM user_objects");
+        assertEquals(countUserObjects1, countUserObjects2);
+
+        MigrationInfo[] migrationInfos = flyway.info().applied();
+        for (MigrationInfo migrationInfo : migrationInfos) {
+            assertNotNull(migrationInfo.getScript() + " has no checksum", migrationInfo.getChecksum());
+        }
+    }
+
+
+    @Test
+    public void vacuum() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/vacuum");
+        flyway.setResolvers(new PostgresPlusMigrationMediumTest.NoTransactionMigrationResolver(new String[][]{
+                {"2.0", "Vacuum without transaction", "vacuum-notrans", "VACUUM t"}
+        }));
+        flyway.migrate();
+    }
+
+    @Test
+    public void cleanUnknown() throws Exception {
+        flyway.setSchemas("non-existant");
+        flyway.clean();
+    }
+
+    private class NoTransactionMigrationResolver implements MigrationResolver {
+        private final String[][] data;
+
+        private NoTransactionMigrationResolver(String[][] data) {
+            this.data = data;
+        }
+
+        @Override
+        public Collection<ResolvedMigration> resolveMigrations() {
+            List<ResolvedMigration> resolvedMigrations = new ArrayList<ResolvedMigration>();
+            for (String[] migrationData : data) {
+                resolvedMigrations.add(new PostgresPlusMigrationMediumTest.NoTransactionResolvedMigration(migrationData));
+            }
+            return resolvedMigrations;
+        }
+    }
+
+    private class NoTransactionResolvedMigration implements ResolvedMigration {
+        private final String[] data;
+
+        private NoTransactionResolvedMigration(String[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public MigrationVersion getVersion() {
+            return MigrationVersion.fromVersion(data[0]);
+        }
+
+        @Override
+        public String getDescription() {
+            return data[1];
+        }
+
+        @Override
+        public String getScript() {
+            return data[2];
+        }
+
+        @Override
+        public Integer getChecksum() {
+            return data[3].hashCode();
+        }
+
+        @Override
+        public MigrationType getType() {
+            return MigrationType.CUSTOM;
+        }
+
+        @Override
+        public String getPhysicalLocation() {
+            return null;
+        }
+
+        @Override
+        public MigrationExecutor getExecutor() {
+            return new PostgresPlusMigrationMediumTest.NoTransactionMigrationExecutor(data[3]);
+        }
+    }
+
+    private class NoTransactionMigrationExecutor implements MigrationExecutor {
+        private final String data;
+
+        private NoTransactionMigrationExecutor(String data) {
+            this.data = data;
+        }
+
+        @Override
+        public void execute(Connection connection) throws SQLException {
+            jdbcTemplate.executeStatement(data);
+        }
+
+        @Override
+        public boolean executeInTransaction() {
+            return false;
+        }
+    }
+
+    /**
+     * Tests clean and migrate for postgresplus Stored Procedures.
+     * TODO: Identify why the Oracle tests include a V2__Invalid.sql file
+     */
+    @Test
+    public void storedProcedure() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/procedure");
+        flyway.migrate();
+
+        assertEquals("Hello", jdbcTemplate.queryForString("SELECT value FROM test_data"));
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests parsing of CREATE PACKAGE.
+     * TODO: Follow-up on EDB bug to see if the fix allows the complex comments in package body to work
+     */
+    @Test
+    public void createPackage() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/package");
+        flyway.migrate();
+    }
+
+    @Test
+    public void count() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/count");
+        flyway.migrate();
+    }
+
+    /**
+     * Tests parsing of object names that contain keywords such as MY_TABLE.
+     */
+    @Test
+    public void objectNames() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/objectnames");
+        flyway.migrate();
+    }
+
+    /**
+     * Tests cleaning up after CREATE MATERIALIZED VIEW.
+     */
+    @Test
+    public void createMaterializedView() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/materialized");
+        flyway.migrate();
+        flyway.clean();
+    }
+
+    /**
+     * Tests clean and migrate for Views.
+     */
+    @Test
+    public void view() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/view");
+        flyway.migrate();
+
+        assertEquals(150, jdbcTemplate.queryForInt("SELECT value FROM \"\"\"v\"\"\""));
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests clean and migrate for child tables.
+     */
+    @Test
+    public void inheritance() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/inheritance");
+        flyway.migrate();
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests clean and migrate for Domains.
+     */
+    @Test
+    public void domain() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/domain");
+        flyway.migrate();
+
+        assertEquals("foo", jdbcTemplate.queryForString("SELECT x FROM t"));
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests clean and migrate for Enums.
+     */
+    @Test
+    public void enumeration() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/enum");
+        flyway.migrate();
+
+        assertEquals("positive", jdbcTemplate.queryForString("SELECT x FROM t"));
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests clean and migrate for Aggregates.
+     */
+    @Test
+    public void aggregate() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/aggregate");
+        flyway.migrate();
+
+        flyway.clean();
+
+        flyway.migrate();
+    }
+
+    /**
+     * Tests parsing support for $$ string literals.
+     */
+    @Test
+    public void dollarQuote() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/dollar");
+        flyway.migrate();
+        assertEquals(9, jdbcTemplate.queryForInt("select count(*) from dollar"));
+    }
+
+    /**
+     * Tests parsing support for multiline string literals.
+     */
+    @Test
+    public void multiLine() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/multiline");
+        flyway.migrate();
+        assertEquals(1, jdbcTemplate.queryForInt("select count(*) from address"));
+    }
+
+    /**
+     * Tests support for COPY FROM STDIN statements generated by pg_dump..
+     */
+    @Test
+    @Ignore("The EDB JDBC driver doesn't currently support copy operations")
+    public void copy() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/copy");
+        flyway.migrate();
+        assertEquals(6, jdbcTemplate.queryForInt("select count(*) from copy_test"));
+    }
+
+    /**
+     * Tests support for user defined types.
+     * TODO: Uncomment the TYPE BODY stanza in the SQL file once the EDB bug is fixed.
+     */
+    @Test
+    public void type() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/type");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    /**
+     * Tests support for create function.
+     */
+    @Test
+    public void function() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/function");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    /**
+     * Tests support for create trigger. Ensures that a Statement is used instead of a PreparedStatement.
+     * Also ensures that schema-level triggers are properly cleaned.
+     */
+    @Test
+    public void trigger() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/trigger");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    /**
+     * Tests support for clean together with PostgresPlus Text indexes.
+     */
+    @Test
+    @Ignore("Beyond the scope of the current iteration")
+    public void text() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/text");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    /**
+     * Tests support for clean together with Index Organized Tables.
+     */
+    @Test
+    public void indexOrganizedTable() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/iot");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void commentPostgresPlus() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/comment");
+        assertEquals(3, flyway.migrate());
+
+        String statusWithComment = jdbcTemplate.queryForString("select ob.STATUS from user_objects ob where ob.OBJECT_NAME = 'PERSON_WITH_COMMENT' ");
+        String statusWithoutComment = jdbcTemplate.queryForString("select ob.STATUS from user_objects ob where ob.OBJECT_NAME = 'PERSON_WITHOUT_COMMENT' ");
+        assertEquals("VALID", statusWithoutComment);
+        assertEquals("VALID", statusWithComment);
+    }
+
+    /**
+     * Tests support for clean together with XML Type.
+     */
+    @Test
+    @Ignore("Beyond the scope of the current iteration")
+    public void xml() throws FlywayException {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/xml");
+        flyway.migrate();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    /**
+     * Tests that the lock on SCHEMA_VERSION is not blocking SQL commands in migrations. This test won't fail if there's
+     * a too restrictive lock - it would just hang endlessly.
+     * TODO: Figure out whether the default LOCK MODE is valid
+     */
+    @Test
+    @Ignore("Default LOCK MODE on PPAS is restrictive?")
+    public void lock() {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/lock");
+        flyway.migrate();
+    }
+
+    @Test
+    public void emptySearchPath() {
+        Flyway flyway1 = new Flyway();
+        DriverDataSource driverDataSource = (DriverDataSource) dataSource;
+        flyway1.setDataSource(new DriverDataSource(Thread.currentThread().getContextClassLoader(),
+                null, driverDataSource.getUrl(), driverDataSource.getUser(), driverDataSource.getPassword()) {
+            @Override
+            public Connection getConnection() throws SQLException {
+                Connection connection = super.getConnection();
+                Statement statement = null;
+                try {
+                    statement = connection.createStatement();
+                    statement.execute("SELECT set_config('search_path', '', false)");
+                } finally {
+                    JdbcUtils.closeStatement(statement);
+                }
+                return connection;
+            }
+        });
+        flyway1.setLocations(getBasedir());
+        flyway1.setSchemas("public");
+        flyway1.migrate();
+    }
+
+    @Test(expected = FlywayException.class)
+    public void warning() {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/warning");
+        flyway.migrate();
+        // Log should contain "This is a warning"
+    }
+
+    @Override
+    protected void createFlyway3MetadataTable() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE \"schema_version\" (\n" +
+                "    \"version_rank\" INT NOT NULL,\n" +
+                "    \"installed_rank\" INT NOT NULL,\n" +
+                "    \"version\" VARCHAR(50) NOT NULL,\n" +
+                "    \"description\" VARCHAR(200) NOT NULL,\n" +
+                "    \"type\" VARCHAR(20) NOT NULL,\n" +
+                "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+                "    \"checksum\" INTEGER,\n" +
+                "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+                "    \"installed_on\" TIMESTAMP NOT NULL DEFAULT now(),\n" +
+                "    \"execution_time\" INTEGER NOT NULL,\n" +
+                "    \"success\" BOOLEAN NOT NULL\n" +
+                ") WITH (\n" +
+                "  OIDS=FALSE\n" +
+                ")");
+        jdbcTemplate.execute("ALTER TABLE \"schema_version\" ADD CONSTRAINT \"schema_version_pk\" PRIMARY KEY (\"version\")");
+        jdbcTemplate.execute("CREATE INDEX \"schema_version_vr_idx\" ON \"schema_version\" (\"version_rank\")");
+        jdbcTemplate.execute("CREATE INDEX \"schema_version_ir_idx\" ON \"schema_version\" (\"installed_rank\")");
+        jdbcTemplate.execute("CREATE INDEX \"schema_version_s_idx\" ON \"schema_version\" (\"success\")");
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSchemaSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSchemaSmallTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.oracle.OracleSchema;
+import org.junit.Test;
+
+/**
+ * Small Test for OracleSchema.
+ */
+@SuppressWarnings({"JavaDoc"})
+public class PostgresPlusSchemaSmallTest {
+    /**
+     * Checks that cleaning can not be performed for the SYSTEM schema (Issue 102)
+     */
+    @Test(expected = FlywayException.class)
+    public void createCleanScriptWithSystem() throws Exception {
+        OracleSchema schema = new OracleSchema(null, null, "SYSTEM");
+        schema.clean();
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlScriptSmallTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.internal.dbsupport.SqlScript;
+import org.flywaydb.core.internal.dbsupport.SqlStatement;
+import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for PostgresPlusSqlScript.
+ */
+public class PostgresPlusSqlScriptSmallTest {
+    @Test
+    public void parseSqlStatements() throws Exception {
+        String source = new ClassPathResource("migration/dbsupport/postgresplus/sql/placeholders/V1__Placeholders.sql",
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(3, sqlStatements.size());
+        assertEquals(18, sqlStatements.get(0).getLineNumber());
+        assertEquals(27, sqlStatements.get(1).getLineNumber());
+        assertEquals(32, sqlStatements.get(2).getLineNumber());
+        assertEquals("COMMIT", sqlStatements.get(2).getSql());
+    }
+
+    @Test
+    public void parseSqlStatementsWithInlineCommentsInsidePlSqlBlocks() throws Exception {
+        String source = new ClassPathResource("migration/dbsupport/postgresplus/sql/function/V2__FunctionWithConditionals.sql",
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(1, sqlStatements.size());
+        assertEquals(18, sqlStatements.get(0).getLineNumber());
+        assertTrue(sqlStatements.get(0).getSql().contains("/* for the rich */"));
+    }
+
+    @Test
+    public void parseFunctionsAndProcedures() throws Exception {
+        String source = new ClassPathResource("migration/dbsupport/postgresplus/sql/function/V1__Function.sql",
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(5, sqlStatements.size());
+        assertEquals(18, sqlStatements.get(0).getLineNumber());
+        assertEquals(33, sqlStatements.get(1).getLineNumber());
+        assertEquals(41, sqlStatements.get(2).getLineNumber());
+        assertEquals(43, sqlStatements.get(3).getLineNumber());
+        assertEquals(51, sqlStatements.get(4).getLineNumber());
+        assertEquals("COMMIT", sqlStatements.get(4).getSql());
+    }
+
+    @Test
+    public void parsePackages() throws Exception {
+        String source = new ClassPathResource("migration/dbsupport/postgresplus/sql/package/V1__Package.sql",
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(3, sqlStatements.size());
+        assertEquals(16, sqlStatements.get(0).getLineNumber());
+        assertEquals(27, sqlStatements.get(1).getLineNumber());
+    }
+
+    @Test
+    public void parseCompoundTrigger() throws Exception {
+        String source = "CREATE OR REPLACE TRIGGER triggername\n" +
+                "  FOR insert ON tablename\n" +
+                "    COMPOUND TRIGGER\n" +
+                "\n" +
+                "  -- Global declaration.\n" +
+                "  g_global_variable VARCHAR2(10);\n" +
+                "\n" +
+                "  BEFORE STATEMENT IS\n" +
+                "  BEGIN\n" +
+                "    NULL; -- Do something here.\n" +
+                "  END BEFORE STATEMENT;\n" +
+                "\n" +
+                "  BEFORE EACH ROW IS\n" +
+                "  BEGIN\n" +
+                "    NULL; -- Do something here.\n" +
+                "  END BEFORE EACH ROW;\n" +
+                "\n" +
+                "  AFTER EACH ROW IS\n" +
+                "  BEGIN\n" +
+                "    NULL; -- Do something here.\n" +
+                "  END AFTER EACH ROW;\n" +
+                "\n" +
+                "  AFTER STATEMENT IS\n" +
+                "  BEGIN\n" +
+                "    NULL; -- Do something here.\n" +
+                "  END AFTER STATEMENT;\n" +
+                "\n" +
+                "END <trigger-name>;\n" +
+                "/";
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(1, sqlStatements.size());
+    }
+
+    @Test
+    public void parseMergeInsert() throws Exception {
+        String source = "INSERT INTO ss.CODETBL(FIELDNAME,FIELDVALUE,IDS)\n" +
+                "SELECT FIELDNAME,FIELDVALUE,IDS FROM\n" +
+                "(\n" +
+                "SELECT 'ACCT_TYPE_CD' FIELDNAME, '$' FIELDVALUE,'SAMP' IDS FROM DUAL UNION ALL\n" +
+                "SELECT 'ACCT_TYPE_CD', 'L','SAMP' FROM DUAL UNION ALL\n" +
+                "SELECT 'ACCT_TYPE_CD', 'C','SAMP' FROM DUAL \n" +
+                ")\n" +
+                "D\n" +
+                "WHERE NOT EXISTS\n" +
+                "(\n" +
+                "SELECT 1 FROM SS.CODETBL \n" +
+                "WHERE D.FIELDNAME = FIELDNAME \n" +
+                "AND D.FIELDVALUE = FIELDVALUE\n" +
+                "AND D.IDS = IDS\n" +
+                ");";
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(1, sqlStatements.size());
+    }
+
+    @Test
+    public void parseProcedure() throws Exception {
+        String source = "CREATE OR REPLACE PROCEDURE set_right_value_for_sequence(seq_name in VARCHAR2, table_name in VARCHAR2, column_id in VARCHAR2)\n" +
+                "IS\n" +
+                "    seq_val NUMBER(6);\n" +
+                "    row_count NUMBER(6);\n" +
+                "BEGIN\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'select ' || seq_name || '.nextval from dual' INTO seq_val;\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'alter sequence  ' || seq_name || ' increment by -' || seq_val || ' minvalue 0';\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'select ' || seq_name || '.nextval from dual' INTO seq_val;\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'select case when max(' || column_id || ') is null then 1 else max(' || column_id || ') end from ' || table_name INTO row_count;\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'alter sequence ' || seq_name || ' increment by ' || row_count || ' minvalue 0';\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'select ' || seq_name || '.nextval from dual' INTO seq_val;\n" +
+                "\n" +
+                "    EXECUTE IMMEDIATE\n" +
+                "    'alter sequence ' || seq_name || ' increment by 1 minvalue 1';\n" +
+                "END;\n" +
+                "/\n" +
+                "\n" +
+                "EXECUTE set_right_value_for_sequence('SEQ_ATR', 'TOTCATTRIB', 'ATTRIB_ID');";
+
+        SqlScript sqlScript = new SqlScript(source, new PostgresPlusDbSupport(null));
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        assertEquals(2, sqlStatements.size());
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSqlStatementBuilderSmallTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test for PostgresPlusSqlStatementBuilder.
+ */
+public class PostgresPlusSqlStatementBuilderSmallTest {
+    private PostgresPlusSqlStatementBuilder builder = new PostgresPlusSqlStatementBuilder();
+
+    @Test
+    public void setDefineOff() {
+        builder.addLine("set define off;");
+        assertTrue(builder.canDiscard());
+    }
+
+    @Test
+    public void changeDelimiterRegEx() {
+        assertNull(builder.changeDelimiterIfNecessary("BEGIN_DATE", null));
+        assertEquals("/", builder.changeDelimiterIfNecessary("BEGIN DATE", null).getDelimiter());
+        assertEquals("/", builder.changeDelimiterIfNecessary("BEGIN", null).getDelimiter());
+    }
+
+    @Test
+    public void nvarchar() {
+        builder.addLine("INSERT INTO nvarchar2_test VALUES ( N'qwerty' );");
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void notNvarchar() {
+        builder.addLine("INSERT INTO nvarchar2_test VALUES ( ' N' );");
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void qQuote() {
+        builder.addLine("select q'[Hello 'no quotes]' from dual;");
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void quotedStringEndingWithN() {
+        builder.addLine("insert into table (COLUMN) values 'VALUE_WITH_N';");
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void quotedWithFrom() {
+        builder.addLine("insert into table (COLUMN) values 'FROM';");
+        assertTrue(builder.isTerminated());
+    }
+
+    @Test
+    public void quotedWithFromComplex() {
+        builder.addLine("DELETE FROM TEST.TABLE1 where CFG_AREA_ID_1 like '%NAME%' AND SOME_ID='NITS'AND CFG_AREA_CD IN ('COND_TXT','FORM');");
+        assertTrue(builder.isTerminated());
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSuperUserMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresplus/PostgresPlusSuperUserMigrationMediumTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.postgresplus;
+
+import org.flywaydb.core.DbCategory;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+
+/**
+ * PostgreSQL medium tests that require SuperUser permissions.
+ */
+@SuppressWarnings({"JavaDoc"})
+@Category(DbCategory.PostgreSQL.class)
+public class PostgresPlusSuperUserMigrationMediumTest {
+    private Flyway flyway;
+
+    @Before
+    public void setUp() throws Exception {
+        File customPropertiesFile = new File(System.getProperty("user.home") + "/flyway-mediumtests.properties");
+        Properties customProperties = new Properties();
+        if (customPropertiesFile.canRead()) {
+            customProperties.load(new FileInputStream(customPropertiesFile));
+        }
+
+        String password = customProperties.getProperty("postgresplus.password", "flyway");
+        String url = customProperties.getProperty("postgresplus.url", "jdbc:edb://localhost/flyway_db");
+
+        flyway = new Flyway();
+        flyway.setSchemas("super_user_test");
+        flyway.setDataSource(new DriverDataSource(Thread.currentThread().getContextClassLoader(), null, url, "flyway", password));
+        flyway.setValidateOnMigrate(true);
+        flyway.clean();
+    }
+
+    /**
+     * Tests clean and migrate for PostgresPlus Types.
+     */
+    @Test
+    public void basetype() throws Exception {
+        flyway.setLocations("migration/dbsupport/postgresplus/sql/basetype");
+        flyway.migrate();
+
+        flyway.clean();
+
+        // Running migrate again on an unclean database, triggers duplicate object exceptions.
+        flyway.migrate();
+
+        // Clean again, to prevent tests with non superuser rights to fail.
+        flyway.clean();
+    }
+}

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/createDatabase.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/createDatabase.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE ROLE flyway LOGIN UNENCRYPTED PASSWORD 'flyway';
+CREATE DATABASE flyway_db
+  WITH OWNER = flyway ENCODING = 'UTF8' TABLESPACE = pg_default;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/dropDatabase.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/dropDatabase.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+DROP DATABASE flyway_db;
+DROP USER flyway;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/aggregate/V1__Aggregate.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/aggregate/V1__Aggregate.sql
@@ -1,0 +1,34 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- State transition function:
+CREATE  FUNCTION create_select(acc text, instr text) RETURNS text AS $$
+  BEGIN
+    IF acc IS NULL OR acc = '' THEN
+      RETURN replace(instr,'.','_') ;
+    ELSE
+      RETURN acc || ', ' || replace(instr,'.','_') ;
+    END IF;
+  END;
+$$ LANGUAGE plpgsql;
+
+-- Aggregate function
+CREATE AGGREGATE textcat_all(
+  basetype    = text,
+  sfunc       = create_select,
+  stype       = text,
+  initcond    = ''
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/basetype/V1__BaseType.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/basetype/V1__BaseType.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TYPE test_type;
+
+CREATE FUNCTION test_type_in(cstring) RETURNS test_type AS
+'record_in'
+LANGUAGE internal STABLE STRICT COST 1;
+/
+
+CREATE FUNCTION test_type_out(test_type) RETURNS cstring AS
+'record_out' LANGUAGE internal STABLE STRICT COST 1;
+/
+
+CREATE TYPE test_type(INPUT=test_type_in, OUTPUT=test_type_out);
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V1__comment.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V1__comment.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ CREATE TABLE table1 (
+  name VARCHAR(25) NOT NULL, --' first
+  PRIMARY KEY(name)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V2__type_with_comment.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V2__type_with_comment.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+  CREATE OR REPLACE TYPE PERSON_WITH_COMMENT as object
+( person_id number (15),
+  sex       number (1),  ---'1' male, '0' female
+  balance   number (10,2)
+
+);
+
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V3__type_without_comment.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/comment/V3__type_without_comment.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+  CREATE OR REPLACE TYPE PERSON_WITHOUT_COMMENT as object
+( person_id number (15),
+  sex       number (1),
+  balance   number (10,2)
+
+);
+
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/copy/V002__create_copy_test_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/copy/V002__create_copy_test_table.sql
@@ -1,0 +1,64 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: copy_test; Type: TABLE; Schema: public; Owner: arnd; Tablespace: 
+--
+
+CREATE TABLE copy_test (
+    c1 integer NOT NULL,
+    c2 character varying,
+    c3 double precision
+);
+
+--
+-- Name: copy_test_c1_seq; Type: SEQUENCE; Schema: public; Owner: arnd
+--
+
+CREATE SEQUENCE copy_test_c1_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: c1; Type: DEFAULT; Schema: public; Owner: arnd
+--
+
+ALTER TABLE ONLY copy_test ALTER COLUMN c1 SET DEFAULT nextval('copy_test_c1_seq'::regclass);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/copy/V003__fill_copy_test_table_with_copy.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/copy/V003__fill_copy_test_table_with_copy.sql
@@ -1,0 +1,57 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Data for Name: copy_test; Type: TABLE DATA; Schema: public; Owner: arnd
+--
+
+COPY copy_test (c1, c2, c3) FROM stdin;
+1	utf8: ümlaute: äüß	NaN
+2	\N	123
+3	text	123.234444444444449
+\.
+
+COPY copy_test (c1, c2, c3)
+  FROM stdin;
+4	utf8: ümlaute: äüß	NaN
+5	\N	123
+6	text	123.234444444444449
+\.
+
+
+--
+-- Name: copy_test_c1_seq; Type: SEQUENCE SET; Schema: public; Owner: arnd
+--
+
+SELECT pg_catalog.setval('copy_test_c1_seq', 3, true);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/count/V1__count.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/count/V1__count.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+create table employees ( i int, name varchar2(10), instime date);
+-- sample file has 1 create stmt, 3 insert stmts, 2 update stmts , 1 delete stmts
+
+insert into employees values (1, 'test1', sysdate);
+insert into employees values (2, 'test2', sysdate);
+insert into employees values (3, 'test3', sysdate);
+update employees set i=4 where name='test3';
+update employees set i=5 where name='test1';
+delete from employees where i=2;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/dollar/V1__Dollar.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/dollar/V1__Dollar.sql
@@ -1,0 +1,46 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE dollar (str VARCHAR(100));
+
+INSERT INTO dollar VALUES($$Hello 'quotes']$$);
+INSERT INTO dollar VALUES($abc$Hello 'quotes' and $'s$abc$);
+INSERT INTO dollar VALUES($$Hello ''quotes'$$);
+INSERT INTO dollar VALUES($$Hello $quotes$ $$);
+INSERT INTO dollar VALUES($abc$Hello $$quotes$$ $abc$);
+
+INSERT INTO dollar VALUES($$Hello '
+multi-line
+quotes;
+'$$);
+
+INSERT INTO dollar VALUES($$Hello
+multi-line
+quotes;
+$$);
+
+INSERT INTO dollar VALUES($abc$Hello ';
+multi-line;
+quotes;
+$abc$);
+
+INSERT INTO dollar VALUES(
+$abc$
+Hello ;
+multi-line;
+quotes;
+$abc$
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/dollar/V2__Even_more_dollars.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/dollar/V2__Even_more_dollars.sql
@@ -1,0 +1,32 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+do $$
+begin
+	raise notice 'hello world';
+end
+$$;
+
+do '
+begin
+	raise notice ''hello world'';
+end';
+
+do language plpgsql $$
+begin
+	raise notice 'hello world';
+end
+$$;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/domain/V1__Domain.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/domain/V1__Domain.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE DOMAIN dom as VARCHAR(64);
+CREATE TABLE t (x dom);
+INSERT INTO T VALUES ('foo');

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/enum/V1__Enum.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/enum/V1__Enum.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TYPE rating AS ENUM('positive', 'negative');
+CREATE TABLE t (x rating);
+INSERT INTO T VALUES ('positive');

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/function/V1__Function.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/function/V1__Function.sql
@@ -1,0 +1,51 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    LANGUAGE sql IMMUTABLE STRICT
+    AS $_$
+    select $1 + $2;
+$_$;
+
+CREATE OR REPLACE FUNCTION EVAL (EXPR VARCHAR2) RETURN VARCHAR2
+AS
+ RET VARCHAR2(4000);
+ BEGIN
+  EXECUTE IMMEDIATE 'BEGIN :RESULT := ' || EXPR || '; END;' USING OUT RET;
+  RETURN RET;
+ END;
+/
+
+create or replace procedure selectdata is
+  v_number number;
+  begin
+    select 1 into v_number from dual;
+    dbms_output.put_line('var>'||v_number);
+  end;
+/
+
+CALL selectdata();
+
+CREATE OR REPLACE PROCEDURE remove_emp (employee_id NUMBER) AS
+   tot_emps NUMBER;
+   BEGIN
+      DELETE FROM employees
+      WHERE employees.employee_id = remove_emp.employee_id;
+   tot_emps := tot_emps - 1;
+   END;
+/
+COMMIT;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/function/V2__FunctionWithConditionals.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/function/V2__FunctionWithConditionals.sql
@@ -1,0 +1,43 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+CREATE OR REPLACE Function IncomeLevel
+     ( monthly_value IN number(6) )
+     RETURN varchar2
+IS
+     ILevel varchar2(20);
+
+BEGIN
+
+  IF monthly_value <= 4000 THEN  /* for the poor */
+     ILevel := 'Low Income';
+
+  ELSIF monthly_value > 4000 and/*and weekly_value*/monthly_value <= 7000 THEN /* for the middle class */
+     ILevel := 'Avg Income';
+
+  ELSIF monthly_value > 7000 and/* / */ monthly_value <= 15000 THEN /* for the well-off */
+     ILevel := 'Moderate Income';
+
+  ELSE /* for the rich */
+     ILevel := 'High Income';
+
+  END IF;
+
+  RETURN ILevel;
+
+END;
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/inheritance/V1__Inheritance.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/inheritance/V1__Inheritance.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int     -- in feet
+);
+
+CREATE TABLE cities_capitals (
+    state           char(2)
+) INHERITS (cities);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/iot/V1__IndexOrganizedTable.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/iot/V1__IndexOrganizedTable.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE network_device_day_start_state
+(   segment_Id          INTEGER DEFAULT 1 NOT NULL,
+    day                 TIMESTAMP,
+    net_device_id       INTEGER,
+    uiq_device_state_id INTEGER,
+    PRIMARY KEY (day, net_device_id));

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/lock/V2__dummy.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/lock/V2__dummy.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+/*
+  We need this dummy migration for the test because it ensures that table SCHEMA_VERSION has been created and committed
+  when the lock test is done in next migration file
+*/
+SELECT 1;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/lock/V3__lock.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/lock/V3__lock.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ANALYZE;
+
+/*
+  ANALYZE is just an example. Depending on the LOCK MODE other SQL commands trying to access
+  SCHEMA_VERSION can also create the problem. Other example:
+  SELECT * FROM SCHEMA_VERSION;
+  hangs when lock mode is ACCESS EXCLUSIVE (the most restrictive one)
+*/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/materialized/V1__MaterializedView.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/materialized/V1__MaterializedView.sql
@@ -1,0 +1,37 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE MATERIALIZED VIEW v_dwh_dim_date_mat AS select now();
+
+CREATE MATERIALIZED VIEW """v_dwh_dim_date_mat2""" AS select now();
+
+CREATE OR REPLACE VIEW v_dwh_dim_date AS SELECT * from v_dwh_dim_date_mat;
+
+CREATE TABLE test_user (
+  id INT NOT NULL,
+  name VARCHAR(25) NOT NULL,
+  PRIMARY KEY(name)
+);
+
+CREATE MATERIALIZED VIEW user_data REFRESH COMPLETE
+   AS SELECT * FROM test_user;
+
+CREATE MATERIALIZED VIEW log BUILD IMMEDIATE
+   AS SELECT * FROM test_user;
+
+CREATE MATERIALIZED VIEW more_user_data BUILD IMMEDIATE
+   REFRESH ON DEMAND
+   AS SELECT * FROM test_user;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/multiline/V1__MultiLine.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/multiline/V1__MultiLine.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE address (
+    id bigint NOT NULL,
+    address character varying(256) NOT NULL
+);
+
+INSERT INTO address VALUES (1, '1. first
+2. second');
+
+COMMENT ON COLUMN address.address IS 'ATIVO = 1;
+CONCLUIDO = 2;
+CANCELADO = 0;';
+

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/objectnames/V1__ObjectNames.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/objectnames/V1__ObjectNames.sql
@@ -1,0 +1,119 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--
+-- TT FUNCTION
+--
+CREATE TABLE TT_FUNCTION
+(
+   CODE            VARCHAR(10) NOT NULL,
+   LANG            VARCHAR(10) NOT NULL,
+   TEXT_SHORT      VARCHAR(20),
+   TEXT_LONG       VARCHAR(80),
+   VALID_FROM      DATE NOT NULL,
+   VALID_TO        DATE NOT NULL,
+   CREATED         DATE NOT NULL,
+   INVALIDATED     DATE,
+   CREATED_BY      VARCHAR(32) NOT NULL,
+   INVALIDATED_BY  VARCHAR(32) NOT NULL,
+   PRIMARY KEY (CODE, LANG)
+);
+
+CREATE OR REPLACE VIEW V_TT_FUNCTION
+(
+   CODE,
+   LANG,
+   TEXT_SHORT,
+   TEXT_LONG,
+   VALID_FROM,
+   VALID_TO,
+   CREATED,
+   INVALIDATED,
+   CREATED_BY,
+   INVALIDATED_BY
+)
+AS SELECT
+   CODE,
+   LANG,
+   TEXT_SHORT,
+   TEXT_LONG,
+   VALID_FROM,
+   VALID_TO,
+   CREATED,
+   INVALIDATED,
+   CREATED_BY,
+   INVALIDATED_BY
+FROM
+   TT_FUNCTION
+;
+
+--
+-- TT SOME_KV_PACKAGE
+--
+CREATE TABLE TT_SOME_KV_PACKAGE
+(
+   CODE            VARCHAR(10) NOT NULL,
+   LANG            VARCHAR(10) NOT NULL,
+   TEXT_SHORT      VARCHAR(20),
+   TEXT_LONG       VARCHAR(80),
+   VALID_FROM      DATE NOT NULL,
+   VALID_TO        DATE NOT NULL,
+   CREATED         DATE NOT NULL,
+   INVALIDATED     DATE,
+   CREATED_BY      VARCHAR(32) NOT NULL,
+   INVALIDATED_BY  VARCHAR(32) NOT NULL,
+   PRIMARY KEY (CODE, LANG)
+);
+
+CREATE OR REPLACE VIEW V_TT_SOME_KV_PACKAGE
+(
+   CODE,
+   LANG,
+   TEXT_SHORT,
+   TEXT_LONG,
+   VALID_FROM,
+   VALID_TO,
+   CREATED,
+   INVALIDATED,
+   CREATED_BY,
+   INVALIDATED_BY
+)
+AS SELECT
+   CODE,
+   LANG,
+   TEXT_SHORT,
+   TEXT_LONG,
+   VALID_FROM,
+   VALID_TO,
+   CREATED,
+   INVALIDATED,
+   CREATED_BY,
+   INVALIDATED_BY
+FROM
+   TT_SOME_KV_PACKAGE
+;
+
+CREATE TABLE PURCHASEPROCEDURE (
+id NUMBER(18),
+name VARCHAR2(100));
+
+CREATE TABLE Action (
+  Id NUMBER(11, 0) NOT NULL,
+  Application VARCHAR2(64),
+  Module VARCHAR2(64),
+  Function VARCHAR2(64),
+  Action VARCHAR2(64)
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/V1__Package.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/V1__Package.sql
@@ -1,0 +1,50 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE OR REPLACE PACKAGE emp_actions AS  -- spec
+   TYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);
+   PROCEDURE hire_employee (
+      ename  VARCHAR2,
+      job    VARCHAR2,
+      mgr    NUMBER,
+      sal    NUMBER,
+      comm   NUMBER,
+      deptno NUMBER);
+   PROCEDURE fire_employee (emp_id NUMBER);
+END emp_actions;
+/
+
+CREATE OR REPLACE PACKAGE BODY emp_actions AS  -- body
+   CURSOR desc_salary IS
+      SELECT empno, sal FROM emp ORDER BY sal DESC;
+   PROCEDURE hire_employee (
+      ename  VARCHAR2,
+      job    VARCHAR2,
+      mgr    NUMBER,
+      sal    NUMBER,
+      comm   NUMBER,
+      deptno NUMBER) IS
+   BEGIN
+      INSERT INTO emp VALUES (empno_seq.NEXTVAL, ename, job,
+         mgr, SYSDATE, sal, comm, deptno);
+   END hire_employee;
+
+   PROCEDURE fire_employee (emp_id NUMBER) IS
+   BEGIN
+      DELETE FROM emp WHERE empno = emp_id;
+   END fire_employee;
+END emp_actions;
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/V2__PackageBody.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/V2__PackageBody.sql
@@ -1,0 +1,437 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE PRJ_IMPORTTABLES_CONFIG (
+  TABLE_REALNAME VARCHAR2(50) NOT NULL,
+  TABLE_SYNONYMNAME VARCHAR2(50) NOT NULL,
+  VERSION_NUMBER NUMBER(4) NOT NULL,
+  JOBNAME VARCHAR2(40) NOT NULL,
+  ACTIVE_FLG NUMBER(1) NOT NULL,
+  INSERTED_AT DATE NOT NULL,
+  INSERTED_BY VARCHAR2(30) NOT NULL,
+  UPDATED_AT DATE,
+  UPDATED_BY VARCHAR2(30)
+ );
+
+COMMENT ON TABLE PRJ_IMPORTTABLES_CONFIG IS 'Stores configuration details which are required for import process of PRJ tables from DWH into PRJDB';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.TABLE_REALNAME IS 'Real name of PRJ-table in database';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.TABLE_SYNONYMNAME IS 'Synonym the application is using for table access';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.VERSION_NUMBER IS 'Version number';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.JOBNAME IS 'Name of import job which is loading data into table';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.ACTIVE_FLG IS 'Flag which table is active (synonym points to): 1 = active; 0 = incative; (only one "active record" per synonym is allowed)';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.INSERTED_AT IS 'Date and time when data were inserted';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.INSERTED_BY IS 'Name of user who inserted data';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.UPDATED_AT IS 'Date and time when data were changed';
+COMMENT ON COLUMN PRJ_IMPORTTABLES_CONFIG.UPDATED_BY IS 'Name of user or process changing data';
+
+
+--
+-- Non Foreign Key Constraints for Table PRJ_IMPORTTABLES_CONFIG
+--
+ALTER TABLE PRJ_IMPORTTABLES_CONFIG ADD
+  CONSTRAINT PRJ_ITC_PK PRIMARY KEY (TABLE_REALNAME);
+
+
+--
+-- Non Foreign Key Constraints for Table PRJ_IMPORTTABLES_CONFIG
+--
+ALTER TABLE PRJ_IMPORTTABLES_CONFIG ADD
+  CONSTRAINT PRJ_ITC_ACTIVE_FLG_CON CHECK (ACTIVE_FLG IN (0,1));
+
+
+--
+-- Create Index
+--
+CREATE UNIQUE INDEX PRJ_ITC_ACTFLG_TABSYN_UI ON PRJ_IMPORTTABLES_CONFIG
+(DECODE (ACTIVE_FLG, 1, TABLE_SYNONYMNAME, NULL));
+
+
+--
+-- Create Table
+--
+CREATE TABLE PRJ_IMPORTJOB_LOG
+(
+  IMPORTJOBLOG_ID NUMBER(11) NOT NULL,
+  JOBNAME VARCHAR2(40) NOT NULL,
+  IMPORTFILE VARCHAR2(50) NOT NULL,
+  TABLENAME VARCHAR2(50) NOT NULL,
+  TOTAL_OF_RECORDS NUMBER(9) NOT NULL,
+  SYNONYM_SWITCHED_FLG NUMBER(1) NOT NULL,
+  IMPORT_STATUS NUMBER(2) NOT NULL,
+  IMPORTED_AT DATE NOT NULL,
+  IMPORTED_BY VARCHAR2(30) NOT NULL,
+  PROCESSED_AT DATE,
+  PROCESSED_BY VARCHAR2(30)
+);
+
+COMMENT ON TABLE PRJ_IMPORTJOB_LOG IS 'In this table all import job for PRJ tables are logged';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.IMPORTJOBLOG_ID IS 'Importjoblog_ID: Primary Key';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.JOBNAME IS 'Name of importjob';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.IMPORTFILE IS 'Name of imported file';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.TOTAL_OF_RECORDS IS 'Total of records contained in the importfile';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.SYNONYM_SWITCHED_FLG IS 'Flag indicating if synonym for table was switched: 0 = not switched; 1 = switched;';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.IMPORT_STATUS IS 'Status of import: 0 = Job processing not started; 99 = Job processing succesfully ended; -99 = Job processing failed';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.IMPORTED_AT IS 'Date of import';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.IMPORTED_BY IS 'Who started the importjob';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.PROCESSED_AT IS 'Date when job is processed';
+COMMENT ON COLUMN PRJ_IMPORTJOB_LOG.PROCESSED_BY IS 'Who processed the job';
+
+
+--
+-- Non Foreign Key Constraints for Table PRJ_IMPORTJOB_LOG
+--
+ALTER TABLE PRJ_IMPORTJOB_LOG ADD
+  CONSTRAINT PRJ_IJL_PK PRIMARY KEY
+ (IMPORTJOBLOG_ID);
+
+
+--
+-- Non Foreign Key Constraints for Table PRJ_IMPORTJOB_LOG
+--
+ALTER TABLE PRJ_IMPORTJOB_LOG ADD
+  CONSTRAINT PRJ_IJL_SYN_SWITCHED_FLG_CON CHECK (SYNONYM_SWITCHED_FLG IN (0,1));
+
+
+--
+-- Non Foreign Key Constraints for Table PRJ_IMPORTJOB_LOG
+--
+ALTER TABLE PRJ_IMPORTJOB_LOG ADD
+  CONSTRAINT PRJ_IJL_IMPORT_STATUS_CON CHECK (IMPORT_STATUS IN (0,-99,99));
+
+
+--
+-- Create Package
+--
+CREATE OR REPLACE PACKAGE PRJ_UTIL AS
+
+/**
+*/
+
+
+/*
+********************************************************************************
+** EXCEPTION definitions
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** TYPE AND SUBTYPE definitions
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** CONSTANT definitions
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** PROCEDURE and FUNCTION specifications
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** PROCEDURE and FUNCTION specifications
+********************************************************************************
+*/
+  /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  FUNCTION GetNextInactiveTable(picImpJob IN VARCHAR2)
+     RETURN VARCHAR2;
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE TruncateImportTable (picTableName IN VARCHAR2);
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE InsertLogTable ( pinImportJobLogID IN PRJ_importjob_log.importjoblog_id%TYPE,
+                             picJobName        IN PRJ_importjob_log.jobname%TYPE,
+                             picImportFile     IN PRJ_importjob_log.importfile%TYPE,
+                             picTableName      IN PRJ_importjob_log.tablename%TYPE,
+                             pinTotalOfRecords IN PRJ_importjob_log.total_of_records%TYPE,
+                             picImportedBy     IN PRJ_importjob_log.imported_by%TYPE);
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE ProcessAllImportJobs;
+
+ /**
+  */
+  PROCEDURE CheckImportJob(pinImpJobID  IN NUMBER
+                          ,pobValid     OUT BOOLEAN
+                          ,pocTableName OUT VARCHAR2);
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE ProcessSingleImportJob(pinImpJobID IN NUMBER) ;
+END PRJ_UTIL;
+/
+
+CREATE OR REPLACE PACKAGE BODY PRJ_UTIL AS
+/**
+*/
+
+
+/*
+********************************************************************************
+** Global Variables
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** Private CONSTANTs
+********************************************************************************
+*/
+
+/*
+********************************************************************************
+** Private PROCEDUREs and FUNCTIONs
+********************************************************************************
+*/
+
+
+
+/*
+********************************************************************************
+** Public PROCEDUREs and FUNCTIONs
+********************************************************************************
+*/
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  FUNCTION GetNextInactiveTable(picImpJob IN VARCHAR2) RETURN VARCHAR2 IS
+      vcTableName     PRJ_importtables_config.table_realname%TYPE;
+      vcActiveVersion PRJ_importtables_config.version_number%TYPE;
+  BEGIN
+        -- Get active version
+        SELECT version_number
+          INTO vcActiveVersion
+          FROM PRJ_importtables_config
+         WHERE jobname = picImpJob
+           AND active_flg = 1;
+        -- Get name of inactive table
+        BEGIN
+            -- Select name of inactive with proximate version number
+            SELECT cic1.table_realname
+              INTO vcTableName
+              FROM PRJ_importtables_config cic1
+             WHERE cic1.jobname = picImpJob
+               AND cic1.version_number = (SELECT MIN(cic2.version_number)
+                                            FROM PRJ_importtables_config cic2
+                                           WHERE cic2.version_number > vcActiveVersion
+                                             AND cic2.jobname = picImpJob);
+        EXCEPTION WHEN NO_DATA_FOUND THEN
+            -- active version is highest version number => get tablename with minimum version number
+            SELECT cic1.table_realname
+              INTO vcTableName
+              FROM PRJ_importtables_config cic1
+             WHERE cic1.jobname = picImpJob
+               AND cic1.version_number = (SELECT MIN(cic2.version_number)
+                                            FROM PRJ_importtables_config cic2
+                                           WHERE cic2.active_flg <> 1
+                                             AND cic2.jobname = picImpJob);
+        END;
+        -- Return name of table
+        RETURN vcTableName;
+  END GetNextInactiveTable;
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+
+  PROCEDURE TruncateImportTable (picTableName IN VARCHAR2) IS
+      vcSQL          VARCHAR2(4000);
+  BEGIN
+      -- Truncate given table
+      vcSQL := 'TRUNCATE  TABLE '||picTableName;
+      EXECUTE IMMEDIATE vcSQL;
+  END TruncateImportTable;
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE InsertLogTable ( pinImportJobLogID IN PRJ_importjob_log.importjoblog_id%TYPE,
+                             picJobName        IN PRJ_importjob_log.jobname%TYPE,
+                             picImportFile     IN PRJ_importjob_log.importfile%TYPE,
+                             picTableName      IN PRJ_importjob_log.tablename%TYPE,
+                             pinTotalOfRecords IN PRJ_importjob_log.total_of_records%TYPE,
+                             picImportedBy     IN PRJ_importjob_log.imported_by%TYPE) IS
+  BEGIN
+      -- Insert into table PRJ_IMPORTJOB_LOG
+      INSERT
+        INTO PRJ_importjob_log
+           ( importjoblog_id, jobname, importfile, tablename, total_of_records, synonym_switched_flg
+            ,import_status, imported_at, imported_by)
+      VALUES
+           ( pinImportJobLogID, picJobName, picImportFile, picTableName, pinTotalOfRecords, 0
+            ,0, SYSDATE, picImportedBy);
+      -- Commit insert
+      COMMIT;
+      --
+  END InsertLogTable;
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE ProcessAllImportJobs IS
+        CURSOR curImpJobLMS IS
+            SELECT importjoblog_id
+              FROM PRJ_importjob_log
+             WHERE import_status = 0
+             ORDER BY importjoblog_id ASC;
+  BEGIN
+      -- Process all new import jobs
+      FOR recImpJobLMS IN curImpJobLMS
+      LOOP
+          ProcessSingleImportJob(recImpJobLMS.importjoblog_id);
+      END LOOP;
+  END ProcessAllImportJobs;
+
+ /**
+  ********************************************************************************
+  ********************************************************************************
+  */
+  PROCEDURE CheckImportJob(pinImpJobID  IN NUMBER
+                          ,pobValid     OUT BOOLEAN
+                          ,pocTableName OUT VARCHAR2) IS
+      vcTableName             PRJ_importjob_log.tablename%TYPE;
+      vnTotalOfRecords        PRJ_importjob_log.total_of_records%TYPE;
+      vnCountRecords          PRJ_importjob_log.total_of_records%TYPE;
+      vnImportStatus          PRJ_importjob_log.import_status%TYPE;
+      vnSynonymSwitchedFlg    PRJ_importjob_log.synonym_switched_flg%TYPE;
+      vbValid                 BOOLEAN;
+      vcSQL                   VARCHAR2(4000);
+      -- cursor to find indexes of loaded tables
+      CURSOR curIndex(picTableName IN PRJ_importjob_log.tablename%TYPE) IS
+          SELECT index_name
+            FROM user_indexes
+           WHERE table_name = picTableName
+             AND status != 'VALID';
+  BEGIN
+      -- Check if Importjob ID was provided
+      IF pinImpJobID IS NULL THEN
+          RAISE_APPLICATION_ERROR (-20001, 'Mandatory input parameter pinImpJobID is NULL') ;
+      END IF;
+      -- Get tablename and number of imported records from log table
+      BEGIN
+          SELECT tablename, total_of_records, import_status, synonym_switched_flg
+            INTO vcTableName, vnTotalOfRecords , vnImportStatus, vnSynonymSwitchedFlg
+            FROM PRJ_importjob_log
+           WHERE importjoblog_id = pinImpJobID;
+      EXCEPTION
+          -- If import record not found return
+          WHEN NO_DATA_FOUND THEN
+              RAISE_APPLICATION_ERROR (-20002, 'No log record found for pinImpJobID=['||pinImpJobID||'] ');
+      END;
+      --  Check if record has correct status
+      IF vnImportStatus <> 0 THEN
+          RAISE_APPLICATION_ERROR (/*test*/-20003, 'Import job pinImpJobID=['||pinImpJobID||'] has wrong status ['||vnImportStatus||'] ');
+      END IF;
+      -- #6469 Check for unusable indexes and recreate
+      FOR recIndex IN curIndex(vcTableName)
+      LOOP
+          EXECUTE IMMEDIATE 'ALTER INDEX '|| recIndex.index_name ||' REBUILD NOLOGGING';
+      END LOOP;
+      -- Determine total number of records in imported table
+      vcSQL := 'SELECT count(*) FROM '||vcTableName;
+      EXECUTE IMMEDIATE vcSQL
+         INTO vnCountRecords;
+      -- Compare number of records to check import process
+      IF vnCountRecords <> vnTotalOfRecords THEN
+          pobValid := FALSE;
+          -- Import was not successful: update log table for import failure
+          UPDATE PRJ_importjob_log
+             SET import_status = -99
+                 ,processed_at = SYSDATE
+                 ,processed_by = USER
+           WHERE importjoblog_id = pinImpJobID;
+      ELSE
+          pobValid := TRUE;
+      END IF;
+      -- Give the table name back
+      pocTableName := vcTableName;
+  END CheckImportJob;
+
+ /**
+  ********************************************************************************
+
+  ********************************************************************************
+  */
+  PROCEDURE ProcessSingleImportJob(pinImpJobID IN NUMBER) IS
+      vcTableName             PRJ_importjob_log.tablename%TYPE;
+      vbSwitchSynonymFlg      BOOLEAN;
+      vcSynonymName           PRJ_importtables_config.table_synonymname%TYPE;
+      vcSQL                   VARCHAR2(4000);
+  BEGIN
+      CheckImportJob(pinImpJobID  => pinImpJobID
+                    ,pobValid     => vbSwitchSynonymFlg
+                    ,pocTableName => vcTableName);
+      -- Switch synonym and update table PRJ_importtables_config
+      IF vbSwitchSynonymFlg THEN
+          -- Determine synonym
+          SELECT table_synonymname
+            INTO vcSynonymName
+            FROM PRJ_importtables_config
+           WHERE table_realname = vcTableName;
+          -- Switch synonym
+          vcSQL := 'CREATE OR REPLACE SYNONYM '||vcSynonymName||' FOR '||vcTableName;
+          EXECUTE IMMEDIATE vcSQL;
+          -- Update table PRJ_importtables_config
+          UPDATE PRJ_importtables_config
+             SET active_flg = 0
+                 ,updated_at = SYSDATE
+                 ,updated_by = USER
+           WHERE table_synonymname = vcSynonymName
+             AND active_flg = 1;
+          UPDATE PRJ_importtables_config
+             SET active_flg = 1
+                 ,updated_at = SYSDATE
+                 ,updated_by = USER
+           WHERE table_realname = vcTableName;
+          -- Update table PRJ_importjob_log
+          UPDATE PRJ_importjob_log
+             SET import_status = 99
+                 ,synonym_switched_flg = 1
+                 ,processed_at = SYSDATE
+                 ,processed_by = USER
+           WHERE importjoblog_id = pinImpJobID;
+      END IF;
+      -- Commit work
+      COMMIT;
+  END ProcessSingleImportJob;
+END PRJ_UTIL;
+/
+

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/~V3__ComplexComments.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/package/~V3__ComplexComments.sql
@@ -1,0 +1,95 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+create or replace
+PACKAGE AgingUtils
+IS
+  /* ----------------------------------
+  NAME
+  AgingUtils - create / drop partitions.
+
+  DESCRIPTION
+
+  NOTES
+  load_defaults - procedure with default ranges.
+  Below prefixTsName. All tablespaces will have name started with this prefix.
+
+  Important:
+  Fixes for NETRO schema.
+	Run output from those queries.
+SQL> select 'alter table '||table_name||' rename partition '||partition_name||' to '||replace(partition_name,'GG','G')||';' from user_tab_partitions where partition_name like '%GG%';
+SQL> select 'alter index '||index_name||' rename partition '||partition_name||' to '||replace(partition_name,'GG','G')||';' from user_ind_partitions where partition_name like '%GG%';
+----------------------------------  */
+
+prefixTsName VARCHAR2(10) DEFAULT 'TNF';
+versionString VARCHAR2(10) DEFAULT '5.12';
+
+TYPE tp_prop IS TABLE OF VARCHAR2(5) INDEX BY VARCHAR2(100);
+
+function version return varchar2;
+
+/**----------------------------------
+  Add partition for table with p_date date
+  INPUT VALUE:
+  p_table_name : Table Name
+  p_date:      Date for partition
+  RETURN CODE:
+  0 - success
+  Number   - ORA error
+  */
+
+FUNCTION add_partition_for_table (
+    p_table_name VARCHAR2,
+    p_date NUMBER )
+  RETURN NUMBER;
+
+END AgingUtils;
+/
+
+create or replace
+PACKAGE BODY AgingUtils
+IS
+
+/* VERSION 5.11 */
+/*
+edbplus ctr/ctr@'(DESCRIPTION = (ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)(HOST = 172.30.2.35)(PORT = 1521))) ( CONNECT_DATA = (SERVICE_NAME = vero)))'
+*/
+procedure load_defaults (prop OUT tp_prop)
+IS
+  properties tp_prop;
+BEGIN
+      properties('persistence.aggregation.range.M') :=  'M';
+      properties('persistence.aggregation.range.W') :=  'W';
+      properties('persistence.aggregation.range.D') := 'D';
+      properties('persistence.aggregation.range.H') := 'D';
+      properties('persistence.aggregation.range.MIN') :=  'D';
+  ---    properties('persistence.aggregation.range.15') :=  'D';
+  ---    properties('persistence.aggregation.range.01') :=  'D';
+  ---    properties('persistence.aggregation.range.F_SESSION_CHUNK') :=  'D';
+  prop := properties;
+end;
+
+/**
+*/
+function version return varchar2
+is
+begin
+  return versionString;
+end;
+
+-- more procedures and functions here ...
+END AgingUtils;
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/placeholders/V1_1__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/placeholders/V1_1__Populate_table.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+INSERT INTO ${tableName} (name) VALUES ('Mr. T');

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/placeholders/V1__Placeholders.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/placeholders/V1__Placeholders.sql
@@ -1,0 +1,32 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+/* Single line comment */
+CREATE TABLE test_user (
+  name VARCHAR(25) NOT NULL,
+  PRIMARY KEY(name)
+);
+
+/*
+Multi-line
+comment
+*/
+CREATE TRIGGER test_trig AFTER insert ON test_user
+BEGIN
+    UPDATE test_user SET name = CONCAT(name, ' triggered');
+END;
+/
+COMMIT;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/procedure/V1__Procedure.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/procedure/V1__Procedure.sql
@@ -1,0 +1,487 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE test_data (
+  value/*test*/ /*test*/VARCHAR(25) NOT NULL PRIMARY KEY
+);
+
+CREATE FUNCTION AddData() RETURNS INTEGER
+AS $$
+    BEGIN
+     INSERT INTO test_data (value) VALUES ('Hello');
+     RETURN 1;
+   END;
+ $$ LANGUAGE plpgsql;
+
+SELECT *  INTO TEMP adddata_temp_table FROM AddData() ;
+
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    LANGUAGE sql/*test*/ IMMUTABLE STRICT
+    AS $_$select $1 + $2;$_$;
+
+CREATE FUNCTION """add2"""(integer, integer) RETURNS integer
+    LANGUAGE sql/*test*/ IMMUTABLE STRICT
+    AS $_$select $1 + $2;$_$;
+
+CREATE FUNCTION inc(i integer) RETURNS VARCHAR(25)
+    LANGUAGE sql
+    AS $$SELECT * FROM test_data$$;
+/
+
+create table sectors (
+  id numeric,
+  name varchar(500)
+);
+create table sub_sectors (
+  id numeric,
+  name varchar(500),
+  sector_id numeric
+);
+create table firms (
+  id numeric,
+  firm_name varchar(500)
+);
+create table firm_ratings (
+  id numeric,
+  name varchar(500),
+  scheme_id numeric
+);
+create table firm_rating_schemes (
+  id numeric,
+  name varchar(500),
+  firm_id numeric
+);
+create table countries (
+  id numeric,
+  name varchar(500)
+);
+create table portfolios (
+  id numeric,
+  pf_name varchar(500),
+  sub_sector_id numeric,
+  country_id numeric,
+  data_file_id numeric,
+  scheme_id numeric,
+  initial_bal numeric,
+  bus_unit varchar(500),
+  currency varchar(25),
+  asset_class varchar(50)
+);
+create table firm_subportfolios (
+  id numeric,
+  name varchar(500),
+  approach varchar(250),
+  maturity_dt timestamp,
+  db numeric,
+  ead numeric,
+  rwa numeric,
+  pd numeric,
+  lgd numeric,
+  el numeric
+);
+create table scenarios (
+  id numeric,
+  name varchar(500)
+);
+create table firm_data_files (
+  id numeric,
+  name varchar(500)
+);
+create table risk_parameters (
+  id numeric,
+  name varchar(500)
+);
+create table rparam_types (
+  id numeric,
+  scope varchar(500),
+  name varchar(500)
+);
+create table rparam_values (
+  id numeric,
+  value varchar(500)
+);
+create table rparam_dim_values (
+  param_id numeric,
+  dim_axis numeric,
+  dim_order numeric
+);
+
+create or replace
+procedure id_for_sub_sector (
+      p_sub_sector_name in sub_sectors.name%type,
+      p_sub_sector_id out sub_sectors.id%type) as
+   begin
+      select id
+        into p_sub_sector_id
+        from sub_sectors
+        where name = p_sub_sector_name;
+   exception when NO_DATA_FOUND then
+      insert into sub_sectors (id, name)
+      values (sub_sectors_seq.nextval, p_sub_sector_name) returning id into p_sub_sector_id;
+   end id_for_sub_sector;
+/
+
+set define off;
+
+create or replace
+procedure id_for_sector (
+      p_sector_name in sectors.name%type,
+      p_sector_id out sectors.id%type) as
+   begin
+      select id
+        into p_sector_id
+        from sectors
+        where name = p_sector_name;
+   exception when NO_DATA_FOUND then
+      insert into sectors (id, name)
+      values (sectors_seq.nextval, p_sector_name) returning id into p_sector_id;
+   end id_for_sector;
+/
+
+create or replace
+procedure id_for_rating (
+      p_scheme_id in firm_rating_schemes.id%type,
+      p_firm_rating_name in firm_ratings.name%type,
+      p_rating_id out firm_ratings.id%type) as
+   begin
+      select id
+        into p_rating_id
+        from firm_ratings
+        where name = p_firm_rating_name
+        and scheme_id = p_scheme_id;
+   exception when NO_DATA_FOUND then
+      insert into firm_ratings (id, scheme_id, name, rating_order, credit_grade_id)
+      values (firm_ratings_seq.nextval, p_scheme_id, p_firm_rating_name, 0, 1) returning id into p_rating_id;
+   end id_for_rating;
+/
+
+create or replace
+procedure id_for_rating_scheme (
+      p_scheme_name in firm_rating_schemes.name%type,
+      p_firm_id in firms.id%type,
+      p_scheme_id out firm_ratings.id%type) as
+   begin
+      select id
+        into p_scheme_id
+        from firm_rating_schemes
+        where name = p_scheme_name
+        and firm_id = p_firm_id;
+   exception when NO_DATA_FOUND then
+      insert into firm_rating_schemes (id, firm_id, name)
+      values (firm_rating_schemes_seq.nextval, p_firm_id, p_scheme_name) returning id into p_scheme_id;
+   end id_for_rating_scheme;
+/
+
+create or replace
+procedure id_for_risk_param_type (
+      p_type_name in rparam_types.name%type,
+      p_type_scope in rparam_types.scope%type,
+      p_type_id out rparam_types.id%type) as
+   begin
+      select id
+        into p_type_id
+        from rparam_types
+        where name = p_type_name
+        and scope = p_type_scope;
+   exception when NO_DATA_FOUND then
+      insert into rparam_types (id, name, family_id, scope)
+      values (rparam_types_seq.nextval, p_type_name, 0, p_type_scope) returning id into p_type_id;
+   end id_for_risk_param_type;
+   /
+
+create or replace
+procedure id_for_portfolio (
+      p_pf_name in portfolios.pf_name%type,
+      p_data_file_id in portfolios.data_file_id%type,
+      p_pf_id out portfolios.id%type) as
+   begin
+      select id
+        into p_pf_id
+        from portfolios
+        where pf_name = p_pf_name
+        and data_file_id = p_data_file_id;
+   exception when NO_DATA_FOUND then
+      insert into portfolios (id, pf_name, data_file_id, sub_sector_id)
+      values (portfolios_seq.nextval, p_pf_name, p_data_file_id, 0) returning id into p_pf_id;
+   end id_for_portfolio;
+   /
+
+create or replace
+procedure id_for_country (
+      p_country_name in countries.name%type,
+      p_country_id out countries.id%type) as
+   begin
+      select id
+        into p_country_id
+        from countries
+        where name = p_country_name;
+   exception when NO_DATA_FOUND then
+      insert into countries (id, code, name)
+      values (countries_seq.nextval, p_country_name, p_country_name) returning id into p_country_id;
+   end id_for_country;
+   /
+
+create or replace
+procedure id_for_firm (
+      p_firm_name in firms.firm_name%type,
+      p_firm_id out firms.id%type) as
+   begin
+      select id
+        into p_firm_id
+        from firms
+        where firm_name = p_firm_name;
+   exception when no_data_found then
+      insert into firms (id, firm_name)
+      values (firms_seq.nextval, p_firm_name) returning id into p_firm_id;
+   end id_for_firm;
+   /
+
+
+create or replace
+procedure id_for_sub_sector_and_sector (
+      p_sub_sector_name in sub_sectors.name%type,
+      p_sector_id in sectors.id%type,
+      p_sub_sector_id out sub_sectors.id%type) as
+   begin
+      select id
+        into p_sub_sector_id
+        from sub_sectors
+        where name = p_sub_sector_name
+        and sector_id = p_sector_id;
+   exception when NO_DATA_FOUND then
+      insert into sub_sectors (id, name, sector_id)
+      values (sub_sectors_seq.nextval, p_sub_sector_name, p_sector_id) returning id into p_sub_sector_id;
+   end id_for_sub_sector_and_sector;
+/
+
+CREATE OR REPLACE procedure add_portfolio (
+      p_name in portfolios.pf_name%type,
+      p_asset_class  in PORTFOLIOS.ASSET_CLASS%type,
+      p_data_file_id in firm_data_files.id%type,
+      p_country_name in countries.name%type,
+      p_sectorName in sectors.name%type,
+      p_subsectorname in sub_sectors.name%type,
+      p_firm_name in firms.firm_name%type,
+      p_firm_rating_scheme in firm_rating_schemes.name%type,
+      p_pf_id out portfolios.id%type) as
+   v_sector_id sectors.id%type;
+   v_firm_id firms.id%type;
+   v_sub_sector_id sectors.id%type;
+   v_country_id countries.id%type;
+   v_scheme_id firm_rating_schemes.id%type;
+   begin
+     id_for_firm (p_firm_name, v_firm_id);
+     id_for_rating_scheme (p_firm_rating_scheme, v_firm_id, v_scheme_id);
+     if p_country_name is not null then
+         id_for_country (p_country_name, v_country_id);
+     end if;
+     if p_sectorName is not null then
+         id_for_sector (p_sectorName, v_sector_id);
+     end if;
+     if p_subSectorName is not null then
+        id_for_sub_sector_and_sector (p_subSectorName, v_sector_id, v_sub_sector_id);
+     end if;
+    select id
+        into p_pf_id
+        from portfolios
+        where pf_name = p_name
+        and data_file_id = p_data_file_id
+        and country_id = v_country_id
+        and scheme_id = v_scheme_id
+        and sub_sector_id = v_sub_sector_id;
+   exception when no_data_found then
+     insert into portfolios(id, pf_name, asset_class,  data_file_id, country_id, sub_sector_id, scheme_id)
+             values (portfolios_seq.nextval, p_name, p_asset_class,  p_data_file_id, v_country_id, v_sub_sector_id, v_scheme_id) returning id into p_pf_id;
+end add_portfolio;
+/
+
+
+CREATE OR REPLACE PROCEDURE update_portfolio(
+    p_name in portfolios.pf_name%type,
+    p_product_type in portfolios.bus_unit%type,
+    p_currency  in PORTFOLIOS.currency%type,
+    p_initial_balance  in portfolios.initial_bal%type) as
+    --
+    v_pf_id portfolios.id%type;
+    --
+    cursor c1 is
+    select id
+    from portfolios
+    where pf_name = p_name
+    for update of bus_unit, currency, initial_bal;
+    --
+begin
+  open c1;
+  fetch c1 into v_pf_id;
+
+  if c1%notfound then raise no_data_found;
+  else
+    update  portfolios
+    set
+        bus_unit = p_product_type,
+        currency = p_currency  ,
+        initial_bal = p_initial_balance
+     where current of c1;
+  end if;
+  -- dbms_output.put_line('PROCEDURE update_portfolio : portfolio updated : ' || p_name  );
+exception
+    when no_data_found then
+        dbms_output.put_line('PROCEDURE update_portfolio : no portfolio found: ' || p_name  );
+        raise no_data_found;
+    WHEN OTHERS THEN
+       -- Consider logging the error and then re-raise
+        dbms_output.put_line('PROCEDURE update_portfolio : error in update to portfolio: ' || p_name  );
+       RAISE;
+END update_portfolio;
+/
+
+create or replace
+procedure add_rparam_value (
+      p_rparam_id in risk_parameters.id%type,
+      p_row_order in rparam_dim_values.dim_order%type,
+      p_col_order in rparam_dim_values.dim_order%type,
+      p_value in rparam_values.value%type) as
+   v_row_ref_id rparam_values.id%type;
+   v_col_ref_id rparam_values.id%type;
+ begin
+
+    select id
+        into v_row_ref_id
+        from rparam_dim_values
+        where param_id = p_rparam_id
+        and dim_axis = 0
+        and dim_order = p_row_order;
+    select id
+        into v_col_ref_id
+        from rparam_dim_values
+        where param_id = p_rparam_id
+        and dim_axis = 1
+        and dim_order = p_col_order;
+
+  insert into rparam_values(id, row_ref_id, col_ref_id, value) values (rparam_values_seq.nextval, v_row_ref_id, v_col_ref_id, p_value);
+
+end add_rparam_value;
+/
+
+create or replace
+procedure add_risk_parameter (
+      p_scenario_id in scenarios.id%type,
+      p_name in risk_parameters.name%type,
+      p_rparam_type_name in rparam_types.name%type,
+      p_rparam_type_scope in rparam_types.scope%type,
+      p_country_name in countries.name%type,
+      p_sector_name in sectors.name%type,
+      p_pf_name in portfolios.pf_name%type,
+      p_data_file_id in portfolios.data_file_id%type,
+      p_rparam_id out portfolios.id%type) as
+   v_pf_id sectors.id%type;
+   v_err_msg varchar2(250);
+   v_rparam_type_id rparam_types.id%type;
+   v_country_id countries.id%type;
+   v_sector_id sectors.id%type;
+
+   begin
+     if p_country_name is not null then
+         id_for_country (p_country_name, v_country_id);
+     end if;
+     if p_sector_name is not null then
+         id_for_sector (p_sector_name, v_sector_id);
+     end if;
+     if p_pf_name is not null then
+        id_for_portfolio (p_pf_name, p_data_file_id, v_pf_id);
+     end if;
+     if p_rparam_type_name is not null then
+        id_for_risk_param_type(p_rparam_type_name, p_rparam_type_scope, v_rparam_type_id);
+     end if;
+     insert into risk_parameters(id, name, type_id, scenario_id, country_id, sector_id, portfolio_id)
+             values (risk_parameters_seq.nextval, p_name, v_rparam_type_id,
+              p_scenario_id, v_country_id, v_sector_id, v_pf_id) returning id into p_rparam_id;
+     exception
+       when others then
+      v_err_msg := sqlerrm;
+       dbms_output.put_line('Could not create risk parameter ' || p_name || ':');
+       dbms_output.put_line(v_err_msg);
+
+end add_risk_parameter;
+/
+
+create or replace
+procedure add_sub_portfolio (
+      p_name in firm_subportfolios.name%type,
+      p_pf_id in portfolios.id%type,
+      p_firm_name in firms.firm_name%type,
+      p_approach in firm_subportfolios.approach%type,
+      p_maturity_dt in firm_subportfolios.maturity_dt%type,
+      p_firm_rating_scheme in firm_rating_schemes.name%type,
+      p_firm_rating_name in firm_ratings.name%type,
+      p_db in firm_subportfolios.db%type,
+      p_ead in firm_subportfolios.ead%type,
+      p_rwa in firm_subportfolios.rwa%type,
+      p_pd in firm_subportfolios.pd%type,
+      p_lgd in firm_subportfolios.lgd%type,
+      p_el in firm_subportfolios.el%type,
+      p_sub_pf_id out firm_subportfolios.id%type) as
+   v_rating_id firm_ratings.id%type;
+   v_firm_id firms.id%type;
+   v_scheme_id firm_rating_schemes.id%type;
+   begin
+     id_for_firm (p_firm_name, v_firm_id);
+     id_for_rating_scheme (p_firm_rating_scheme, v_firm_id, v_scheme_id);
+     id_for_rating (v_scheme_id, p_firm_rating_name, v_rating_id);
+     insert into firm_subportfolios(id, portfolio_id, name, approach, firm_rating_id, db, ead, rwa, pd, lgd, el)
+             values (firm_subportfolios_seq.nextval, p_pf_id, p_name, p_approach, v_rating_id, p_db, p_ead, p_rwa, p_pd, p_lgd, p_el) returning id into p_sub_pf_id;
+end add_sub_portfolio;
+/
+
+CREATE OR REPLACE PROCEDURE set_right_value_for_sequence(seq_name in VARCHAR2, table_name in VARCHAR2, column_id in VARCHAR2)
+IS
+  seq_val NUMBER(6);
+  row_count NUMBER(6);
+  BEGIN
+    EXECUTE IMMEDIATE
+    'select ' || seq_name || '.nextval from dual' INTO seq_val;
+
+    EXECUTE IMMEDIATE
+    'alter sequence  ' || seq_name || ' increment by -' || seq_val || ' minvalue 0';
+
+    EXECUTE IMMEDIATE
+    'select ' || seq_name || '.nextval from dual' INTO seq_val;
+
+    EXECUTE IMMEDIATE
+    'select case when max(' || column_id || ') is null then 1 else max(' || column_id || ') end from ' || table_name INTO row_count;
+
+    EXECUTE IMMEDIATE
+    'alter sequence ' || seq_name || ' increment by ' || row_count || ' minvalue 0';
+
+    EXECUTE IMMEDIATE
+    'select ' || seq_name || '.nextval from dual' INTO seq_val;
+
+    EXECUTE IMMEDIATE
+    'alter sequence ' || seq_name || ' increment by 1 minvalue 1';
+  END;
+/
+
+CREATE OR REPLACE PROCEDURE dummy_proc(seq_name in VARCHAR2, table_name in VARCHAR2, column_id in VARCHAR2)
+IS
+  seq_val NUMBER(6);
+  row_count NUMBER(6);
+  BEGIN
+    EXECUTE IMMEDIATE
+    'select ''abc'' from dual';
+  END;
+/
+
+CALL dummy_proc('SEQ_ATR', 'TOTCATTRIB', 'ATTRIB_ID');

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/procedure/~V2__Invalid.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/procedure/~V2__Invalid.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+create or replace procedure update_test
+begin
+  update test set id=1;
+end;
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/text/V1__Text.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/text/V1__Text.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE docs (id NUMBER PRIMARY KEY, text VARCHAR2(200));
+
+INSERT INTO docs VALUES(1, '<HTML>California is a state in the US.</HTML>');
+INSERT INTO docs VALUES(2, '<HTML>Paris is a city in France.</HTML>');
+INSERT INTO docs VALUES(3, '<HTML>France is in Europe.</HTML>');
+
+CREATE INDEX idx_docs ON docs(text)
+     INDEXTYPE IS CTXSYS.CONTEXT PARAMETERS
+     ('FILTER CTXSYS.NULL_FILTER SECTION GROUP CTXSYS.HTML_SECTION_GROUP');

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/trigger/V1__Trigger.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/trigger/V1__Trigger.sql
@@ -1,0 +1,84 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+CREATE TABLE test1(a1 INT);
+CREATE TABLE test2(a2 INT);
+CREATE TABLE test3(a3 SERIAL NOT NULL PRIMARY KEY);
+CREATE TABLE test4(
+  a4 SERIAL NOT NULL PRIMARY KEY,
+  b4 INT DEFAULT 0
+);
+
+CREATE SEQUENCE test_sequence START 101;
+SELECT setval('test_sequence', 400);
+
+CREATE FUNCTION testtrigger() RETURNS trigger
+AS $$
+  BEGIN
+    INSERT INTO test2 (a2) VALUES(NEW.a1);
+    DELETE FROM test3 WHERE a3 = NEW.a1;
+    UPDATE test4 SET b4 = b4 + 1 WHERE a4 = NEW.a1;
+    RETURN NEW;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER testref BEFORE INSERT ON test1
+  FOR EACH ROW EXECUTE PROCEDURE testtrigger();
+
+
+
+INSERT INTO test3 (a3) VALUES
+  (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT),
+  (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT);
+
+INSERT INTO test4 (a4) VALUES
+  (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT), (DEFAULT);
+
+CREATE TABLE Emp_tab
+(
+  sal    INTEGER,
+  Empno  INTEGER
+);
+
+CREATE OR REPLACE TRIGGER Print_salary_changes
+  BEFORE DELETE ON Emp_tab
+  FOR EACH ROW
+WHEN (old.Empno > 0)
+DECLARE
+    sal_diff number;
+BEGIN
+    sal_diff  := :new.sal  - :old.sal;
+    dbms_output.put('Old salary: ' || :old.sal);
+    dbms_output.put('  New salary: ' || :new.sal);
+    dbms_output.put_line('  Difference ' || sal_diff);
+END;
+/
+
+CREATE OR REPLACE TRIGGER Print_salary_changes
+  BEFORE INSERT OR UPDATE ON Emp_tab
+  FOR EACH ROW
+WHEN (new.Empno > 0)
+DECLARE
+    sal_diff number;
+BEGIN
+    sal_diff  := :new.sal  - :old.sal;
+    dbms_output.put('Old salary: ' || :old.sal);
+    dbms_output.put('  New salary: ' || :new.sal);
+    dbms_output.put_line('  Difference ' || sal_diff);
+END;
+/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/type/V1__Type.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/type/V1__Type.sql
@@ -1,0 +1,74 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TYPE my_type AS (my_type_id integer);
+
+CREATE TYPE """my_type2""" AS (my_type_id integer);
+
+CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');
+
+CREATE TYPE """bug_status2""" AS ENUM ('new', 'open', 'closed');
+
+CREATE TYPE full_name_type AS OBJECT
+( FirstName       VARCHAR2(80),
+  MiddleName      VARCHAR2(80),
+  LastName        VARCHAR2(80) );
+/
+
+create or replace
+TYPE full_name_type_array AS TABLE of full_name_type;
+/
+
+CREATE TYPE full_mailing_address_type AS OBJECT
+( full_name    full_name_type,
+  Street       VARCHAR2(80),
+  City         VARCHAR2(80),
+  State        CHAR(2));
+/
+
+CREATE TABLE customer (
+  full_address  full_mailing_address_type
+);
+
+INSERT INTO customer VALUES (
+  full_mailing_address_type(
+    full_name_type('John', 'F', 'Kennedy'),
+    'Whitehouse plaza',
+    'Washington',
+    'DC'
+  )
+);
+
+CREATE OR REPLACE TYPE fact_row IS OBJECT (
+    FACT_TIME      TIMESTAMP,
+    DIMENSION_VALUE VARCHAR(4000),
+    MEASURE_VALUE   NUMBER,
+    MEMBER PROCEDURE display_fact_row (SELF IN OUT fact_row)
+  );
+/
+
+/*
+  There is a bug in the EDB JDBC driver that prevents the proper execution of the following Type Body
+ */
+/*CREATE OR REPLACE TYPE BODY fact_row AS
+  MEMBER PROCEDURE display_fact_row (SELF IN OUT fact_row) IS
+  BEGIN
+   DBMS_OUTPUT.PUT_LINE('FACT_TIME       :' || FACT_TIME);
+   DBMS_OUTPUT.PUT_LINE('DIMENSION_VALUE :' || FACT_TIME);
+   DBMS_OUTPUT.PUT_LINE('MEASURE_VALUE   :' || FACT_TIME);
+  END;
+END;
+*/

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/vacuum/V1__Vacuum.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/vacuum/V1__Vacuum.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE t (qty INT, price INT);
+INSERT INTO t VALUES(3, 50);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/view/V1__View.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/view/V1__View.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE """t""" (qty INT, price INT);
+INSERT INTO """t""" VALUES(3, 50);
+CREATE VIEW """v""" AS SELECT qty, price, qty*price AS value FROM """t""";
+
+CREATE VIEW features AS SELECT * FROM information_schema.sql_features;

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/warning/V1__Warning.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/warning/V1__Warning.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE FUNCTION Test() RETURNS VOID AS $$
+BEGIN
+  RAISE WARNING 'This is a warning';
+  RAISE EXCEPTION 'This is an error';
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT Test();

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/xml/V1__Xml.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresplus/sql/xml/V1__Xml.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE po_xml_tab(
+  poid number,
+  poDoc XMLTYPE);
+
+CREATE TABLE po_xtab of XMLType;
+
+CREATE TABLE test (
+id number(10) not null,
+xmlDocument xmltype,
+primary key (id)
+);
+
+CREATE TABLE test2 (
+revid number(10) not null,
+test_id number(10) not null,
+xmlDocument xmltype,
+primary key (revid,test_id),
+foreign key (test_id) references test(id)
+);
+
+CREATE INDEX test_xmlindex_ix ON test(xmlDocument) indextype IS xdb.xmlindex
+PARAMETERS ('PATH TABLE test_path_table
+PATH ID INDEX test_path_id_ix
+ORDER KEY INDEX test_order_key_ix
+VALUE INDEX test_value_ix');
+
+CREATE INDEX test2_xmlindex_ix ON test2(xmlDocument) indextype IS xdb.xmlindex
+PARAMETERS ('PATH TABLE test2_path_table
+PATH ID INDEX test2_rev_path_id_ix
+ORDER KEY INDEX test2_order_key_ix
+VALUE INDEX test2_value_ix');

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <version.equinoxcommon>3.6.0.v20100503</version.equinoxcommon>
         <version.android>4.0.1.2</version.android>
         <version.slf4j>1.7.16</version.slf4j>
-        <version.jre>8.74</version.jre>
+        <version.jre>8.77</version.jre>
     </properties>
 
     <dependencyManagement>
@@ -236,6 +236,12 @@
                 <groupId>com.oracle</groupId>
                 <artifactId>ojdbc6</artifactId>
                 <version>12.1.0.1</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>com.edb</groupId>
+                <artifactId>edb-jdbc17</artifactId>
+                <version>9.5.1.6-RC1</version>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
[EnterpriseDB Postgres Plus Advanced Server](http://www.enterprisedb.com/products-services-training/products/postgres-plus-advanced-server)

* New dialect supporting the weird blend of Oracle and PostgreSQL known as SPL.
* Unit tests

Unit tests pass

75 tests pass, 4 ignored:
* xml types and indexes are not tested
* text types and indexes are not tested
* pg_copy JDBC functionality is not yet available
* lock - looks like maybe there is a overly restrictive LOCK MODE by default in EDB

There were other tests that had to be commented out because the EDB JDBC drivers have some
additional bugs:
* TYPE BODY cannot be executed.
* Package Body with complex comments causes ArrayOutOfBoundsException.

And one test that just plain confused me:
* The Oracle tests I used as my starting point included a V2__Invalid.sql migration script which had an
invalid procedure in it - couldn't figure out why, so it's not being tested.