### PR TITLE
Execution of migration scipts and update/insert of meta data table in one transaction for databases which supports ddl transaction

### DIFF
--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -22,17 +22,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import javax.sql.DataSource;
+import javax.xml.crypto.Data;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
@@ -40,6 +46,7 @@ import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationState;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.callback.BaseFlywayCallback;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.DbSupportFactory;
@@ -54,6 +61,7 @@ import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +78,7 @@ public abstract class MigrationTestCase {
     protected static final String MIGRATIONDIR = "migration";
     protected static final String BASEDIR = "migration/sql";
 
+    private DataSource unwrappedDataSource;
     protected DataSource dataSource;
     private Connection connection;
     protected DbSupport dbSupport;
@@ -84,7 +93,8 @@ public abstract class MigrationTestCase {
         if (customPropertiesFile.canRead()) {
             customProperties.load(new FileInputStream(customPropertiesFile));
         }
-        dataSource = createDataSource(customProperties);
+        unwrappedDataSource = createDataSource(customProperties);
+        dataSource = Mockito.spy(unwrappedDataSource);
 
         connection = dataSource.getConnection();
         dbSupport = DbSupportFactory.createDbSupport(connection, false);
@@ -672,4 +682,5 @@ public abstract class MigrationTestCase {
     protected String getCommentLocation() {
         return "migration/comment";
     }
+
 }

--- a/flyway-core/src/test/resources/migration/dbsupport/sqlite/autoincrement/V1__Autoincrement.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/sqlite/autoincrement/V1__Autoincrement.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2010-2016 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 CREATE TABLE test_table (
   id INTEGER PRIMARY KEY AUTOINCREMENT
 );


### PR DESCRIPTION
Fixes #1236 

I have ideas of test to add for this feature such as triggering an exception between user connection commit and metadata connection commit, but they are really complex.

I can manage it if you agree with the design.

Regards
