### PR TITLE
Default constructors for jdbc resolvers

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1139,7 +1139,7 @@ public class Flyway implements FlywayConfiguration {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations, createPlaceholderReplacer(), resolvers);
+        return new CompositeMigrationResolver(dbSupport, this);
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1132,15 +1132,14 @@ public class Flyway implements FlywayConfiguration {
      * Creates the MigrationResolver.
      *
      * @param dbSupport The database-specific support.
-     * @param scanner   The Scanner for resolving migrations.
      * @return A new, fully configured, MigrationResolver instance.
      */
-    private MigrationResolver createMigrationResolver(DbSupport dbSupport, Scanner scanner) {
+    private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
         for (MigrationResolver resolver : resolvers) {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, scanner, this, locations, createPlaceholderReplacer(), resolvers);
+        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations, createPlaceholderReplacer(), resolvers);
     }
 
     /**
@@ -1390,8 +1389,9 @@ public class Flyway implements FlywayConfiguration {
                 schemas[i] = dbSupport.getSchema(schemaNames[i]);
             }
 
-            Scanner scanner = new Scanner(classLoader);
-            MigrationResolver migrationResolver = createMigrationResolver(dbSupport, scanner);
+            // force creation of a new Scanner to prevent location caching, because the classpath might have been changed
+            Scanner scanner = Scanner.createNew(classLoader);
+            MigrationResolver migrationResolver = createMigrationResolver(dbSupport);
 
             if (!skipDefaultCallbacks) {
                 Set<FlywayCallback> flywayCallbacks = new LinkedHashSet<FlywayCallback>(Arrays.asList(callbacks));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -56,23 +56,24 @@ public class CompositeMigrationResolver implements MigrationResolver {
     /**
      * Creates a new CompositeMigrationResolver.
      *
-     * @param dbSupport                The database-specific support.
-     * @param scanner                  The Scanner for loading migrations on the classpath.
+     * @param dbSupport                    The database-specific support.
+     * @param classLoader                      The classloader for loading migrations on the classpath.
      * @param configuration            The Flyway configuration.
-     * @param locations                The locations where migrations are located.
-     * @param placeholderReplacer      The placeholder replacer to use.
-     * @param customMigrationResolvers Custom Migration Resolvers.
+     * @paramlocations                    The locations where migrations are located.
+
+     * @param placeholderReplacer          The placeholder replacer to use.
+     * @param customMigrationResolvers     Custom Migration Resolvers.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, Scanner scanner, FlywayConfiguration configuration, Locations locations,
+    public CompositeMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, FlywayConfiguration configuration, Locations locations,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         if (!configuration.isSkipDefaultResolvers()) {
 
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, locations, placeholderReplacer, configuration));
-            migrationResolvers.add(new JdbcMigrationResolver(scanner, locations, configuration));
+            migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, locations, placeholderReplacer, configuration));
+            migrationResolvers.add(new JdbcMigrationResolver(classLoader, locations, configuration));
 
-            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, locations, configuration));
+            if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
+                migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, locations, configuration));
             }
         }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -57,13 +57,11 @@ public class JdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The base packages on the classpath where to migrations are located.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public JdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -58,12 +58,12 @@ public class JdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param locations     The base packages on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(Scanner scanner, Locations locations, FlywayConfiguration configuration) {
+    public JdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
         this.locations = locations;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -19,6 +19,7 @@ import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
@@ -38,11 +39,7 @@ import java.util.List;
  * Migration resolver for Jdbc migrations. The classes must have a name like R__My_description, V1__Description
  * or V1_1_3__Description.
  */
-public class JdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base package on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class JdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -54,22 +51,16 @@ public class JdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public JdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) {
                 continue;
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -15,25 +15,23 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
-import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationExecutor;
 import org.flywaydb.core.internal.util.*;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,11 +39,7 @@ import java.util.List;
  * Migration resolver for Spring Jdbc migrations. The classes must have a name like V1 or V1_1_3 or V1__Description
  * or V1_1_3__Description.
  */
-public class SpringJdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base packages on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class SpringJdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -57,22 +51,16 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) {
                 continue;
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -61,12 +61,12 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param locations     The base packages on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(Scanner scanner, Locations locations, FlywayConfiguration configuration) {
+    public SpringJdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
         this.locations = locations;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -60,13 +60,11 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The base packages on the classpath where to migrations are located.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -75,15 +75,15 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
-     * @param scanner                      The Scanner for loading migrations on the classpath.
+     * @param classloader                  The classloader for loading migrations from the classpath.
      * @param locations                    The locations on the classpath where to migrations are located.
      * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
      * @param configuration                The Flyway configuration.
      */
-    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Locations locations,
+    public SqlMigrationResolver(DbSupport dbSupport, ClassLoader classloader, Locations locations,
                                 PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
         this.dbSupport = dbSupport;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classloader);
         this.locations = locations;
         this.placeholderReplacer = placeholderReplacer;
         this.configuration = configuration;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -75,18 +75,24 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
-     * @param classloader                  The classloader for loading migrations from the classpath.
-     * @param locations                    The locations on the classpath where to migrations are located.
-     * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
-     * @param configuration                The Flyway configuration.
+     * @param configuration                The configuration object.
      */
-    public SqlMigrationResolver(DbSupport dbSupport, ClassLoader classloader, Locations locations,
-                                PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
+    public SqlMigrationResolver(DbSupport dbSupport, FlywayConfiguration configuration) {
         this.dbSupport = dbSupport;
-        this.scanner = Scanner.create(classloader);
-        this.locations = locations;
-        this.placeholderReplacer = placeholderReplacer;
+        this.scanner = Scanner.create(configuration.getClassLoader());
+        this.locations = new Locations(configuration.getLocations());
+        this.placeholderReplacer = createPlaceholderReplacer(configuration);
         this.configuration = configuration;
+    }
+
+    /**
+     * @return A new, fully configured, PlaceholderReplacer.
+     */
+    private PlaceholderReplacer createPlaceholderReplacer(FlywayConfiguration config) {
+        if (config.isPlaceholderReplacement()) {
+            return new PlaceholderReplacer(config.getPlaceholders(), config.getPlaceholderPrefix(), config.getPlaceholderSuffix());
+        }
+        return PlaceholderReplacer.NO_PLACEHOLDERS;
     }
 
     public List<ResolvedMigration> resolveMigrations() {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
@@ -19,7 +19,7 @@ import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 
 /**
- * Utility class for interfaced based injection.
+ * Utility class for interface based injection.
  */
 public class ConfigurationInjectionUtils {
 
@@ -30,13 +30,13 @@ public class ConfigurationInjectionUtils {
     /**
      * Injects the given flyway configuration into the target object if target implements the
      * {@link ConfigurationAware} interface. Does nothing if target is not configuration aware.
-     *
      * @param target The object to inject the configuration into.
      * @param configuration The configuration to inject.
      */
-    public static void injectFlywayConfiguration(Object target, FlywayConfiguration configuration) {
+    public static <T> T injectFlywayConfiguration(T target, FlywayConfiguration configuration) {
         if (target instanceof ConfigurationAware) {
             ((ConfigurationAware) target).setFlywayConfiguration(configuration);
         }
+        return target;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
@@ -18,10 +18,14 @@ package org.flywaydb.core.internal.util.scanner;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ResourceAndClassScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.android.AndroidScanner;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemScanner;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Scanner for Resources and Classes.
@@ -32,13 +36,48 @@ public class Scanner {
     private final ClassLoader classLoader;
     private final FileSystemScanner fileSystemScanner = new FileSystemScanner();
 
-    public Scanner(ClassLoader classLoader) {
+    private Scanner(ClassLoader classLoader) {
         this.classLoader = classLoader;
         if (new FeatureDetector(classLoader).isAndroidAvailable()) {
             resourceAndClassScanner = new AndroidScanner(classLoader);
         } else {
             resourceAndClassScanner = new ClassPathScanner(classLoader);
         }
+    }
+
+    private static Map<ClassLoader, WeakReference<Scanner>> scannerCache = new WeakHashMap<ClassLoader, WeakReference<Scanner>>();
+
+    /**
+     * Create or retrieves a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key.
+     * @param classLoader The classloader to scan.
+     * @return A new or existing Scanner instance, never null.
+     */
+    public static synchronized Scanner create(ClassLoader classLoader) {
+        WeakReference<Scanner> result = scannerCache.get(classLoader);
+
+        if (result == null || result.get() == null) {
+            return createNew(classLoader);
+        }
+
+        return result.get();
+    }
+
+    /**
+     * Creates a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key. This method is necessary when flyway is methods are called a) multiple times
+     * in one run, b) using the same classloader and c) when the classpath of the classloader changes between
+     * invocations. This can happen for example in the Maven plugin in a "clean migrate" scenario, where between
+     * the clean step an the migrate step source code is compiled / copied and the classloader extended (with the
+     * target/classes folder, Maven 2 did create a new classloader, thus the problem did not occur).
+     * @param classLoader The classloader to scan.
+     * @return A new Scanner instance, never null.
+     */
+    public static synchronized Scanner createNew(ClassLoader classLoader) {
+        WeakReference<Scanner> result = new WeakReference<Scanner>(new Scanner(classLoader));
+        scannerCache.put(classLoader, result);
+
+        return result.get();
     }
 
     /**

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -74,7 +74,7 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
     @Override
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, Thread.currentThread().getContextClassLoader(),
                 new Locations(getBasedir() + "/default"),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -71,13 +71,9 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
         }
     }
 
-    @Override
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Locations(getBasedir() + "/default"),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                FlywayConfigurationForTests.create());
+                dbSupport, FlywayConfigurationForTests.createWithLocations(getBasedir() + "/default"));
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -22,7 +22,6 @@ import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.util.*;
@@ -36,13 +35,10 @@ import static org.junit.Assert.assertTrue;
 public class CompositeMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsMultipleLocations() {
-        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1");
+        config.setResolvers(new MyCustomMigrationResolver());
 
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                Thread.currentThread().getContextClassLoader(), config,
-                new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                placeholderReplacer, new MyCustomMigrationResolver());
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
@@ -143,13 +139,10 @@ public class CompositeMigrationResolverSmallTest {
 
     @Test
     public void skipDefaultResolvers() {
-        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy");
         config.setSkipDefaultResolvers(true);
 
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                Thread.currentThread().getContextClassLoader(), config,
-                new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
-                PlaceholderReplacer.NO_PLACEHOLDERS);
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -40,7 +40,7 @@ public class CompositeMigrationResolverSmallTest {
 
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                Thread.currentThread().getContextClassLoader(), config,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
                 placeholderReplacer, new MyCustomMigrationResolver());
 
@@ -147,7 +147,7 @@ public class CompositeMigrationResolverSmallTest {
         config.setSkipDefaultResolvers(true);
 
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                Thread.currentThread().getContextClassLoader(), config,
                 new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
                 PlaceholderReplacer.NO_PLACEHOLDERS);
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -24,6 +24,7 @@ import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -43,15 +44,14 @@ public class JdbcMigrationResolverSmallTest {
     @Test(expected = FlywayException.class)
     public void broken() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
-        new JdbcMigrationResolver(config).resolveMigrations();
+        ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
 
-        JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(config);
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -78,7 +78,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -87,7 +87,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -42,13 +42,16 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
+        new JdbcMigrationResolver(config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
+
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -75,7 +78,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -84,7 +87,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -15,8 +15,8 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
-import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
@@ -38,18 +38,17 @@ import static org.junit.Assert.assertNull;
  * Test for JdbcMigrationResolver.
  */
 public class JdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -76,7 +75,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -85,7 +84,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -41,8 +42,7 @@ public class SpringJdbcMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
-        SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -61,7 +61,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -70,7 +70,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -36,13 +36,12 @@ import static org.junit.Assert.assertNull;
  * Test for SpringJdbcMigrationResolver.
  */
 public class SpringJdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -61,7 +60,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -70,7 +69,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -40,8 +40,9 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrations() {
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -60,7 +61,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -69,7 +70,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.io.File;
@@ -42,7 +41,7 @@ public class SqlMigrationResolverMediumTest {
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
                         FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -18,8 +18,7 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,10 +39,8 @@ public class SqlMigrationResolverMediumTest {
         @SuppressWarnings("ConstantConditions")
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        FlywayConfigurationForTests.create());
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:" + new File(path).getPath());
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(null, config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -18,8 +18,6 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -38,8 +36,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("migration/subdir"));
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -57,10 +54,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsRoot() {
-        FlywayConfigurationForTests configuration = FlywayConfigurationForTests.createWithPrefix("CheckValidate");
-        configuration.setRepeatableSqlMigrationPrefix("X");
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "");
+        config.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
+                new SqlMigrationResolver(null, config);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -69,8 +66,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing"));
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -78,8 +74,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -89,8 +84,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations(""));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -100,8 +94,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir"));
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),
                 new Location("filesystem:/some/dir")));

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -36,12 +35,10 @@ import static org.junit.Assert.*;
  */
 public class SqlMigrationResolverSmallTest {
 
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
-
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
@@ -63,7 +60,7 @@ public class SqlMigrationResolverSmallTest {
         FlywayConfigurationForTests configuration = FlywayConfigurationForTests.createWithPrefix("CheckValidate");
         configuration.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -72,7 +69,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
 
         sqlMigrationResolver.resolveMigrations();
@@ -81,7 +78,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -92,7 +89,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Locations(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -103,7 +100,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -298,12 +298,10 @@ public abstract class MigrationTestCase {
      * @param migrationInfo
      *            The migration to check.
      */
-    protected void assertChecksum(MigrationInfo migrationInfo) {
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Locations(getBasedir()),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                FlywayConfigurationForTests.create());
+    private void assertChecksum(MigrationInfo migrationInfo) {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations(getBasedir());
+
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(dbSupport, config);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -300,7 +300,7 @@ public abstract class MigrationTestCase {
      */
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, Thread.currentThread().getContextClassLoader(),
                 new Locations(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());


### PR DESCRIPTION
(needs PR #1569)

Part of #1567 

I split this one from the handling of SqlMigrationResolver, because this one is rather trivial, while SqlMigrationResolver changes need handling for DbSupport)