### PR TITLE
Throw exception if no migration found

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -205,6 +205,11 @@ public interface FlywayConfiguration {
     String[] getLocations();
 
     /**
+     * @return True if flyway will check the existence of migrations at given location.
+     */
+    boolean getCheckLocation();
+
+    /**
      * <p>
      * Whether to automatically call baseline when migrate is executed against a non-empty schema with no metadata table.
      * This schema will then be initialized with the {@code baselineVersion} before executing the migrations.

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
@@ -30,14 +30,19 @@ public class Scanner {
     private final ResourceAndClassScanner resourceAndClassScanner;
 
     private final ClassLoader classLoader;
-    private final FileSystemScanner fileSystemScanner = new FileSystemScanner();
+    private final FileSystemScanner fileSystemScanner;
 
     public Scanner(ClassLoader classLoader) {
+        this(classLoader, false);
+    }
+
+    public Scanner(ClassLoader classLoader, boolean checkLocation) {
         this.classLoader = classLoader;
+        this.fileSystemScanner = new FileSystemScanner(checkLocation);
         if (new FeatureDetector(classLoader).isAndroidAvailable()) {
             resourceAndClassScanner = new AndroidScanner(classLoader);
         } else {
-            resourceAndClassScanner = new ClassPathScanner(classLoader);
+            resourceAndClassScanner = new ClassPathScanner(classLoader, checkLocation);
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/filesystem/FileSystemScanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/filesystem/FileSystemScanner.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.util.scanner.filesystem;
 
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.logging.Log;
 import org.flywaydb.core.internal.util.logging.LogFactory;
@@ -30,6 +31,17 @@ import java.util.TreeSet;
  */
 public class FileSystemScanner {
     private static final Log LOG = LogFactory.getLog(FileSystemScanner.class);
+    private final boolean checkLocation;
+
+    /**
+     * Creates a new FileSystemScanner.
+     *
+     * @param checkLocation If set to true, Flyway will throw an exception if the location does not
+     *                      contain any migration script.
+     */
+    public FileSystemScanner(boolean checkLocation) {
+        this.checkLocation = checkLocation;
+    }
 
     /**
      * Scans the FileSystem for resources under the specified location, starting with the specified prefix and ending with
@@ -40,6 +52,7 @@ public class FileSystemScanner {
      * @param suffix   The suffix of the resource names to match.
      * @return The resources that were found.
      * @throws java.io.IOException when the location could not be scanned.
+     * @throws FlywayException if the location does not contain any migration script
      */
     public Resource[] scanForResources(Location location, String prefix, String suffix) throws IOException {
         String path = location.getPath();
@@ -48,6 +61,9 @@ public class FileSystemScanner {
         File dir = new File(path);
         if (!dir.isDirectory() || !dir.canRead()) {
             LOG.warn("Unable to resolve location filesystem:" + path);
+            if (checkLocation) {
+                throw new FlywayException("No migration detected at filesystem location " + path);
+            }
             return new Resource[0];
         }
 

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywayMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywayMediumTest.java
@@ -593,6 +593,15 @@ public class FlywayMediumTest {
         flyway.migrate();
     }
 
+    @Test(expected = FlywayException.class)
+    public void invalidLocationsWithException() {
+        Flyway flyway = new Flyway();
+        flyway.setDataSource("jdbc:h2:mem:flyway_validate_pending;DB_CLOSE_DELAY=-1", "sa", "");
+        flyway.setLocations("abcd", "efgh");
+        flyway.setCheckLocation(true);
+        flyway.migrate();
+    }
+
     @Test
     public void validateOutOfOrder() {
         Flyway flyway = new Flyway();

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -31,6 +31,7 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
 
     private ClassLoader classLoader;
     private String[] locations = new String[0];
+    private boolean checkLocation;
     private String encoding;
     private String sqlMigrationPrefix;
     private String repeatableSqlMigrationPrefix;
@@ -59,6 +60,10 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
 
     public void setLocations(String[] locations) {
         this.locations = locations;
+    }
+
+    public void setCheckLocation(boolean checkLocation) {
+        this.checkLocation= checkLocation;
     }
 
     public void setEncoding(String encoding) {
@@ -199,6 +204,11 @@ public class FlywayConfigurationForTests implements FlywayConfiguration {
     @Override
     public String[] getLocations() {
         return this.locations;
+    }
+
+    @Override
+    public boolean getCheckLocation() {
+        return this.checkLocation;
     }
 
     @Override

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.flywaydb.core.internal.dbsupport.db2.DB2MigrationMediumTest;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
@@ -111,6 +112,12 @@ public class ClassPathScannerSmallTest {
     @Test
     public void scanForResourcesInvalidPath() throws Exception {
         classPathScanner.scanForResources(new Location("classpath:invalid"), "V", ".sql");
+    }
+
+    @Test(expected = FlywayException.class)
+    public void scanForResourcesInvalidPathWithException() throws Exception {
+        new ClassPathScanner(Thread.currentThread().getContextClassLoader(), true).
+            scanForResources(new Location("classpath:invalid"), "V", ".sql");
     }
 
     @Test

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/filesystem/FileSystemScannerMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/filesystem/FileSystemScannerMediumTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.util.scanner.filesystem;
 
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.util.Location;
 import org.junit.Test;
 
@@ -24,6 +25,11 @@ import org.junit.Test;
 public class FileSystemScannerMediumTest {
     @Test
     public void nonExistentDirectory() throws Exception {
-        new FileSystemScanner().scanForResources(new Location("filesystem:/invalid-path"), "", "");
+        new FileSystemScanner(false).scanForResources(new Location("filesystem:/invalid-path"), "", "");
+    }
+
+    @Test(expected = FlywayException.class)
+    public void nonExistentDirectoryWithException() throws Exception {
+        new FileSystemScanner(true).scanForResources(new Location("filesystem:/invalid-path"), "", "");
     }
 }


### PR DESCRIPTION
Added property `checkLocation` for FlywayConfiguration. If this property is set to false
(default), then flyway will only log a warning if no migration script is found at a location.
If set to true, flyway will throw an exception. Unit tests for this feature are also added.

This feature is helpful if users want their program to fail fast when no migrations are detected
at a given location.

Fixes #1496