### PR TITLE
Support multiple migrations per transaction

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -22,6 +22,8 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.batch.DefaultMigrationBatchService;
+import org.flywaydb.core.internal.batch.MigrationBatchService;
 import org.flywaydb.core.internal.callback.SqlScriptFlywayCallback;
 import org.flywaydb.core.internal.command.DbBaseline;
 import org.flywaydb.core.internal.command.DbClean;
@@ -296,6 +298,11 @@ public class Flyway implements FlywayConfiguration {
     private boolean dbConnectionInfoPrinted;
 
     /**
+     * The migration batch service to use
+     */
+    private MigrationBatchService migrationBatchService = new DefaultMigrationBatchService();
+
+    /**
      * Creates a new instance of Flyway. This is your starting point.
      */
     public Flyway() {
@@ -309,6 +316,11 @@ public class Flyway implements FlywayConfiguration {
             result[i] = locations.getLocations().get(i).toString();
         }
         return result;
+    }
+
+    @Override
+    public MigrationBatchService getMigrationBatchService() {
+        return migrationBatchService;
     }
 
     @Override
@@ -835,6 +847,13 @@ public class Flyway implements FlywayConfiguration {
     }
 
     /**
+     * @param migrationBatchService The migration batch service to use
+     */
+    public void setMigrationBatchService(MigrationBatchService migrationBatchService) {
+        this.migrationBatchService = migrationBatchService;
+    }
+
+    /**
      * Gets the callbacks for lifecycle notifications.
      *
      * @return The callbacks for lifecycle notifications. An empty array if none. (default: none)
@@ -954,7 +973,7 @@ public class Flyway implements FlywayConfiguration {
                 }
 
                 DbMigrate dbMigrate =
-                        new DbMigrate(connectionMetaDataTable, connectionUserObjects, dbSupport, metaDataTable,
+                        new DbMigrate(migrationBatchService, connectionMetaDataTable, connectionUserObjects, dbSupport, metaDataTable,
                                 schemas[0], migrationResolver, target, ignoreFutureMigrations, ignoreFailedFutureMigration, outOfOrder, flywayCallbacks);
                 return dbMigrate.migrate();
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.api.configuration;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.batch.MigrationBatchService;
 
 import javax.sql.DataSource;
 import java.util.Map;
@@ -204,4 +205,9 @@ public interface FlywayConfiguration {
      * @return Locations to scan recursively for migrations. (default: db/migration)
      */
     String[] getLocations();
+
+    /**
+     * @return The migration batch service
+     */
+    MigrationBatchService getMigrationBatchService();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/batch/DefaultMigrationBatchService.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/batch/DefaultMigrationBatchService.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.batch;
+
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+
+/**
+ * Created on 07/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class DefaultMigrationBatchService implements MigrationBatchService {
+    @Override
+    public boolean isLastOfBatch(DbSupport dbSupport, MigrationInfo migrationInfo) {
+        return true;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/batch/MigrationBatchResult.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/batch/MigrationBatchResult.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.batch;
+
+/**
+ * Created on 07/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class MigrationBatchResult {
+
+    private int numberOfAppliedMigrations;
+    private boolean done;
+
+    public int getNumberOfAppliedMigrations() {
+        return numberOfAppliedMigrations;
+    }
+
+    public void setNumberOfAppliedMigrations(int numberOfAppliedMigrations) {
+        this.numberOfAppliedMigrations = numberOfAppliedMigrations;
+    }
+
+    public boolean isDone() {
+        return done;
+    }
+
+    public void setDone(boolean done) {
+        this.done = done;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/batch/MigrationBatchService.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/batch/MigrationBatchService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.batch;
+
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+
+/**
+ * Created on 07/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public interface MigrationBatchService {
+
+    /**
+     * @param dbSupport
+     * @param migrationInfo
+     * @return True if the migration is to be considered as the last of its batch.<br>
+     *      A migration marked as last of batch will be followed by a commit on success.
+     */
+    boolean isLastOfBatch(DbSupport dbSupport, MigrationInfo migrationInfo);
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/batch/SingleTransactionBatchService.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/batch/SingleTransactionBatchService.java
@@ -1,0 +1,16 @@
+package org.flywaydb.core.internal.batch;
+
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+
+/**
+ * Created on 07/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class SingleTransactionBatchService implements MigrationBatchService {
+    @Override
+    public boolean isLastOfBatch(DbSupport dbSupport, MigrationInfo migrationInfo) {
+        return false;
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoDumperSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoDumperSmallTest.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.batch.DefaultMigrationBatchService;
 import org.flywaydb.core.internal.metadatatable.AppliedMigration;
 import org.flywaydb.core.internal.metadatatable.MetaDataTable;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.info;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.batch.DefaultMigrationBatchService;
 import org.flywaydb.core.internal.metadatatable.AppliedMigration;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
 import org.junit.Test;

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoServiceImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoServiceImplSmallTest.java
@@ -19,6 +19,7 @@ import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationState;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.internal.batch.DefaultMigrationBatchService;
 import org.flywaydb.core.internal.metadatatable.AppliedMigration;
 import org.flywaydb.core.internal.metadatatable.MetaDataTable;
 import org.flywaydb.core.api.resolver.MigrationResolver;

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -23,6 +23,8 @@ import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.batch.DefaultMigrationBatchService;
+import org.flywaydb.core.internal.batch.MigrationBatchService;
 
 /**
  * Dummy Implementation of {@link FlywayConfiguration} for unit tests.
@@ -171,6 +173,11 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public String[] getLocations() {
         return this.locations;
+    }
+
+    @Override
+    public MigrationBatchService getMigrationBatchService() {
+        return new DefaultMigrationBatchService();
     }
 
     @Override

--- a/flyway-core/src/test/resources/migration/failed_transactional/V1_1__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/failed_transactional/V1_1__Populate_table.sql
@@ -14,6 +14,4 @@
 -- limitations under the License.
 --
 
-CREATE TABLE test_table (
-  id INTEGER PRIMARY KEY AUTOINCREMENT
-);
+INSERT INTO test_user (name) VALUES ('Mr. T');

--- a/flyway-core/src/test/resources/migration/failed_transactional/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/failed_transactional/V1__First.sql
@@ -14,6 +14,7 @@
 -- limitations under the License.
 --
 
-CREATE TABLE test_table (
-  id INTEGER PRIMARY KEY AUTOINCREMENT
+CREATE TABLE test_user (
+  name VARCHAR(25) NOT NULL,
+  PRIMARY KEY(name)
 );

--- a/flyway-core/src/test/resources/migration/failed_transactional/V3__Should_Fail.sql
+++ b/flyway-core/src/test/resources/migration/failed_transactional/V3__Should_Fail.sql
@@ -14,6 +14,5 @@
 -- limitations under the License.
 --
 
-CREATE TABLE test_table (
-  id INTEGER PRIMARY KEY AUTOINCREMENT
-);
+THIS IS NOT VALID SQL;
+THIS MIGRATION SHOULD FAIL;


### PR DESCRIPTION
Fixes #181 .

Added a notion of batch of migrations.
A batch of migrations executes into a single transaction.
By default a batch of migrations consists of only one migration.

To modify batch creation, one have to implement the MigrationBatchService and pass it to Flyway object:

```java
public interface MigrationBatchService {
    /**
     * @param dbSupport
     * @param migrationInfo
     * @return True if the migration is to be considered as the last of its batch.<br>
     *      A migration marked as last of batch will be followed by a commit on success.
     */
    boolean isLastOfBatch(DbSupport dbSupport, MigrationInfo migrationInfo);
}
```

Therefore we can have the following behaviours:
- One migration per transaction (default)
- All migrations into one transaction
- Migrations grouped by major versions

Regards