### PR TITLE
Support for external data sources in single connection mode

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -42,10 +42,7 @@ import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.flywaydb.core.internal.util.VersionPrinter;
-import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
-import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
-import org.flywaydb.core.internal.util.jdbc.TransactionCallback;
-import org.flywaydb.core.internal.util.jdbc.TransactionTemplate;
+import org.flywaydb.core.internal.util.jdbc.*;
 import org.flywaydb.core.internal.util.logging.Log;
 import org.flywaydb.core.internal.util.logging.LogFactory;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -750,6 +747,15 @@ public class Flyway implements FlywayConfiguration {
     public void setDataSource(DataSource dataSource) {
         this.dataSource = dataSource;
         createdDataSource = false;
+    }
+
+    /**
+     * Sets the datasource to use in single connection mode. Must have the necessary privileges to execute ddl.
+     *
+     * @param dataSource The datasource to use. Must have the necessary privileges to execute ddl.
+     */
+    public void setSingleConnectionDataSource(DataSource dataSource) {
+        setDataSource(new SingleConnectionDataSourceProxy(dataSource));
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/SingleConnectionDataSourceProxy.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/SingleConnectionDataSourceProxy.java
@@ -1,0 +1,72 @@
+package org.flywaydb.core.internal.util.jdbc;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * SingleConnectionDataSourceProxy.
+ */
+public class SingleConnectionDataSourceProxy implements DataSource {
+    
+    private final DataSource delegate;
+    private Connection connection;
+
+    public SingleConnectionDataSourceProxy(DataSource delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public synchronized Connection getConnection() throws SQLException {
+        if (connection == null) {
+            connection = delegate.getConnection();
+        }
+        return connection;
+    }
+
+    @Override
+    public synchronized Connection getConnection(String username, String password) throws SQLException {
+        if (connection == null) {
+            connection = delegate.getConnection(username, password);
+        }
+        return connection;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new UnsupportedOperationException("getParentLogger");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
+    }
+    
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -24,6 +24,7 @@ import org.flywaydb.core.internal.metadatatable.MetaDataTable;
 import org.flywaydb.core.internal.resolver.MyCustomMigrationResolver;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -208,4 +209,18 @@ public class FlywaySmallTest {
             //expected
         }
     }
+
+    @Test
+    public void dataSourceInSingleConnectionMode() throws Exception {
+        final DataSource dataSource = Mockito.mock(DataSource.class);
+        Mockito.when(dataSource.getConnection())
+            .thenReturn(Mockito.mock(Connection.class))
+            .thenThrow(new AssertionError("In single connection mode."));
+        final Flyway flyway = new Flyway();
+        flyway.setSingleConnectionDataSource(dataSource);
+        flyway.getDataSource().getConnection();
+        flyway.getDataSource().getConnection("", "");
+        Mockito.verify(dataSource, Mockito.times(1)).getConnection();
+    }
+
 }


### PR DESCRIPTION
Flyway fails to migrate SQLite on provided application level DataSource instance.
> Caused by: java.sql.SQLException: [SQLITE_BUSY]  The database file is locked (database is locked)

As far as it is not possible to define database type through `dataSource` , `setSingleConnectionDataSource(DataSource)` was added to facade to workaround the bug.
Known related issue: #1180 