### PR TITLE
Fix IBM classloader regression

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScanner.java
@@ -188,7 +188,7 @@ public class ClassPathScanner implements ResourceAndClassScanner {
 
         if (classLoader.getClass().getName().startsWith("com.ibm")) {
             // WebSphere
-            Enumeration<URL> urls = classLoader.getResources(location + "/flyway.location");
+            Enumeration<URL> urls = classLoader.getResources(location.getPath() + "/flyway.location");
             if (!urls.hasMoreElements()) {
                 LOG.warn("Unable to resolve location " + location + " (ClassLoader: " + classLoader + ")"
                         + " On WebSphere an empty file named flyway.location must be present on the classpath location for WebSphere to find it!");


### PR DESCRIPTION
Migration during #979 fix introduced regression on #175
Migration to Location from String in ClassPathResolver on cbc9fef introduced regression in websphere hack from #175 in ClassPathScanner. Location there resolves to "classpath:db/migration/flyway.location" which renders resource not visible for IBM classloader. Added getPath() like in normal classloader flow. Tested on WebSphere 8.5.5.9 jdk8.