### PR TITLE
Add the ability to dynamically ignore some sql errors on sql migration's scripts

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -21,6 +21,7 @@ import org.flywaydb.core.api.MigrationInfoService;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.internal.callback.SqlScriptFlywayCallback;
 import org.flywaydb.core.internal.command.DbBaseline;
@@ -35,6 +36,7 @@ import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.info.MigrationInfoServiceImpl;
 import org.flywaydb.core.internal.metadatatable.MetaDataTable;
 import org.flywaydb.core.internal.metadatatable.MetaDataTableImpl;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.resolver.CompositeMigrationResolver;
 import org.flywaydb.core.internal.util.ClassUtils;
 import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
@@ -171,6 +173,11 @@ public class Flyway implements FlywayConfiguration {
      * which using the defaults translates to V1_1__My_description.sql</p>
      */
     private String sqlMigrationSuffix = ".sql";
+
+    /**
+     * The sql migration script interceptor to use. (default: an implementation act as pass through)
+     */
+    private SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor = new PassThroughSqlMigrationScriptExecutionInterceptor();
 
     /**
      * Ignore future migrations when reading the metadata table. These are migrations that were performed by a
@@ -358,6 +365,10 @@ public class Flyway implements FlywayConfiguration {
     @Override
     public String getSqlMigrationPrefix() {
         return sqlMigrationPrefix;
+    }
+
+    public SqlMigrationScriptExecutionInterceptor getSqlMigrationScriptExecutionInterceptor() {
+        return sqlMigrationScriptExecutionInterceptor;
     }
 
     @Override
@@ -700,6 +711,14 @@ public class Flyway implements FlywayConfiguration {
      */
     public void setSqlMigrationPrefix(String sqlMigrationPrefix) {
         this.sqlMigrationPrefix = sqlMigrationPrefix;
+    }
+
+    /**
+     * Sets the sql migration script interceptor.
+     * @param sqlMigrationScriptExecutionInterceptor The sql migration script interceptor to set
+     */
+    public void setSqlMigrationScriptExecutionInterceptor(SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor){
+        this.sqlMigrationScriptExecutionInterceptor = sqlMigrationScriptExecutionInterceptor;
     }
 
     /**
@@ -1125,7 +1144,7 @@ public class Flyway implements FlywayConfiguration {
 
         return new CompositeMigrationResolver(dbSupport, scanner, this, locations,
                 encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix,
-                createPlaceholderReplacer(), resolvers);
+                createPlaceholderReplacer(), sqlMigrationScriptExecutionInterceptor, resolvers);
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.api.configuration;
 
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 
 import javax.sql.DataSource;
@@ -124,6 +125,12 @@ public interface FlywayConfiguration {
      * @return The file name prefix for sql migrations. (default: V)
      */
     String getSqlMigrationPrefix();
+
+    /**
+     *
+     * @return The sql migration script interceptor to use
+     */
+    SqlMigrationScriptExecutionInterceptor getSqlMigrationScriptExecutionInterceptor();
 
     /**
      * Checks whether placeholders should be replaced.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/sql/SqlMigrationScriptExecutionInterceptor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/sql/SqlMigrationScriptExecutionInterceptor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api.migration.sql;
+
+import java.sql.SQLException;
+
+/**
+ * Created on 12/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public interface SqlMigrationScriptExecutionInterceptor {
+
+    /**
+     * Intercepts an sql script executor
+     * @param executor
+     * @throws SQLException
+     */
+    void intercept(SqlScriptExecutor executor) throws SQLException;
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/sql/SqlScriptExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/sql/SqlScriptExecutor.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.api.migration.sql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Created on 12/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public interface SqlScriptExecutor {
+
+    void execute() throws SQLException;
+
+    String getSql();
+
+    Connection getConnection();
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
@@ -100,7 +100,7 @@ public class SqlScriptFlywayCallback implements FlywayCallback {
                                 "-> " + existing.getResource().getLocationOnDisk() + "\n" +
                                 "-> " + resource.getLocationOnDisk());
                     }
-                    scripts.put(key, new SqlScript(dbSupport, resource, placeholderReplacer, encoding));
+                    scripts.put(key, new SqlScript(dbSupport, resource, placeholderReplacer, encoding, null));
                 }
             }
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/migration/sql/PassThroughSqlMigrationScriptExecutionInterceptor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/migration/sql/PassThroughSqlMigrationScriptExecutionInterceptor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.migration.sql;
+
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
+import org.flywaydb.core.api.migration.sql.SqlScriptExecutor;
+
+import java.sql.SQLException;
+
+/**
+ * Created on 12/08/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class PassThroughSqlMigrationScriptExecutionInterceptor implements SqlMigrationScriptExecutionInterceptor {
+
+    @Override
+    public void intercept(SqlScriptExecutor executor) throws SQLException {
+        executor.execute();
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.internal.resolver;
 
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
@@ -65,6 +66,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
      * @param sqlMigrationSeparator        The file name separator for sql migrations.
      * @param sqlMigrationSuffix           The file name suffix for sql migrations.
      * @param placeholderReplacer          The placeholder replacer to use.
+     * @param sqlMigrationScriptExecutionInterceptor     The sql migration script interceptor to use
      * @param customMigrationResolvers     Custom Migration Resolvers.
      */
     public CompositeMigrationResolver(DbSupport dbSupport, Scanner scanner, FlywayConfiguration config, Locations locations,
@@ -72,11 +74,12 @@ public class CompositeMigrationResolver implements MigrationResolver {
                                       String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
                                       String sqlMigrationSeparator, String sqlMigrationSuffix,
                                       PlaceholderReplacer placeholderReplacer,
+                                      SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor,
                                       MigrationResolver... customMigrationResolvers) {
         if (!config.isSkipDefaultResolvers()) {
             for (Location location : locations.getLocations()) {
                 migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer,
-                        encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix));
+                        encoding, sqlMigrationPrefix, repeatableSqlMigrationPrefix, sqlMigrationSeparator, sqlMigrationSuffix, sqlMigrationScriptExecutionInterceptor));
                 migrationResolvers.add(new JdbcMigrationResolver(scanner, location, config));
 
                 if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.resolver.sql;
 
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.api.resolver.MigrationExecutor;
@@ -51,23 +52,30 @@ public class SqlMigrationExecutor implements MigrationExecutor {
     private final String encoding;
 
     /**
+     * The sql migration script interceptor
+     */
+    private final SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor;
+
+    /**
      * Creates a new sql script migration based on this sql script.
      *
-     * @param dbSupport           The database-specific support.
-     * @param sqlScriptResource   The resource containing the sql script.
-     * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
-     * @param encoding            The encoding of this Sql migration.
+     * @param dbSupport                 The database-specific support.
+     * @param sqlScriptResource         The resource containing the sql script.
+     * @param placeholderReplacer       The placeholder replacer to apply to sql migration scripts.
+     * @param encoding                  The encoding of this Sql migration.
+     * @param sqlMigrationScriptExecutionInterceptor  The sql migration interceptor
      */
-    public SqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding) {
+    public SqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding, SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor) {
         this.dbSupport = dbSupport;
         this.sqlScriptResource = sqlScriptResource;
         this.encoding = encoding;
         this.placeholderReplacer = placeholderReplacer;
+        this.sqlMigrationScriptExecutionInterceptor = sqlMigrationScriptExecutionInterceptor;
     }
 
     @Override
     public void execute(Connection connection) {
-        SqlScript sqlScript = new SqlScript(dbSupport, sqlScriptResource, placeholderReplacer, encoding);
+        SqlScript sqlScript = new SqlScript(dbSupport, sqlScriptResource, placeholderReplacer, encoding, sqlMigrationScriptExecutionInterceptor);
         sqlScript.execute(new JdbcTemplate(connection, 0));
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.callback.SqlScriptFlywayCallback;
@@ -90,6 +91,11 @@ public class SqlMigrationResolver implements MigrationResolver {
     private final String sqlMigrationSuffix;
 
     /**
+     * The sql migration script interceptor
+     */
+    private final SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor;
+
+    /**
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
@@ -101,11 +107,13 @@ public class SqlMigrationResolver implements MigrationResolver {
      * @param repeatableSqlMigrationPrefix The prefix for repeatable sql migrations
      * @param sqlMigrationSeparator        The separator for sql migrations
      * @param sqlMigrationSuffix           The suffix for sql migrations
+     * @param sqlMigrationScriptExecutionInterceptor     The sql migration interceptor
      */
     public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Location location,
                                 PlaceholderReplacer placeholderReplacer, String encoding,
                                 String sqlMigrationPrefix, String repeatableSqlMigrationPrefix,
-                                String sqlMigrationSeparator, String sqlMigrationSuffix) {
+                                String sqlMigrationSeparator, String sqlMigrationSuffix,
+                                SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor) {
         this.dbSupport = dbSupport;
         this.scanner = scanner;
         this.location = location;
@@ -115,6 +123,7 @@ public class SqlMigrationResolver implements MigrationResolver {
         this.repeatableSqlMigrationPrefix = repeatableSqlMigrationPrefix;
         this.sqlMigrationSeparator = sqlMigrationSeparator;
         this.sqlMigrationSuffix = sqlMigrationSuffix;
+        this.sqlMigrationScriptExecutionInterceptor = sqlMigrationScriptExecutionInterceptor;
     }
 
     public List<ResolvedMigration> resolveMigrations() {
@@ -143,7 +152,7 @@ public class SqlMigrationResolver implements MigrationResolver {
             migration.setChecksum(calculateChecksum(resource, resource.loadAsString(encoding)));
             migration.setType(MigrationType.SQL);
             migration.setPhysicalLocation(resource.getLocationOnDisk());
-            migration.setExecutor(new SqlMigrationExecutor(dbSupport, resource, placeholderReplacer, encoding));
+            migration.setExecutor(new SqlMigrationExecutor(dbSupport, resource, placeholderReplacer, encoding, sqlMigrationScriptExecutionInterceptor));
             migrations.add(migration);
         }
     }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -40,6 +40,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.FlywaySqlScriptException;
 import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
@@ -76,7 +77,7 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
                 new Location(getBasedir() + "/default"),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 "UTF-8",
-                "V", "R", "__", ".sql");
+                "V", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/derby/DerbyMigrationMediumTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLMigrationMediumTest.java
@@ -61,6 +61,11 @@ public class PostgreSQLMigrationMediumTest extends MigrationTestCase {
         return "migration/quote";
     }
 
+    @Override
+    protected boolean canRecoverFromAStatementError() {
+        return false;
+    }
+
     /**
      * Tests clean and migrate for PostgreSQL Types.
      */

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/info/MigrationInfoImplSmallTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010-2016 Boxfuse GmbH
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -42,7 +43,7 @@ public class CompositeMigrationResolverSmallTest {
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
                 new Scanner(Thread.currentThread().getContextClassLoader()), config,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                "UTF-8", "V", "R", "__", ".sql", placeholderReplacer, new MyCustomMigrationResolver());
+                "UTF-8", "V", "R", "__", ".sql", placeholderReplacer, new PassThroughSqlMigrationScriptExecutionInterceptor(), new MyCustomMigrationResolver());
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
@@ -149,7 +150,7 @@ public class CompositeMigrationResolverSmallTest {
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
                 new Scanner(Thread.currentThread().getContextClassLoader()), config,
                 new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
-                "UTF-8", "V", "R", "__", ".sql", PlaceholderReplacer.NO_PLACEHOLDERS);
+                "UTF-8", "V", "R", "__", ".sql", PlaceholderReplacer.NO_PLACEHOLDERS, new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -22,7 +22,9 @@ import javax.sql.DataSource;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.migration.sql.SqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 
 /**
  * Dummy Implementation of {@link FlywayConfiguration} for unit tests.
@@ -39,6 +41,7 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     private MyCustomMigrationResolver[] migrationResolvers = new MyCustomMigrationResolver[0];
     private boolean skipDefaultResolvers;
     private boolean skipDefaultCallbacks;
+    private SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor = new PassThroughSqlMigrationScriptExecutionInterceptor();
 
     public FlywayConfigurationForTests(ClassLoader contextClassLoader, String[] locations, String encoding,
             String sqlMigrationPrefix, String repeatableSqlMigrationPrefix, String sqlMigrationSeparator, String sqlMigrationSuffix,
@@ -131,6 +134,14 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public String getSqlMigrationPrefix() {
         return sqlMigrationPrefix;
+    }
+
+    public SqlMigrationScriptExecutionInterceptor getSqlMigrationScriptExecutionInterceptor() {
+        return sqlMigrationScriptExecutionInterceptor;
+    }
+
+    public void setSqlMigrationScriptExecutionInterceptor(SqlMigrationScriptExecutionInterceptor sqlMigrationScriptExecutionInterceptor){
+        this.sqlMigrationScriptExecutionInterceptor = sqlMigrationScriptExecutionInterceptor;
     }
 
     @Override

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -16,6 +16,7 @@
 package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -42,7 +43,7 @@ public class SqlMigrationResolverMediumTest {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
                         new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        "UTF-8", "V", "R", "__", ".sql");
+                        "UTF-8", "V", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.internal.migration.sql.PassThroughSqlMigrationScriptExecutionInterceptor;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -42,7 +43,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
-                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql");
+                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "V", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -62,7 +63,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsRoot() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql");
+                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "CheckValidate", "X", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -73,7 +74,7 @@ public class SqlMigrationResolverSmallTest {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
                         new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                            "CheckValidate", "R", "__", ".sql");
+                            "CheckValidate", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -82,7 +83,7 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
-                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -92,7 +93,7 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner, new Location(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql");
+                        PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8", "db_", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader())));
@@ -103,7 +104,7 @@ public class SqlMigrationResolverSmallTest {
         SqlMigrationResolver sqlMigrationResolver = 
                 new SqlMigrationResolver(null, scanner,
                         new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, "UTF-8",
-                            "V", "R", "__", ".sql");
+                            "V", "R", "__", ".sql", new PassThroughSqlMigrationScriptExecutionInterceptor());
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql")));
     }

--- a/flyway-core/src/test/resources/migration/catched_fail/V1__Should_Be_Catched.sql
+++ b/flyway-core/src/test/resources/migration/catched_fail/V1__Should_Be_Catched.sql
@@ -14,6 +14,8 @@
 -- limitations under the License.
 --
 
-CREATE TABLE test_table (
-  id INTEGER PRIMARY KEY AUTOINCREMENT
+THIS IS NOT VALID SQL;
+CREATE TABLE ${tableName} (
+  id int
 );
+THIS MIGRATION SHOULD FAIL;


### PR DESCRIPTION
Fixes #1175

I don't think it is a niche requirement.
In many DB provider such as PostgreSQL, there is no way to check for some object existence before creating them.
For example you cannot know if a column already exists before creating in one simple SQL line.

Moreover, SqlMigrationResolver being still impossible to extend, I think this feature is required.

Regards
