### PR TITLE
Fixed ClassCastException in AndroidScanner #1474

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/android/AndroidScanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/android/AndroidScanner.java
@@ -17,7 +17,6 @@ package org.flywaydb.core.internal.util.scanner.classpath.android;
 
 import android.content.Context;
 import dalvik.system.DexFile;
-import dalvik.system.PathClassLoader;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.android.ContextHolder;
 import org.flywaydb.core.internal.util.ClassUtils;
@@ -40,10 +39,10 @@ public class AndroidScanner implements ResourceAndClassScanner {
 
     private final Context context;
 
-    private final PathClassLoader classLoader;
+    private final ClassLoader classLoader;
 
     public AndroidScanner(ClassLoader classLoader) {
-        this.classLoader = (PathClassLoader) classLoader;
+        this.classLoader = classLoader;
         context = ContextHolder.getContext();
         if (context == null) {
             throw new FlywayException("Unable to scan for Migrations! Context not set. " +


### PR DESCRIPTION
Local classLoader typed to ClassLoader, not PathClassLoader
Removed unnecessary cast causing error.
