### PR TITLE
Replace references to deprecated "flyway.properties" file.

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -254,7 +254,7 @@ public class Main {
         LOG.info("baselineVersion              : Version to tag schema with when executing baseline");
         LOG.info("baselineDescription          : Description to tag schema with when executing baseline");
         LOG.info("baselineOnMigrate            : Baseline on migrate against uninitialized non-empty schema");
-        LOG.info("configFile                   : Config file to use (default: conf/flyway.properties)");
+        LOG.info("configFile                   : Config file to use (default: ./flyway.conf)");
         LOG.info("configFileEncoding           : Encoding of the config file (default: UTF-8)");
         LOG.info("jarDirs                      : Dirs for Jdbc drivers & Java migrations (default: jars)");
         LOG.info("");
@@ -371,7 +371,7 @@ public class Main {
 
     /**
      * Loads the configuration from the configuration file. If a configuration file is specified using the -configfile
-     * argument it will be used, otherwise the default config file (conf/flyway.properties) will be loaded.
+     * argument it will be used, otherwise the default config file (./flyway.conf) will be loaded.
      *
      * @param properties    The properties object to load to configuration into.
      * @param file          The configuration file to load.

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -254,7 +254,7 @@ public class Main {
         LOG.info("baselineVersion              : Version to tag schema with when executing baseline");
         LOG.info("baselineDescription          : Description to tag schema with when executing baseline");
         LOG.info("baselineOnMigrate            : Baseline on migrate against uninitialized non-empty schema");
-        LOG.info("configFile                   : Config file to use (default: ./flyway.conf)");
+        LOG.info("configFile                   : Config file to use (default: <install-dir>/conf/flyway.conf)");
         LOG.info("configFileEncoding           : Encoding of the config file (default: UTF-8)");
         LOG.info("jarDirs                      : Dirs for Jdbc drivers & Java migrations (default: jars)");
         LOG.info("");
@@ -371,7 +371,7 @@ public class Main {
 
     /**
      * Loads the configuration from the configuration file. If a configuration file is specified using the -configfile
-     * argument it will be used, otherwise the default config file (./flyway.conf) will be loaded.
+     * argument it will be used, otherwise the default config file (<install-dir>/conf/flyway.conf) will be loaded.
      *
      * @param properties    The properties object to load to configuration into.
      * @param file          The configuration file to load.


### PR DESCRIPTION
Resolves https://github.com/flyway/flyway/issues/1382

According to the following [line](https://github.com/sw00/flyway/blob/0ef790a4a71e91297ce6ff02754dfa203be1fdfb/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java#L364), flyway will by default load `./flyway.conf` and not `conf/flyway.properties` when executed as a CLI.
