### PR TITLE
WIP: #87; Adding a 'dryRun' feature to Flyway for supported DB types

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -137,6 +137,8 @@ public class Main {
             flyway.baseline();
         } else if ("migrate".equals(operation)) {
             flyway.migrate();
+        } else if ("dryrun".equals(operation)) {
+            flyway.dryRun();
         } else if ("validate".equals(operation)) {
             flyway.validate();
         } else if ("info".equals(operation)) {
@@ -217,6 +219,7 @@ public class Main {
         LOG.info("Commands");
         LOG.info("--------");
         LOG.info("migrate  : Migrates the database");
+        LOG.info("dryrun   : Migrates the database in a single transaction and then rolls it back regardless of the outcome (requires supported database type)");
         LOG.info("clean    : Drops all objects in the configured schemas");
         LOG.info("info     : Prints the information about applied, current and pending migrations");
         LOG.info("validate : Validates the applied migrations against the ones on the classpath");

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DryRun.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/DryRun.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
+import org.flywaydb.core.api.FlywayException;
+
+public class DryRun {
+    private static final String SAVEPOINT_MARKER = "dryrun";
+    private final Map<Connection, Savepoint> dryRunSavepoints = new WeakHashMap<Connection, Savepoint>();
+    private final int connectionCount;
+    
+    public DryRun(int transactionIsolationLevel, DbSupport dbSupport, Connection... connections) {
+        if (dbSupport == null) {
+            throw new NullPointerException("A Dry-run requires dbSupport to determine whether connections can support a rollback successfully.");
+        }
+
+        if (!dbSupport.supportsDdlTransactions()) {
+            throw new FlywayException("Dry-run is not supported with this database: " + dbSupport.getDbName());
+        }
+        for (Connection c : connections) {
+            try {
+                c.setTransactionIsolation(transactionIsolationLevel);
+                c.setAutoCommit(false);
+                dryRunSavepoints.put(c, c.setSavepoint(SAVEPOINT_MARKER));
+            } catch (Exception e) {
+                throw new FlywayException("Unable to start a dry-run: " + e.getMessage(), e);
+            }
+        }
+        connectionCount = connections.length;
+    }
+    
+    public DryRun(DbSupport dbSupport, Connection... connections) {
+        this(Connection.TRANSACTION_READ_COMMITTED, dbSupport, connections);
+    }
+
+    public void rollback() throws FlywayException {
+        FlywayException flywayException = null;
+        Iterator<Map.Entry<Connection, Savepoint>> it = dryRunSavepoints.entrySet().iterator();
+        int rollbacks = 0;
+        while (it.hasNext()) {
+            Map.Entry<Connection, Savepoint> entry = it.next();
+            try {
+                rollbacks++;
+                entry.getKey().rollback(entry.getValue());
+            } catch (SQLException e) {
+                flywayException = new FlywayException("Unable to rollback the 'dryrun' transaction", e);
+                // Keep going, attempt to rollback all provided connections
+            }
+            it.remove();
+        }
+        if (flywayException != null) {
+            throw flywayException;
+        }
+        if (rollbacks != connectionCount) {
+            throw new FlywayException("Only attempted to roll back " + rollbacks + " connections.  Dry-run was enabled for " + connectionCount + " connections.  Verify database integrity.");
+        }
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/TransactionTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/TransactionTemplate.java
@@ -70,7 +70,9 @@ public class TransactionTemplate {
             oldAutocommit = connection.getAutoCommit();
             connection.setAutoCommit(false);
             T result = transactionCallback.doInTransaction();
-            connection.commit();
+            if (oldAutocommit) {
+                connection.commit();
+            }
             return result;
         } catch (SQLException e) {
             throw new FlywayException("Unable to commit transaction", e);
@@ -85,7 +87,9 @@ public class TransactionTemplate {
                 }
             } else {
                 try {
-                    connection.commit();
+                    if (oldAutocommit) {
+                        connection.commit();
+                    }
                 } catch (SQLException se) {
                     LOG.error("Unable to commit transaction", se);
                 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/DryRunMigrateTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/DryRunMigrateTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.derby.DerbyDbSupport;
+import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
+import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
+import org.flywaydb.core.internal.dbsupport.sqlite.SQLiteDbSupport;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Run migration and rollback at end in a single transaction
+ */
+@SuppressWarnings({"JavaDoc"})
+public class DryRunMigrateTest 
+{
+    private final String SCHEMA_NAME= "PUBLIC";
+    
+    private void dryRun(boolean isSupported, SchemaFactory factory, String driverClass, String url, String user, String password, String... initSqls) throws SQLException {
+        DriverDataSource ds = new DriverDataSource(Thread.currentThread().getContextClassLoader(), driverClass, url, user, password, initSqls);
+        Connection conn = ds.getConnection();
+        Schema schema = factory.getSchema(conn);
+        assertTrue(schema.empty());
+        conn.close();
+        
+        Flyway flyway = new Flyway();
+        flyway.setDataSource(ds);
+        flyway.setLocations("migration/sql");
+        int statements = 0;
+        FlywayException flywayException = null;
+        try{
+            statements = flyway.dryRun();
+        } catch(FlywayException e){
+            flywayException = e;
+        }
+        
+        if(isSupported){
+            assertNull("If the database is supported, a flyway exception should not be thrown.", flywayException);
+            assertTrue("Dry-run should still report back the statements it would have run.", statements > 0);
+        } else {
+            assertNotNull(flywayException);
+            assertTrue("Unsupported databases should throw a Flyway Exception", flywayException.getMessage().toLowerCase().contains("dry-run"));
+        }
+        
+        conn = ds.getConnection();
+        schema = factory.getSchema(conn);
+        assertTrue(isSupported 
+                ? "Expected dry-run feature to have rolled back the migration(s)" 
+                : "Expected dry-run feature to fail validation and not perform any migration(s)", schema.empty());
+        conn.close();
+    }
+
+    @Test
+    public void dryRunTest_derbyIsSupported() throws Exception {
+        dryRun(true, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new DerbyDbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null, "jdbc:derby:memory:flyway_db;create=true", "", "");
+    }
+    
+    @Test
+    public void dryRunTest_hsqlIsNotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new HsqlDbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null, "jdbc:hsqldb:mem:flyway_db", "SA", "");
+    }
+    
+    @Test
+    public void dryRunTest_sqliteIsNotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                SQLiteDbSupport support = new SQLiteDbSupport(conn);
+                return support.getSchema(support.getCurrentSchemaName());
+            }
+        }, null, "jdbc:sqlite::memory:", "", "");
+    }
+    
+    @Test
+    public void dryRunTest_h2NotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new H2DbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null,"jdbc:h2:mem:flyway_db;DB_CLOSE_DELAY=-1", "sa", "");
+    }
+    
+    private interface SchemaFactory{
+        Schema getSchema(Connection conn);
+    }
+}

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/DryRunTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/DryRunTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import org.flywaydb.core.api.FlywayException;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DryRunTest {
+
+    @Mock
+    private DbSupport dbSupport;
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Connection connection1;
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Connection connection2;
+
+    @Before
+    public void setup() throws Exception {
+        when(dbSupport.supportsDdlTransactions()).thenReturn(true);
+        doThrow(new SQLException()).when(connection1).setTransactionIsolation(eq(Connection.TRANSACTION_SERIALIZABLE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void invalidParameters() throws Exception {
+        new DryRun(null);
+    }
+
+    @Test
+    public void noConnectionsDoesNothingOk() throws Exception {
+        DryRun dryRun = new DryRun(dbSupport);
+        dryRun.rollback();
+    }
+
+    @Test
+    public void multipleConnectionsRollback() throws Exception {
+        DryRun dryRun = new DryRun(dbSupport, connection1, connection2);
+        verify(connection1, times(1)).setSavepoint(anyString());
+        verify(connection2, times(1)).setSavepoint(anyString());
+        dryRun.rollback();
+        verify(connection1, times(1)).rollback(any(Savepoint.class));
+        verify(connection2, times(1)).rollback(any(Savepoint.class));
+    }
+
+    @Test(expected = FlywayException.class)
+    public void doesNotSupportDdlTransactions() throws Exception {
+        when(dbSupport.supportsDdlTransactions()).thenReturn(false);
+        new DryRun(dbSupport, connection1, connection2);
+    }
+
+    @Test(expected = FlywayException.class)
+    public void doesNotSupportTransactionIsolationLevel() throws Exception {
+        new DryRun(Connection.TRANSACTION_SERIALIZABLE, dbSupport, connection1, connection2);
+    }
+
+    @Test
+    public void errorOnRollbackContinuesForOtherConnections() throws Exception {
+        doThrow(new SQLException()).when(connection1).rollback(any(Savepoint.class));
+        DryRun dryRun = new DryRun(dbSupport, connection1, connection2);
+        verify(connection1, times(1)).setSavepoint(anyString());
+        FlywayException ex = null;
+        try{
+            dryRun.rollback();
+        } catch(FlywayException e){
+            ex = e;
+        }
+        verify(connection1, times(1)).rollback(any(Savepoint.class));
+        verify(connection2, times(1)).rollback(any(Savepoint.class));
+        assertNotNull("Expected a FlywayException to be thrown", ex);
+    }
+}


### PR DESCRIPTION
I'm still setting up test environments per the contribution guide to add tests for Postgres and other 'supported' databases, but I wanted to get this Work in Progress up for comment.