### PR TITLE
SQLite blob literal parsing support

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilder.java
@@ -42,4 +42,14 @@ public class SQLiteSqlStatementBuilder extends SqlStatementBuilder {
         }
         return getDefaultDelimiter();
     }
+
+    @Override
+    protected String cleanToken(String token) {
+        if (token.startsWith("X'")) {
+            // blob literal
+            return token.substring(token.indexOf("'"));
+        }
+        return token;
+    }
+
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilderSmallTest.java
@@ -18,7 +18,6 @@ package org.flywaydb.core.internal.dbsupport.sqlite;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlite/SQLiteSqlStatementBuilderSmallTest.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.dbsupport.sqlite;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -65,4 +66,11 @@ public class SQLiteSqlStatementBuilderSmallTest {
 
         assertTrue(statementBuilder.isTerminated());
     }
+
+    @Test
+    public void blobLiteral() throws Exception {
+        statementBuilder.addLine("INSERT INTO test_table (id, bin) VALUES(1, x'01');");
+        assertTrue(statementBuilder.isTerminated());
+    }
+
 }


### PR DESCRIPTION
`SQLiteSqlStatementBuilder` gets stuck in `insideQuoteStringLiteral` state when encounters [sqlite blob literals](https://www.sqlite.org/lang_expr.html) like `x'00'` or `X'00'`.