### PR TITLE
Allow Flyway to be used on MariaDB/Galera clusters

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/mysql/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/mysql/createMetaDataTable.sql
@@ -24,8 +24,9 @@ CREATE TABLE `${schema}`.`${table}` (
     `installed_by` VARCHAR(100) NOT NULL,
     `installed_on` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `execution_time` INT NOT NULL,
-    `success` BOOL NOT NULL
+    `success` BOOL NOT NULL,
+    -- Add the primary key as part of the CREATE TABLE statement in case `innodb_force_primary_key` is enabled
+    CONSTRAINT `${table}_pk`PRIMARY KEY (`installed_rank`)
 ) ENGINE=InnoDB;
-ALTER TABLE `${schema}`.`${table}` ADD CONSTRAINT `${table}_pk` PRIMARY KEY (`installed_rank`);
 
 CREATE INDEX `${table}_s_idx` ON `${schema}`.`${table}` (`success`);

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/mysql/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/mysql/upgradeMetaDataTable.sql
@@ -17,7 +17,7 @@
 DROP INDEX `${table}_vr_idx` ON `${schema}`.`${table}`;
 DROP INDEX `${table}_ir_idx` ON `${schema}`.`${table}`;
 ALTER TABLE `${schema}`.`${table}` DROP COLUMN `version_rank`;
-ALTER TABLE `${schema}`.`${table}` DROP PRIMARY KEY;
+-- Do this in a single step in case `innodb_force_primary_key` is enabled
+ALTER TABLE `${schema}`.`${table}` DROP PRIMARY KEY, ADD CONSTRAINT `${table}_pk` PRIMARY KEY (`installed_rank`);
 ALTER TABLE `${schema}`.`${table}` MODIFY `version` VARCHAR(50);
-ALTER TABLE `${schema}`.`${table}` ADD CONSTRAINT `${table}_pk` PRIMARY KEY (`installed_rank`);
 UPDATE `${schema}`.`${table}` SET `type`='BASELINE' WHERE `type`='INIT';


### PR DESCRIPTION
Currently, running MariaDB in a Galera cluster requires `innodb_force_primary_key=1` to be set. This breaks Flyway because it manipulates the primary key separately from defining the `schema_version` table.

The way to fix this for all of MySQL, MariaDB and MariaDB/Galera is to set the primary key in the `CREATE TABLE` statement, and if its being dropped and re-created on a different field then it can be done as part of the `ALTER` statement.

Fixes #1293