### PR TITLE
Fixed MigrationInfo.compareTo() implementation

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
@@ -26,6 +26,8 @@ import org.flywaydb.core.internal.util.ObjectUtils;
 
 import java.util.Date;
 
+import static org.flywaydb.core.internal.util.ComparableUtils.compareNullsLast;
+
 /**
  * Default implementation of MigrationInfo.
  */
@@ -277,19 +279,14 @@ public class MigrationInfoImpl implements MigrationInfo {
 
     @SuppressWarnings("NullableProblems")
     public int compareTo(MigrationInfo o) {
-        if ((getInstalledRank() != null) && (o.getInstalledRank() != null)) {
-            return getInstalledRank() - o.getInstalledRank();
+        int result = compareNullsLast(getInstalledRank(), o.getInstalledRank());
+        if (result != 0) {
+            return result;
         }
-        if (getVersion() != null && o.getVersion() != null) {
-            return getVersion().compareTo(o.getVersion());
+        result = compareNullsLast(getVersion(), o.getVersion());
+        if (result != 0) {
+            return result;
         }
-        if (getVersion() != null) {
-            return Integer.MIN_VALUE;
-        }
-        if (o.getVersion() != null) {
-            return Integer.MAX_VALUE;
-        }
-
         return getDescription().compareTo(o.getDescription());
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
@@ -19,20 +19,17 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 
 import java.util.Comparator;
 
+import static org.flywaydb.core.internal.util.ComparableUtils.compareNullsLast;
+
 /**
 * Comparator for ResolvedMigration.
 */
 public class ResolvedMigrationComparator implements Comparator<ResolvedMigration> {
     @Override
     public int compare(ResolvedMigration o1, ResolvedMigration o2) {
-        if ((o1.getVersion() != null) && o2.getVersion() != null) {
-            return o1.getVersion().compareTo(o2.getVersion());
-        }
-        if (o1.getVersion() != null) {
-            return Integer.MIN_VALUE;
-        }
-        if (o2.getVersion() != null) {
-            return Integer.MAX_VALUE;
+        int result = compareNullsLast(o1.getVersion(), o2.getVersion());
+        if (result != 0) {
+            return result;
         }
         return o1.getDescription().compareTo(o2.getDescription());
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ComparableUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ComparableUtils.java
@@ -1,0 +1,15 @@
+package org.flywaydb.core.internal.util;
+
+public class ComparableUtils {
+    /**
+     * Compares the specified pair of {@link Comparable} instances, any of those could be {@code null},
+     * those nulls are sorted after not-null values.
+     */
+    public static <T extends Comparable<T>> int compareNullsLast(T a, T b) {
+        if (a != null) {
+            return b == null ? -1 : a.compareTo(b);
+        } else {
+            return b == null ? 0 : 1;
+        }
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoServiceImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoServiceImplSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.info;
 
+import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationState;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
@@ -104,9 +105,29 @@ public class MigrationInfoServiceImplSmallTest {
         migrationInfoService.refresh();
 
         assertEquals("2", migrationInfoService.current().getVersion().toString());
-        assertEquals(MigrationState.IGNORED, migrationInfoService.all()[0].getState());
-        assertEquals(2, migrationInfoService.all().length);
+        final MigrationInfo[] all = migrationInfoService.all();
+        assertEquals(2, all.length);
+        assertEquals(MigrationState.SUCCESS, all[0].getState());
+        assertEquals(MigrationState.IGNORED, all[1].getState());
         assertEquals(0, migrationInfoService.pending().length);
+    }
+
+    @Test
+    public void twoAppliedOnePending() {
+        MigrationInfoServiceImpl migrationInfoService =
+                new MigrationInfoServiceImpl(
+                        createMigrationResolver(createAvailableMigration(1), createAvailableMigration(2), createAvailableMigration(3)),
+                        createMetaDataTable(createAppliedMigration(1), createAppliedMigration(3)),
+                        MigrationVersion.LATEST, true, true, true);
+        migrationInfoService.refresh();
+
+        assertEquals("3", migrationInfoService.current().getVersion().toString());
+        final MigrationInfo[] all = migrationInfoService.all();
+        assertEquals(3, all.length);
+        assertEquals(MigrationState.SUCCESS, all[0].getState());
+        assertEquals(MigrationState.SUCCESS, all[1].getState());
+        assertEquals(MigrationState.PENDING, all[2].getState());
+        assertEquals(1, migrationInfoService.pending().length);
     }
 
     @Test
@@ -135,8 +156,10 @@ public class MigrationInfoServiceImplSmallTest {
         migrationInfoService.refresh();
 
         assertEquals("2", migrationInfoService.current().getVersion().toString());
-        assertEquals(MigrationState.BELOW_BASELINE, migrationInfoService.all()[0].getState());
-        assertEquals(2, migrationInfoService.all().length);
+        final MigrationInfo[] all = migrationInfoService.all();
+        assertEquals(2, all.length);
+        assertEquals(MigrationState.BASELINE, all[0].getState());
+        assertEquals(MigrationState.BELOW_BASELINE, all[1].getState());
         assertEquals(0, migrationInfoService.pending().length);
     }
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/ComparableUtilsTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/ComparableUtilsTest.java
@@ -1,0 +1,22 @@
+package org.flywaydb.core.internal.util;
+
+import org.junit.Test;
+
+import static org.flywaydb.core.internal.util.ComparableUtils.compareNullsLast;
+import static org.junit.Assert.assertTrue;
+
+public class ComparableUtilsTest {
+    @Test
+    public void notNulls() {
+        assertTrue(compareNullsLast(2, 2) == 0);
+        assertTrue(compareNullsLast(1, 2) < 0);
+        assertTrue(compareNullsLast(3, 2) > 0);
+    }
+
+    @Test
+    public void nulls() {
+        assertTrue(compareNullsLast(null, null) == 0);
+        assertTrue(compareNullsLast(3, null) < 0);
+        assertTrue(compareNullsLast(null, 3) > 0);
+    }
+}


### PR DESCRIPTION
These changes should fix #1249 and #1274.
Migrations order is consistent now - first installed, then pending.