### PR TITLE
Reorder log detection sequence.

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/logging/LogFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/logging/LogFactory.java
@@ -68,10 +68,10 @@ public class LogFactory {
             FeatureDetector featureDetector = new FeatureDetector(Thread.currentThread().getContextClassLoader());
             if (featureDetector.isAndroidAvailable()) {
                 logCreator = new AndroidLogCreator();
-            } else if (featureDetector.isSlf4jAvailable()) {
-                logCreator = new Slf4jLogCreator();
             } else if (featureDetector.isApacheCommonsLoggingAvailable()) {
                 logCreator = new ApacheCommonsLogCreator();
+            } else if (featureDetector.isSlf4jAvailable()) {
+                logCreator = new Slf4jLogCreator();
             } else if (fallbackLogCreator == null) {
                 logCreator = new JavaUtilLogCreator();
             } else {


### PR DESCRIPTION
If one is using flyway from a maven plugin there is no way to control the log sequence. Simply because flyway checks very early if slf4j is present and maven provides SL4J's `SimpleLogger` out of the box. However to change the `SimpleLogger` log level's one must go to ` ${MAVEN_HOME}/conf/logging/simplelogger.properties` and we can't tell every user to change his maven settings. 

This pull-request gives priority to detecting if commons-logging is available. This way the user can route commons-logging to whatever their logging implementation of choice is (log4j, log4j2, logback, etc.) and be able to control the log level.