### PR TITLE
Proper fix for flyway 4.0 upgrade on Oracle [#1235]

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/oracle/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/oracle/upgradeMetaDataTable.sql
@@ -17,7 +17,7 @@
 DROP INDEX "${schema}"."${table}_vr_idx";
 DROP INDEX "${schema}"."${table}_ir_idx";
 ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
-ALTER TABLE "${schema}"."${table}" DROP PRIMARY KEY "${table}_pk";
+ALTER TABLE "${schema}"."${table}" DROP PRIMARY KEY DROP INDEX;
 ALTER TABLE "${schema}"."${table}" MODIFY "version" NULL;
 ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
 UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';


### PR DESCRIPTION
This change contains two modifications:
* delete the name of the PK to be dropped, because it is not valid SQL
  (see https://docs.oracle.com/cd/E11882_01/server.112/e41084/statements_3001.htm#i2104014)
* implement the only working solution for #1235, which was initially suggested by @kevin-wimmer -
  using the DROP INDEX clause