### PR TITLE
Support dependency injection when resolving JdbcMigrations

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -82,7 +82,7 @@ public class JdbcMigrationResolver implements MigrationResolver {
         try {
             Class<?>[] classes = scanner.scanForClasses(location, JdbcMigration.class);
             for (Class<?> clazz : classes) {
-                JdbcMigration jdbcMigration = ClassUtils.instantiate(clazz.getName(), scanner.getClassLoader());
+                JdbcMigration jdbcMigration = instantiate(clazz.getName(), scanner.getClassLoader());
                 ConfigurationInjectionUtils.injectFlywayConfiguration(jdbcMigration, configuration);
 
                 ResolvedMigrationImpl migrationInfo = extractMigrationInfo(jdbcMigration);
@@ -97,6 +97,19 @@ public class JdbcMigrationResolver implements MigrationResolver {
 
         Collections.sort(migrations, new ResolvedMigrationComparator());
         return migrations;
+    }
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param className   The fully qualified name of the jdbc migration class to instantiate.
+     * @param classLoader The ClassLoader to use.
+     * @return The new instance.
+     * @throws Exception Thrown when the instantiation failed.
+     */
+    @SuppressWarnings({"unchecked"})
+    protected JdbcMigration instantiate(String className, ClassLoader classLoader) throws Exception {
+        return ClassUtils.instantiate(className, classLoader);
     }
 
     /**


### PR DESCRIPTION
By extracting the instantiation of JdbcMigrations into a protected 'instantiate' method
it's possible for users of flyway to integrate with a dependency injection
framework by overriding 'instantiate' for example

```
Flyway flyway = new Flyway();
flyway.setSkipDefaultResolvers(true);
flyway.setResolvers(new JdbcMigrationResolver(...) {
    @Override
    protected JdbcMigration instantiate(String className, ClassLoader classLoader) throws Exception {
        return ...;
    }
});
```
