### PR TITLE
Make default resolvers handle all locations in one instance

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -67,13 +67,12 @@ public class CompositeMigrationResolver implements MigrationResolver {
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         if (!configuration.isSkipDefaultResolvers()) {
-            for (Location location : locations.getLocations()) {
-                migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, location, placeholderReplacer, configuration));
-                migrationResolvers.add(new JdbcMigrationResolver(scanner, location, configuration));
 
-                if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                    migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, location, configuration));
-                }
+            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, locations, placeholderReplacer, configuration));
+            migrationResolvers.add(new JdbcMigrationResolver(scanner, locations, configuration));
+
+            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
+                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, locations, configuration));
             }
         }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -21,17 +21,15 @@ import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
-import org.flywaydb.core.internal.util.ClassUtils;
-import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
-import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Pair;
-import org.flywaydb.core.internal.util.StringUtils;
+import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationExecutor;
+import org.flywaydb.core.internal.util.*;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 
 import java.util.ArrayList;
@@ -45,9 +43,9 @@ import java.util.List;
  */
 public class SpringJdbcMigrationResolver implements MigrationResolver {
     /**
-     * The base package on the classpath where to migrations are located.
+     * The base packages on the classpath where to migrations are located.
      */
-    private final Location location;
+    private final Locations locations;
 
     /**
      * The Scanner to use.
@@ -62,24 +60,32 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param location      The base package on the classpath where to migrations are located.
+     * @param locations     The base packages on the classpath where to migrations are located.
      * @param scanner       The Scanner for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(Scanner scanner, Location location, FlywayConfiguration configuration) {
-        this.location = location;
+    public SpringJdbcMigrationResolver(Scanner scanner, Locations locations, FlywayConfiguration configuration) {
+        this.locations = locations;
         this.scanner = scanner;
         this.configuration = configuration;
     }
 
     @Override
-    public Collection<ResolvedMigration> resolveMigrations() {
+    public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        if (!location.isClassPath()) {
-            return migrations;
+        for (Location location : locations.getLocations()) {
+            if (!location.isClassPath()) {
+                continue;
+            }
+            resolveMigrationsForSingleLocation(location, migrations);
         }
 
+        Collections.sort(migrations, new ResolvedMigrationComparator());
+        return migrations;
+    }
+
+    protected void resolveMigrationsForSingleLocation(Location location, List<ResolvedMigration> migrations) {
         try {
             Class<?>[] classes = scanner.scanForClasses(location, SpringJdbcMigration.class);
             for (Class<?> clazz : classes) {
@@ -95,9 +101,6 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
         } catch (Exception e) {
             throw new FlywayException("Unable to resolve Spring Jdbc Java migrations in location: " + location, e);
         }
-
-        Collections.sort(migrations, new ResolvedMigrationComparator());
-        return migrations;
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -27,6 +27,7 @@ import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.Pair;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
@@ -56,9 +57,9 @@ public class SqlMigrationResolver implements MigrationResolver {
     private final Scanner scanner;
 
     /**
-     * The base directory on the classpath where to migrations are located.
+     * The base directories on the classpath where the migrations are located.
      */
-    private final Location location;
+    private final Locations locations;
 
     /**
      * The placeholder replacer to apply to sql migration scripts.
@@ -75,15 +76,15 @@ public class SqlMigrationResolver implements MigrationResolver {
      *
      * @param dbSupport                    The database-specific support.
      * @param scanner                      The Scanner for loading migrations on the classpath.
-     * @param location                     The location on the classpath where to migrations are located.
+     * @param locations                    The locations on the classpath where to migrations are located.
      * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
      * @param configuration                The Flyway configuration.
      */
-    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Location location,
+    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Locations locations,
                                 PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
         this.dbSupport = dbSupport;
         this.scanner = scanner;
-        this.location = location;
+        this.locations = locations;
         this.placeholderReplacer = placeholderReplacer;
         this.configuration = configuration;
     }
@@ -91,14 +92,16 @@ public class SqlMigrationResolver implements MigrationResolver {
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        scanForMigrations(migrations, configuration.getSqlMigrationPrefix(), configuration.getSqlMigrationSeparator(), configuration.getSqlMigrationSuffix());
-        scanForMigrations(migrations, configuration.getRepeatableSqlMigrationPrefix(), configuration.getSqlMigrationSeparator(), configuration.getSqlMigrationSuffix());
+        for (Location location: locations.getLocations()) {
+            scanForMigrations(location, migrations, configuration.getSqlMigrationPrefix(), configuration.getSqlMigrationSeparator(), configuration.getSqlMigrationSuffix());
+            scanForMigrations(location, migrations, configuration.getRepeatableSqlMigrationPrefix(), configuration.getSqlMigrationSeparator(), configuration.getSqlMigrationSuffix());
+        }
 
         Collections.sort(migrations, new ResolvedMigrationComparator());
         return migrations;
     }
 
-    private void scanForMigrations(List<ResolvedMigration> migrations, String prefix, String separator, String suffix) {
+    private void scanForMigrations(Location location, List<ResolvedMigration> migrations, String prefix, String separator, String suffix) {
         for (Resource resource : scanner.scanForResources(location, prefix, suffix)) {
             String filename = resource.getFilename();
             if (isSqlCallback(filename, suffix)) {
@@ -110,7 +113,7 @@ public class SqlMigrationResolver implements MigrationResolver {
             ResolvedMigrationImpl migration = new ResolvedMigrationImpl();
             migration.setVersion(info.getLeft());
             migration.setDescription(info.getRight());
-            migration.setScript(extractScriptName(resource));
+            migration.setScript(extractScriptName(resource, location));
             migration.setChecksum(calculateChecksum(resource, resource.loadAsString(configuration.getEncoding())));
             migration.setType(MigrationType.SQL);
             migration.setPhysicalLocation(resource.getLocationOnDisk());
@@ -138,7 +141,7 @@ public class SqlMigrationResolver implements MigrationResolver {
      * @param resource The resource to process.
      * @return The script name.
      */
-    /* private -> for testing */ String extractScriptName(Resource resource) {
+    /* private -> for testing */ String extractScriptName(Resource resource, Location location) {
         if (location.getPath().isEmpty()) {
             return resource.getLocation();
         }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -43,6 +43,7 @@ import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -74,7 +75,7 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
                 dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
-                new Location(getBasedir() + "/default"),
+                new Locations(getBasedir() + "/default"),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -22,6 +22,7 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
@@ -42,13 +43,13 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -21,6 +21,7 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.spring.dummy.V2__InterfaceBasedMigration;
 import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class SpringJdbcMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Location("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class SqlMigrationResolverMediumTest {
 
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
-                        new Location("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
+                        new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
                         FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
@@ -41,7 +42,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, scanner,
-                        new Location("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                        new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -62,7 +63,7 @@ public class SqlMigrationResolverSmallTest {
         FlywayConfigurationForTests configuration = FlywayConfigurationForTests.createWithPrefix("CheckValidate");
         configuration.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
+                new SqlMigrationResolver(null, scanner, new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -72,7 +73,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, scanner,
-                        new Location("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
+                        new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -81,29 +82,32 @@ public class SqlMigrationResolverSmallTest {
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, scanner,
-                        new Location("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
+                        new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
-                new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader())));
+                new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()),
+                new Location("db/migration")));
     }
 
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Location(""),
+                new SqlMigrationResolver(null, scanner, new Locations(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
-                new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader())));
+                new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()),
+                new Location("")));
     }
 
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
                 new SqlMigrationResolver(null, scanner,
-                        new Location("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                        new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
 
-        assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql")));
+        assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),
+                new Location("filesystem:/some/dir")));
     }
 
     @Test

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -31,6 +31,7 @@ import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.flywaydb.core.internal.util.scanner.Scanner;
@@ -300,7 +301,7 @@ public abstract class MigrationTestCase {
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
                 dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
-                new Location(getBasedir()),
+                new Locations(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();


### PR DESCRIPTION
... instead of the previous 'one resolver per single location'. This makes the default resolvers behave more like custom resolvers and is a step on the way to eventually allow subclasses of default resolvers as custom resolvers.

This PR has no direct effect in itself, but provides only the base. 

This is basically a revisit of #1183 and #1185 

@axelfontaine : Since there will be more than one commit to this topic, I would rather put them all into one PR but as separate commits. Or do you rather want single PRs for all steps?