### PR TITLE
Issue #181

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -252,6 +252,13 @@ public interface FlywayConfiguration {
     boolean isValidateOnMigrate();
 
     /**
+     * Whether to globally commit or not when running migrate.
+     *
+     * @return {@code true} if migrate is globally atomic. {@code false} if each migration is committed. (default: {@code false})
+     */
+    boolean isMigrateAllOrNothing();
+
+    /**
      * Whether to automatically call clean or not when a validation error occurs.
      * <p> This is exclusively intended as a convenience for development. Even tough we
      * strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -221,6 +221,10 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
         return false;
     }
 
+    public boolean isMigrateAllOrNothing() {
+        return false;
+    }
+
     @Override
     public boolean isCleanOnValidationError() {
         return false;


### PR DESCRIPTION
Hello,

I addressed #181 for my own use; maybe this commit will help somebody else.


I introduced a `migrateAllOrNothing` parameter to enable atomic migrate commands (disabled by default).

Basically, it (optionally) wraps all the `DbMigrate.migrate()` logic in a global transaction, while disabling per-migration transactions and throwing a rollback-inducing exception on failure.


I didn't add appropriate unit tests and documentation, but if this PR were deemed acceptable, I could take the time to do so.

HTH