### PR TITLE
Adding support for dashDB (db2)

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2/createMetaDataTable.sql
@@ -26,7 +26,7 @@ CREATE TABLE "${schema}"."${table}" (
     "execution_time" INT NOT NULL,
     "success" SMALLINT NOT NULL,
     CONSTRAINT "${table}_s" CHECK ("success" in(0,1))
-);
+) ORGANIZE BY ROW; -- Row organization is default for db2 but not for dashDB
 ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
 
 CREATE INDEX "${schema}"."${table}_s_idx" ON "${schema}"."${table}" ("success");


### PR DESCRIPTION
dashDB is a db2 database on Bluemix (IBM cloud - see https://www.ibm.com/analytics/us/en/technology/cloud-data-services/dashdb).
On dashDB, tables are organized by columns (on db2, by row).