### PR TITLE
FIX: $user now replaced by username rather than empty string (postgres).

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLDbSupport.java
@@ -61,7 +61,15 @@ public class PostgreSQLDbSupport extends DbSupport {
     }
 
     /* private -> testing */ String getFirstSchemaFromSearchPath(String searchPath) {
-        String result = searchPath.replace(doQuote("$user"), "").trim();
+		String currentUser;
+		try {
+			currentUser = jdbcTemplate.queryForString("SELECT " + getCurrentUserFunction());
+		}
+		catch (SQLException ex) {
+			currentUser = "";
+		}
+		
+        String result = searchPath.replace(doQuote("$user"), currentUser).trim();
         if (result.startsWith(",")) {
             result = result.substring(1);
         }


### PR DESCRIPTION
By default, postgres configures such a search path for database roles:
"$user",public
To determine database schema, Flyway removes "$user" from a search path and takes the first schema from the remaining list.
This pull request replaces "$user" with a real user name (obtained from "SELECT current_user" query). So, by default, if no schema specified for a Flyway instance, $user schema will be used rather than public.
