### PR TITLE
#87; Adding a 'dryRun' feature to Flyway for supported DB types

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -254,6 +254,7 @@ public class Main {
         LOG.info("configFile                   : Config file to use (default: conf/flyway.properties)");
         LOG.info("configFileEncoding           : Encoding of the config file (default: UTF-8)");
         LOG.info("jarDirs                      : Dirs for Jdbc drivers & Java migrations (default: jars)");
+        LOG.info("dryRun                       : Executes the given command in an isolated transaction and rolls back at the end regardless of the outcome (default: false)");
         LOG.info("");
         LOG.info("Add -X to print debug output");
         LOG.info("Add -q to suppress all output, except for errors and warnings");

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -52,6 +52,7 @@ import org.flywaydb.core.internal.util.scanner.Scanner;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Savepoint;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -76,7 +77,7 @@ public class Flyway implements FlywayConfiguration {
      * Property name prefix for placeholders that are configured through properties.
      */
     private static final String PLACEHOLDERS_PROPERTY_PREFIX = "flyway.placeholders.";
-
+    
     /**
      * The locations to scan recursively for migrations.
      * <p/>
@@ -200,6 +201,16 @@ public class Flyway implements FlywayConfiguration {
      * Whether to automatically call validate or not when running migrate. (default: {@code true})
      */
     private boolean validateOnMigrate = true;
+
+    /**
+     * Whether to perform a dry-run. (default: {@code false})
+     */
+    private boolean dryRun = false;
+    
+    /**
+     * The isolation level of the dry-run.  (default: TRANSACTION_READ_UNCOMMITTED (1) )
+     */
+    private int dryRunTransactionIsolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED;
 
     /**
      * Whether to automatically call clean or not when a validation error occurs. (default: {@code false})
@@ -407,6 +418,33 @@ public class Flyway implements FlywayConfiguration {
         return validateOnMigrate;
     }
 
+    /**
+     * Whether to perform a dry run of the migration
+     *
+     * @return {@code true} if the migration should roll back entirely when complete {@code false} if not. (default: {@code false})
+     */
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    /**
+     * 
+     * @return int value of Connection.TRANSACTION_{selected_isolation_level}
+     */
+    public int getDryRunTransactionIsolationLevel() {
+        return dryRunTransactionIsolationLevel;
+    }
+    
+    /**
+     * Whether to automatically call clean or not when a validation error occurs.
+     * <p> This is exclusively intended as a convenience for development. Even tough we
+     * strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a
+     * way of dealing with this case in a smooth manner. The database will be wiped clean automatically, ensuring that
+     * the next migration will bring you back to the state checked into SCM.</p>
+     * <p><b>Warning ! Do not enable in production !</b></p>
+     *
+     * @return {@code true} if clean should be called. {@code false} if not. (default: {@code false})
+     */
     @Override
     public boolean isCleanOnValidationError() {
         return cleanOnValidationError;
@@ -513,6 +551,38 @@ public class Flyway implements FlywayConfiguration {
      */
     public void setValidateOnMigrate(boolean validateOnMigrate) {
         this.validateOnMigrate = validateOnMigrate;
+    }
+
+    /**
+     * Whether to perform a Dry Run.
+     *
+     * @param dryRun {@code true} if the migration should roll back entirely when complete {@code false} if not. (default: {@code false})
+     */
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    /**
+     * Set the specific dry-run transaction isolation level.  
+     * <br/>
+     * Valid values are:
+     * <ul>
+     * <li>{@code Connection.TRANSACTION_READ_COMMITTED}
+     * <li>{@code Connection.TRANSACTION_READ_UNCOMMITTED}
+     * <li>{@code Connection.TRANSACTION_REPEATABLE_READ}
+     * <li>{@code Connection.TRANSACTION_SERIALIZABLE}
+     * </ul>
+     * 
+     * Consult your database documentation to see if any of the above are not supported by your specific database.  Future exceptions will be thrown if it is not.
+     * 
+     * @param dryRunTransactionIsolationLevel 
+     */
+    public void setDryRunTransactionIsolationLevel(int dryRunTransactionIsolationLevel) {
+        if(dryRunTransactionIsolationLevel == Connection.TRANSACTION_NONE || !Arrays.asList(Connection.TRANSACTION_READ_COMMITTED, Connection.TRANSACTION_READ_UNCOMMITTED, Connection.TRANSACTION_REPEATABLE_READ, Connection.TRANSACTION_SERIALIZABLE).contains(dryRunTransactionIsolationLevel)){
+            LOG.warn("An invalid transaction isolation level has been set for the 'dry-run' transaction; using the currently set level of: " + this.dryRunTransactionIsolationLevel + " instead of the provided value of "+dryRunTransactionIsolationLevel);
+        } else {
+            this.dryRunTransactionIsolationLevel = dryRunTransactionIsolationLevel;
+        }
     }
 
     /**
@@ -918,14 +988,19 @@ public class Flyway implements FlywayConfiguration {
                 }
 
                 Connection connectionUserObjects = null;
+                Savepoint dryRunSavepoint = null;
                 try {
                     connectionUserObjects =
                             dbSupport.useSingleConnection() ? connectionMetaDataTable : JdbcUtils.openConnection(dataSource);
+                    if (dryRun) {
+                        dryRunSavepoint = startDryRun(dbSupport, connectionMetaDataTable);
+                    }
                     DbMigrate dbMigrate =
                             new DbMigrate(connectionUserObjects, dbSupport, metaDataTable,
                                     schemas[0], migrationResolver, ignoreFailedFutureMigration, Flyway.this);
                     return dbMigrate.migrate();
                 } finally {
+                    rollbackDryRun(dryRunSavepoint, connectionMetaDataTable);
                     if (!dbSupport.useSingleConnection()) {
                         JdbcUtils.closeConnection(connectionUserObjects);
                     }
@@ -1206,6 +1281,10 @@ public class Flyway implements FlywayConfiguration {
         if (validateOnMigrateProp != null) {
             setValidateOnMigrate(Boolean.parseBoolean(validateOnMigrateProp));
         }
+        String dryRunProp = getValueAndRemoveEntry(props, "flyway.dryRun");
+        if (dryRunProp != null) {
+            setDryRun(Boolean.parseBoolean(dryRunProp));
+        }
         String baselineVersionProp = getValueAndRemoveEntry(props, "flyway.baselineVersion");
         if (baselineVersionProp != null) {
             setBaselineVersion(MigrationVersion.fromVersion(baselineVersionProp));
@@ -1292,6 +1371,29 @@ public class Flyway implements FlywayConfiguration {
         return value;
     }
 
+    private Savepoint startDryRun(DbSupport dbSupport, Connection connection) {
+        if (!dbSupport.supportsDdlTransactions()) {
+            throw new FlywayException("Dry-run is not supported with this database: " + dbSupport.getDbName());
+        }
+        try {
+            connection.setTransactionIsolation(dryRunTransactionIsolationLevel);
+            connection.setAutoCommit(false);
+            return connection.setSavepoint();
+        } catch (Exception e) {
+            throw new FlywayException("Dry-run is not supported with this database: " + dbSupport.getDbName(), e);
+        }
+    }
+
+    private void rollbackDryRun(Savepoint dryRunSavepoint, Connection connectionMetaDataTable) {
+        if (dryRun && dryRunSavepoint != null) {
+            try {
+                connectionMetaDataTable.rollback(dryRunSavepoint);
+            } catch (SQLException e) {
+                throw new FlywayException("Fatal error, unable to rollback 'Dry-run' database transaction", e);
+            }
+        }
+    }
+
     /**
      * Executes this command with proper resource handling and cleanup.
      *
@@ -1305,6 +1407,7 @@ public class Flyway implements FlywayConfiguration {
         VersionPrinter.printVersion();
 
         Connection connectionMetaDataTable = null;
+        Savepoint dryRunSavepoint = null;
 
         try {
             if (dataSource == null) {
@@ -1314,6 +1417,10 @@ public class Flyway implements FlywayConfiguration {
             connectionMetaDataTable = JdbcUtils.openConnection(dataSource);
 
             DbSupport dbSupport = DbSupportFactory.createDbSupport(connectionMetaDataTable, !dbConnectionInfoPrinted);
+            if (dryRun) {
+                dryRunSavepoint = startDryRun(dbSupport, connectionMetaDataTable);
+            }
+
             dbConnectionInfoPrinted = true;
             LOG.debug("DDL Transactions Supported: " + dbSupport.supportsDdlTransactions());
 
@@ -1359,6 +1466,7 @@ public class Flyway implements FlywayConfiguration {
 
             result = command.execute(connectionMetaDataTable, migrationResolver, metaDataTable, dbSupport, schemas, callbacks);
         } finally {
+            rollbackDryRun(dryRunSavepoint, connectionMetaDataTable);
             JdbcUtils.closeConnection(connectionMetaDataTable);
 
             if ((dataSource instanceof DriverDataSource) && createdDataSource) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/TransactionTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/TransactionTemplate.java
@@ -72,7 +72,9 @@ public class TransactionTemplate {
             oldAutocommit = connection.getAutoCommit();
             connection.setAutoCommit(false);
             T result = transactionCallback.call();
-            connection.commit();
+            if (oldAutocommit) {
+                connection.commit();
+            }
             return result;
         } catch (SQLException e) {
             throw new FlywayException("Unable to commit transaction", e);
@@ -104,7 +106,9 @@ public class TransactionTemplate {
                 }
             } else {
                 try {
-                    connection.commit();
+                    if (oldAutocommit) {
+                        connection.commit();
+                    }
                 } catch (SQLException se) {
                     LOG.error("Unable to commit transaction", se);
                 }

--- a/flyway-core/src/test/java/org/flywaydb/core/DryRunMigrateTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/DryRunMigrateTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.derby.DerbyDbSupport;
+import org.flywaydb.core.internal.dbsupport.h2.H2DbSupport;
+import org.flywaydb.core.internal.dbsupport.hsql.HsqlDbSupport;
+import org.flywaydb.core.internal.dbsupport.sqlite.SQLiteDbSupport;
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Run migration and rollback at end in a single transaction
+ */
+@SuppressWarnings({"JavaDoc"})
+public class DryRunMigrateTest {
+
+    private final String SCHEMA_NAME = "PUBLIC";
+
+    private void dryRun(boolean isSupported, SchemaFactory factory, String driverClass, String url, String user, String password, String... initSqls) throws SQLException {
+        DriverDataSource ds = new DriverDataSource(Thread.currentThread().getContextClassLoader(), driverClass, url, user, password, initSqls);
+        Connection conn = ds.getConnection();
+        Schema schema = factory.getSchema(conn);
+        assertTrue(schema.empty());
+        conn.close();
+
+        Flyway flyway = new Flyway();
+        flyway.setDataSource(ds);
+        flyway.setLocations("migration/sql");
+        flyway.setDryRun(true);
+        int statements = 0;
+        FlywayException flywayException = null;
+        try {
+            statements = flyway.migrate();
+        } catch (FlywayException e) {
+            flywayException = e;
+        }
+
+        if (isSupported) {
+            assertNull("If the database is supported, a flyway exception should not be thrown.", flywayException);
+            assertTrue("Dry-run should still report back the statements it would have run.", statements > 0);
+        } else {
+            assertNotNull(flywayException);
+            assertTrue("Unsupported databases should throw a Flyway Exception", flywayException.getMessage().toLowerCase().contains("dry-run"));
+        }
+
+        conn = ds.getConnection();
+        schema = factory.getSchema(conn);
+        assertTrue(isSupported
+                ? "Expected dry-run feature to have rolled back the migration(s)"
+                : "Expected dry-run feature to fail validation and not perform any migration(s)", schema.empty());
+        conn.close();
+    }
+
+    @Test
+    public void dryRunTest_derbyIsSupported() throws Exception {
+        dryRun(true, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new DerbyDbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null, "jdbc:derby:memory:flyway_db;create=true", "", "");
+    }
+
+    @Test
+    public void dryRunTest_hsqlIsNotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new HsqlDbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null, "jdbc:hsqldb:mem:flyway_db", "SA", "");
+    }
+
+    @Test
+    public void dryRunTest_sqliteInMemoryIsNotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                SQLiteDbSupport support = new SQLiteDbSupport(conn);
+                return support.getSchema(support.getCurrentSchemaName());
+            }
+        }, null, "jdbc:sqlite::memory:", "", "");
+    }
+
+    @Test
+    public void dryRunTest_h2NotSupported() throws Exception {
+        dryRun(false, new SchemaFactory() {
+            @Override
+            public Schema getSchema(Connection conn) {
+                return new H2DbSupport(conn).getSchema(SCHEMA_NAME);
+            }
+        }, null, "jdbc:h2:mem:flyway_db;DB_CLOSE_DELAY=-1", "sa", "");
+    }
+
+    private interface SchemaFactory {
+        Schema getSchema(Connection conn);
+    }
+}


### PR DESCRIPTION
Changes made to remove conflicts, squished commits. See https://github.com/flyway/flyway/pull/1454 for old pull request.

Changes from last pull request: removed "dryrun" as a target on the command line and as a method on Flyway.java.  Since anything can be a dry run (including baseline), it made sense to just use the config property to set a given command as a dry run; also, to alleviate concerns from @aldas that this may not be appropriate for all users.  As such, individuals wanting to use dryRun from the command line will have to set the property (and hopefully read the documentation).

A side note:

PS - I am completely unable to run the full test suite.  I tried.  No really, I tried a hell of a lot.  I was able to alter the pom.xml enough to run my tests, but I couldn't run all of the others... I kept getting AWS errors and google was unhelpful in getting past them all.  Before you say anything, yes, I tried "-P-InstallableDBTest -P-CommercialDBTest" and the many derivations found in google searches.

PPS - I'll happily write documentation for the feature, but I haven't yet learned how to submit that.  I'll go read the submission guidelines for documentation next.
