### PR TITLE
Removed drop table because of issues with partitioned tables

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2zos/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2zos/upgradeMetaDataTable.sql
@@ -57,8 +57,7 @@ SELECT
     "success"
 FROM "${schema}"."${table}");
 
---drop all the old things
-DROP TABLE "${schema}"."${table}";
+--drop old tablespace
 DROP TABLESPACE "${schema}".SDBVERS;
 
 RENAME TABLE "${schema}"."TMP_${table}" TO "${table}";


### PR DESCRIPTION
When dropping table in partitioned tablespace the drop fails with -669 in DB2. As the drop tablespace drops the table as well there is no need for this statement.