### PR TITLE
Add an option to append description int hash to the version

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -296,6 +296,11 @@ public class Flyway implements FlywayConfiguration {
     private boolean dbConnectionInfoPrinted;
 
     /**
+     * Whether description hash should be appended to the version
+     */
+    private boolean appendDescriptionHashToVersion;
+
+    /**
      * Creates a new instance of Flyway. This is your starting point.
      */
     public Flyway() {
@@ -309,6 +314,15 @@ public class Flyway implements FlywayConfiguration {
             result[i] = locations.getLocations().get(i).toString();
         }
         return result;
+    }
+
+    @Override
+    public boolean isAppendDescriptionHashToVersion() {
+        return appendDescriptionHashToVersion;
+    }
+
+    public void setAppendDescriptionHashToVersion(boolean appendDescriptionHashToVersion) {
+        this.appendDescriptionHashToVersion = appendDescriptionHashToVersion;
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -204,4 +204,9 @@ public interface FlywayConfiguration {
      * @return Locations to scan recursively for migrations. (default: db/migration)
      */
     String[] getLocations();
+
+    /**
+     * @return True to append description hash to version. This allows multiple files to be named with the same version and different descriptions
+     */
+    boolean isAppendDescriptionHashToVersion();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -76,7 +76,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
         if (!config.isSkipDefaultResolvers()) {
             for (Location location : locations.getLocations()) {
                 migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
-                        encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+                        encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix, config.isAppendDescriptionHashToVersion()));
                 migrationResolvers.add(new JdbcMigrationResolver(scanner, location, config));
 
                 if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/MigrationInfoHelper.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/MigrationInfoHelper.java
@@ -35,15 +35,17 @@ public class MigrationInfoHelper {
     /**
      * Extracts the schema version and the description from a migration name formatted as 1_2__Description.
      *
-     * @param migrationName The migration name to parse. Should not contain any folders or packages.
-     * @param prefix        The migration prefix.
-     * @param separator     The migration separator.
-     * @param suffix        The migration suffix.
+     * @param migrationName                     The migration name to parse. Should not contain any folders or packages.
+     * @param prefix                            The migration prefix.
+     * @param separator                         The migration separator.
+     * @param suffix                            The migration suffix.
+     * @param appendDescriptionHashToVersion    Wheter to append description hash to the version
      * @return The extracted schema version.
      * @throws FlywayException if the migration name does not follow the standard conventions.
      */
     public static Pair<MigrationVersion, String> extractVersionAndDescription(String migrationName,
-                                                                              String prefix, String separator, String suffix) {
+                                                                              String prefix, String separator, String suffix,
+                                                                              boolean appendDescriptionHashToVersion) {
         String cleanMigrationName = migrationName.substring(prefix.length(), migrationName.length() - suffix.length());
 
         // Handle the description
@@ -56,8 +58,19 @@ public class MigrationInfoHelper {
         String version = cleanMigrationName.substring(0, descriptionPos);
         String description = cleanMigrationName.substring(descriptionPos + separator.length()).replaceAll("_", " ");
         if (StringUtils.hasText(version)) {
+            if(appendDescriptionHashToVersion){
+                version = version + "_" + hash(description);
+            }
             return Pair.of(MigrationVersion.fromVersion(version), description);
         }
         return Pair.of(null, description);
+    }
+
+    static int hash(String text){
+        int hash = 7;
+        for (int i = 0; i < text.length(); i++) {
+            hash = hash*31 + text.charAt(i);
+        }
+        return Math.abs(hash);
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -131,7 +131,7 @@ public class JdbcMigrationResolver implements MigrationResolver {
                         + " => ensure it starts with V or R," +
                         " or implement org.flywaydb.core.api.migration.MigrationInfoProvider for non-default naming");
             }
-            Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription(shortName, prefix, "__", "");
+            Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription(shortName, prefix, "__", "", configuration.isAppendDescriptionHashToVersion());
             version = info.getLeft();
             description = info.getRight();
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -132,7 +132,7 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
                         + " => ensure it starts with V or R," +
                         " or implement org.flywaydb.core.api.migration.MigrationInfoProvider for non-default naming");
             }
-            Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription(shortName, prefix, "__", "");
+            Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription(shortName, prefix, "__", "", configuration.isAppendDescriptionHashToVersion());
             version = info.getLeft();
             description = info.getRight();
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -89,6 +89,9 @@ public class SqlMigrationResolver implements MigrationResolver {
      */
     private final String sqlMigrationSuffix;
 
+
+    private final boolean appendDescriptionHashToVersion;
+
     /**
      * Creates a new instance.
      *
@@ -105,7 +108,8 @@ public class SqlMigrationResolver implements MigrationResolver {
     public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Location location,
                                 PlaceholderReplacer placeholderReplacer, String encoding,
                                 String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
-                                String sqlMigrationSeparator, String sqlMigrationSuffix) {
+                                String sqlMigrationSeparator, String sqlMigrationSuffix,
+                                boolean appendDescriptionHashToVersion) {
         this.dbSupport = dbSupport;
         this.scanner = scanner;
         this.location = location;
@@ -115,6 +119,7 @@ public class SqlMigrationResolver implements MigrationResolver {
         this.repeatableSqlMigrationPrefix = repeatableSqlMigrationPrefix;
         this.sqlMigrationSeparator = sqlMigrationSeparator;
         this.sqlMigrationSuffix = sqlMigrationSuffix;
+        this.appendDescriptionHashToVersion = appendDescriptionHashToVersion;
     }
 
     public List<ResolvedMigration> resolveMigrations() {
@@ -134,7 +139,7 @@ public class SqlMigrationResolver implements MigrationResolver {
                 continue;
             }
             Pair<MigrationVersion, String> info =
-                    MigrationInfoHelper.extractVersionAndDescription(filename, prefix, separator, suffix);
+                    MigrationInfoHelper.extractVersionAndDescription(filename, prefix, separator, suffix, appendDescriptionHashToVersion);
 
             ResolvedMigrationImpl migration = new ResolvedMigrationImpl();
             migration.setVersion(info.getLeft());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -76,7 +76,7 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
                 new Location(getBasedir() + "/default"),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 "UTF-8",
-                "V", "R", "__", ".sql");
+                "V", "R", "__", ".sql", false);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -174,6 +174,11 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     }
 
     @Override
+    public boolean isAppendDescriptionHashToVersion() {
+        return false;
+    }
+
+    @Override
     public String getEncoding() {
         return this.encoding;
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MigrationInfoHelperSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MigrationInfoHelperSmallTest.java
@@ -32,12 +32,12 @@ public class MigrationInfoHelperSmallTest {
      */
     @Test(expected = FlywayException.class)
     public void extractSchemaVersionNoDescription() {
-        MigrationInfoHelper.extractVersionAndDescription("9_4", "", "__", "");
+        MigrationInfoHelper.extractVersionAndDescription("9_4", "", "__", "", false);
     }
 
     @Test
     public void repeatableMigration() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("R__EmailAxel.sql", "R", "__", ".sql");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("R__EmailAxel.sql", "R", "__", ".sql", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertNull(version);
@@ -46,7 +46,7 @@ public class MigrationInfoHelperSmallTest {
 
     @Test
     public void extractSchemaVersionDefaults() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V9_4__EmailAxel.sql", "V", "__", ".sql");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V9_4__EmailAxel.sql", "V", "__", ".sql", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("9.4", version.toString());
@@ -54,8 +54,17 @@ public class MigrationInfoHelperSmallTest {
     }
 
     @Test
+    public void extractSchemaVersionDefaultsWithDescriptionHash() {
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V9_4__EmailAxel.sql", "V", "__", ".sql", true);
+        MigrationVersion version = info.getLeft();
+        String description = info.getRight();
+        assertEquals("9.4." +  MigrationInfoHelper.hash("EmailAxel"), version.toString());
+        assertEquals("EmailAxel", description);
+    }
+
+    @Test
     public void extractSchemaVersionCustomSeparator() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V9_4-EmailAxel.sql", "V", "-", ".sql");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V9_4-EmailAxel.sql", "V", "-", ".sql", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("9.4", version.toString());
@@ -67,7 +76,7 @@ public class MigrationInfoHelperSmallTest {
      */
     @Test
     public void extractSchemaVersionWithDescription() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("9_4__EmailAxel", "", "__", "");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("9_4__EmailAxel", "", "__", "", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("9.4", version.toString());
@@ -79,7 +88,7 @@ public class MigrationInfoHelperSmallTest {
      */
     @Test
     public void extractSchemaVersionWithDescriptionWithSpaces() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("9_4__Big_jump", "", "__", "");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("9_4__Big_jump", "", "__", "", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("9.4", version.toString());
@@ -91,7 +100,7 @@ public class MigrationInfoHelperSmallTest {
      */
     @Test
     public void extractSchemaVersionWithLeadingZeroes() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("009_4__EmailAxel", "", "__", "");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("009_4__EmailAxel", "", "__", "", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("009.4", version.toString());
@@ -100,17 +109,17 @@ public class MigrationInfoHelperSmallTest {
 
     @Test(expected = FlywayException.class)
     public void extractSchemaVersionWithLeadingUnderscore() {
-        MigrationInfoHelper.extractVersionAndDescription("_8_0__Description", "", "__", "");
+        MigrationInfoHelper.extractVersionAndDescription("_8_0__Description", "", "__", "", false);
     }
 
     @Test(expected = FlywayException.class)
     public void extractSchemaVersionWithLeadingUnderscoreAndPrefix() {
-        MigrationInfoHelper.extractVersionAndDescription("V_8_0__Description.sql", "V", "__", ".sql");
+        MigrationInfoHelper.extractVersionAndDescription("V_8_0__Description.sql", "V", "__", ".sql", false);
     }
 
     @Test
     public void extractSchemaVersionWithVUnderscorePrefix() {
-        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V_8_0__Description.sql", "V_", "__", ".sql");
+        Pair<MigrationVersion, String> info = MigrationInfoHelper.extractVersionAndDescription("V_8_0__Description.sql", "V_", "__", ".sql", false);
         MigrationVersion version = info.getLeft();
         String description = info.getRight();
         assertEquals("8.0", version.toString());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -42,7 +42,7 @@ public class SqlMigrationResolverMediumTest {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
                         new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        "UTF-8", "V", "R", "__", ".sql");
+                        "UTF-8", "V", "R", "__", ".sql", false);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -42,7 +42,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
-                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
+                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql", false);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -62,7 +62,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsRoot() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql");
+                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql", false);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -73,7 +73,7 @@ public class SqlMigrationResolverSmallTest {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
                         new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                            "CheckValidate", "R", "__", ".sql");
+                            "CheckValidate", "R", "__", ".sql", false);
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -82,7 +82,7 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
-                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql", false);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -92,7 +92,7 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql", false);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -103,7 +103,7 @@ public class SqlMigrationResolverSmallTest {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
                         new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                            "V", "R", "__", ".sql");
+                            "V", "R", "__", ".sql", false);
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql")));
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -285,7 +285,7 @@ public abstract class MigrationTestCase {
                 new Location(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 "UTF-8",
-                "V", "R", "__", ".sql");
+                "V", "R", "__", ".sql", false);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {


### PR DESCRIPTION
In our team of developers, working on multiple feature branches, we frequently end up with conflicts when two developers create migration files with exact same version.

We always resolve those conflicts by incrementing the version of the last commited file. That means, the order between those conflicted updates does not matter because they are almost always unlinked.

I think the easiest solution is to automatically generate the minor part of the version number by computing a hash on the description. This hash would be then appended to the base version.

Example:
- V2_1__john.sql => 2.1.1346565
- V2_1__jane.sql => 2.1.1347966

Regards