### PR TITLE
Retry to obtain db connection during mojo execution.

### DIFF
--- a/flyway-maven-plugin/pom.xml
+++ b/flyway-maven-plugin/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/ConnectionReadyDelay.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/ConnectionReadyDelay.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.maven;
+
+import org.flywaydb.core.internal.util.logging.Log;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A delay-retry mechanism to wait for database connection.
+ *
+ * @author nick.ilkevich@gmail.com
+ */
+class ConnectionReadyDelay {
+
+    private final int maxRetries;
+    private final Log log;
+    private int retries;
+
+    ConnectionReadyDelay(final Log log, final Integer maxRetries) {
+        this.log = log;
+        this.maxRetries = (maxRetries != null && maxRetries > 0) ? maxRetries : 0;
+        this.retries = 0;
+    }
+
+
+    void waitTillConnectionReady(ConnectionChecker checker) throws Exception {
+        try {
+            checker.check();
+        } catch (Exception e) {
+            retries++;
+
+            if (retries > maxRetries) {
+                throw e;
+            }
+
+            log.info(String.format("[%s/%s] Retry... %s", retries, maxRetries, e.getMessage()));
+            sleep();
+            waitTillConnectionReady(checker);
+        }
+    }
+
+
+    void sleep() throws InterruptedException {
+        TimeUnit.SECONDS.sleep(1);
+    }
+
+    /**
+     * Interface to checking connection
+     */
+    interface ConnectionChecker {
+        void check() throws Exception;
+    }
+
+}

--- a/flyway-maven-plugin/src/test/java/org/flywaydb/maven/ConnectionReadyDelaySmallTest.java
+++ b/flyway-maven-plugin/src/test/java/org/flywaydb/maven/ConnectionReadyDelaySmallTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2010-2016 Boxfuse GmbH
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.maven;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.util.logging.Log;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectionReadyDelaySmallTest {
+
+    @Spy
+    private DummyChecker checker;
+    @Mock
+    private Log log;
+
+    @Test
+    public void shouldExecuteImmediatelyWhenOptionNotSpecified() throws Exception {
+        final ConnectionReadyDelay delay = new ConnectionReadyDelay(log, null);
+        delay.waitTillConnectionReady(checker);
+        verify(checker).check();
+    }
+
+    @Test(expected = FlywayException.class)
+    public void shouldReThrowWhenMaxRetriesReached() throws Exception {
+        final ConnectionReadyDelay delay = spy(new ConnectionReadyDelay(log, 15));
+        doThrow(FlywayException.class).when(checker).check();
+        doNothing().when(delay).sleep();
+
+        delay.waitTillConnectionReady(checker);
+
+        verify(checker, times(15)).check();
+    }
+
+    @Test
+    public void shouldExecuteTillDbConnectionUp() throws Exception {
+        Throwable[] errors = new Throwable[5];
+        Arrays.fill(errors, new FlywayException());
+
+        final ConnectionReadyDelay delay = spy(new ConnectionReadyDelay(log, 15));
+
+        when(checker.doCheck()).thenThrow(errors).thenReturn("OK");
+        doNothing().when(delay).sleep();
+
+        delay.waitTillConnectionReady(checker);
+
+        verify(checker, times(6)).check();
+    }
+
+    private static class DummyChecker implements ConnectionReadyDelay.ConnectionChecker {
+
+        @Override
+        public void check() throws Exception {
+            doCheck();
+        }
+
+        Object doCheck() {
+            return new Random();
+        }
+    }
+}


### PR DESCRIPTION
Problem:
A build pipeline might include additional steps in order to fire up a database instance, e.g. a mysql instance inside docker container. The startup process might be asynchronous and Flyway Maven Plugin will crash immediately. 

Solution:
Added an optional parameter 'maxRetries'. The plugin will try to obtain connection every 1 second till connection will be obtained or 'maxRetries' reached. When 'maxRetries' is reached, an exception will be thrown. The parameter 'maxRetries' has default value 0, that means retries won't be performed.