### PR TITLE
Default constructor for sql resolver

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1139,7 +1139,7 @@ public class Flyway implements FlywayConfiguration {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations, createPlaceholderReplacer(), resolvers);
+        return new CompositeMigrationResolver(dbSupport, this);
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1131,25 +1131,14 @@ public class Flyway implements FlywayConfiguration {
     /**
      * Creates the MigrationResolver.
      *
-     * @param dbSupport The database-specific support.
      * @return A new, fully configured, MigrationResolver instance.
      */
-    private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
+    private MigrationResolver createMigrationResolver() {
         for (MigrationResolver resolver : resolvers) {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, this);
-    }
-
-    /**
-     * @return A new, fully configured, PlaceholderReplacer.
-     */
-    private PlaceholderReplacer createPlaceholderReplacer() {
-        if (placeholderReplacement) {
-            return new PlaceholderReplacer(placeholders, placeholderPrefix, placeholderSuffix);
-        }
-        return PlaceholderReplacer.NO_PLACEHOLDERS;
+        return new CompositeMigrationResolver(this);
     }
 
     /**
@@ -1391,12 +1380,12 @@ public class Flyway implements FlywayConfiguration {
 
             // force creation of a new Scanner to prevent location caching, because the classpath might have been changed
             Scanner scanner = Scanner.createNew(classLoader);
-            MigrationResolver migrationResolver = createMigrationResolver(dbSupport);
+            MigrationResolver migrationResolver = createMigrationResolver();
 
             if (!skipDefaultCallbacks) {
                 Set<FlywayCallback> flywayCallbacks = new LinkedHashSet<FlywayCallback>(Arrays.asList(callbacks));
                 flywayCallbacks.add(
-                        new SqlScriptFlywayCallback(dbSupport, scanner, locations, createPlaceholderReplacer(), this));
+                        new SqlScriptFlywayCallback(scanner, locations, PlaceholderReplacer.createFrom(this), this));
                 callbacks = flywayCallbacks.toArray(new FlywayCallback[flywayCallbacks.size()]);
             }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -1132,15 +1132,14 @@ public class Flyway implements FlywayConfiguration {
      * Creates the MigrationResolver.
      *
      * @param dbSupport The database-specific support.
-     * @param scanner   The Scanner for resolving migrations.
      * @return A new, fully configured, MigrationResolver instance.
      */
-    private MigrationResolver createMigrationResolver(DbSupport dbSupport, Scanner scanner) {
+    private MigrationResolver createMigrationResolver(DbSupport dbSupport) {
         for (MigrationResolver resolver : resolvers) {
             ConfigurationInjectionUtils.injectFlywayConfiguration(resolver, this);
         }
 
-        return new CompositeMigrationResolver(dbSupport, scanner, this, locations, createPlaceholderReplacer(), resolvers);
+        return new CompositeMigrationResolver(dbSupport, classLoader, this, locations, createPlaceholderReplacer(), resolvers);
     }
 
     /**
@@ -1390,8 +1389,9 @@ public class Flyway implements FlywayConfiguration {
                 schemas[i] = dbSupport.getSchema(schemaNames[i]);
             }
 
-            Scanner scanner = new Scanner(classLoader);
-            MigrationResolver migrationResolver = createMigrationResolver(dbSupport, scanner);
+            // force creation of a new Scanner to prevent location caching, because the classpath might have been changed
+            Scanner scanner = Scanner.createNew(classLoader);
+            MigrationResolver migrationResolver = createMigrationResolver(dbSupport);
 
             if (!skipDefaultCallbacks) {
                 Set<FlywayCallback> flywayCallbacks = new LinkedHashSet<FlywayCallback>(Arrays.asList(callbacks));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptFlywayCallback.java
@@ -19,7 +19,6 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.util.Location;
@@ -69,13 +68,12 @@ public class SqlScriptFlywayCallback implements FlywayCallback {
     /**
      * Creates a new instance.
      *
-     * @param dbSupport           The database-specific support.
      * @param scanner             The Scanner for loading migrations on the classpath.
      * @param locations           The locations where migrations are located.
      * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
      * @param configuration       The Flyway configuration.
      */
-    public SqlScriptFlywayCallback(DbSupport dbSupport, Scanner scanner, Locations locations,
+    public SqlScriptFlywayCallback(Scanner scanner, Locations locations,
                                    PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
         for (String callback : ALL_CALLBACKS) {
             scripts.put(callback, null);
@@ -100,7 +98,7 @@ public class SqlScriptFlywayCallback implements FlywayCallback {
                                 "-> " + existing.getResource().getLocationOnDisk() + "\n" +
                                 "-> " + resource.getLocationOnDisk());
                     }
-                    scripts.put(key, new SqlScript(dbSupport, resource, placeholderReplacer, configuration.getEncoding(), configuration.isAllowMixedMigrations()));
+                    scripts.put(key, new SqlScript(resource, configuration));
                 }
             }
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlScript.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/SqlScript.java
@@ -16,6 +16,7 @@
 package org.flywaydb.core.internal.dbsupport;
 
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.flywaydb.core.internal.util.logging.Log;
@@ -38,19 +39,9 @@ public class SqlScript {
     private static final Log LOG = LogFactory.getLog(SqlScript.class);
 
     /**
-     * The database-specific support.
-     */
-    private final DbSupport dbSupport;
-
-    /**
      * Whether to allow mixing transactional and non-transactional statements within the same migration.
      */
     private final boolean allowMixedMigrations;
-
-    /**
-     * The sql statements contained in this script.
-     */
-    private final List<SqlStatement> sqlStatements;
 
     /**
      * The resource containing the statements.
@@ -68,34 +59,37 @@ public class SqlScript {
     private boolean nonTransactionalStatementFound;
 
     /**
+     * Controls which tokens are to be replaced.
+     */
+    private PlaceholderReplacer placeholderReplacer;
+
+    /**
+     * The actual script content.
+     */
+    private String sqlScriptSource;
+
+    /**
      * Creates a new sql script from this source.
      *
      * @param sqlScriptSource The sql script as a text block with all placeholders already replaced.
-     * @param dbSupport       The database-specific support.
      */
-    public SqlScript(String sqlScriptSource, DbSupport dbSupport) {
-        this.dbSupport = dbSupport;
+    public SqlScript(String sqlScriptSource) {
         this.allowMixedMigrations = false;
-        this.sqlStatements = parse(sqlScriptSource);
+        this.sqlScriptSource = sqlScriptSource;
         this.resource = null;
+        this.placeholderReplacer = PlaceholderReplacer.NO_PLACEHOLDERS;
     }
 
     /**
      * Creates a new sql script from this resource.
      *
-     * @param dbSupport            The database-specific support.
      * @param sqlScriptResource    The resource containing the statements.
-     * @param placeholderReplacer  The placeholder replacer.
-     * @param encoding             The encoding to use.
-     * @param allowMixedMigrations Whether to allow mixing transactional and non-transactional statements within the same migration.
+     * @param configuration        The flyway configuration.
      */
-    public SqlScript(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, String encoding, boolean allowMixedMigrations) {
-        this.dbSupport = dbSupport;
-        this.allowMixedMigrations = allowMixedMigrations;
-
-        String sqlScriptSource = sqlScriptResource.loadAsString(encoding);
-        this.sqlStatements = parse(placeholderReplacer.replacePlaceholders(sqlScriptSource));
-
+    public SqlScript(Resource sqlScriptResource, FlywayConfiguration configuration) {
+        this.placeholderReplacer = PlaceholderReplacer.createFrom(configuration);
+        this.allowMixedMigrations = configuration.isAllowMixedMigrations();
+        this.sqlScriptSource = sqlScriptResource.loadAsString(configuration.getEncoding());
         this.resource = sqlScriptResource;
     }
 
@@ -114,8 +108,8 @@ public class SqlScript {
      *
      * @return The sql statements contained in this script.
      */
-    public List<SqlStatement> getSqlStatements() {
-        return sqlStatements;
+    public List<SqlStatement> getSqlStatements(DbSupport dbSupport) {
+        return parse(placeholderReplacer.replacePlaceholders(sqlScriptSource), dbSupport);
     }
 
     /**
@@ -131,7 +125,8 @@ public class SqlScript {
      * @param jdbcTemplate The jdbc template to use to execute this script.
      */
     public void execute(final JdbcTemplate jdbcTemplate) {
-        for (SqlStatement sqlStatement : sqlStatements) {
+        DbSupport dbSupport = DbSupportFactory.createDbSupport(jdbcTemplate.getConnection(), false);
+        for (SqlStatement sqlStatement : getSqlStatements(dbSupport)) {
             String sql = sqlStatement.getSql();
             LOG.debug("Executing SQL: " + sql);
 
@@ -154,18 +149,19 @@ public class SqlScript {
      * @return The parsed statements.
      */
     /* private -> for testing */
-    List<SqlStatement> parse(String sqlScriptSource) {
-        return linesToStatements(readLines(new StringReader(sqlScriptSource)));
+    List<SqlStatement> parse(String sqlScriptSource, DbSupport dbSupport) {
+        return linesToStatements(readLines(new StringReader(sqlScriptSource)), dbSupport);
     }
 
     /**
      * Turns these lines in a series of statements.
      *
      * @param lines The lines to analyse.
+     * @param dbSupport
      * @return The statements contained in these lines (in order).
      */
     /* private -> for testing */
-    List<SqlStatement> linesToStatements(List<String> lines) {
+    List<SqlStatement> linesToStatements(List<String> lines, DbSupport dbSupport) {
         List<SqlStatement> statements = new ArrayList<SqlStatement>();
 
         Delimiter nonStandardDelimiter = null;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MetaDataTableImpl.java
@@ -108,7 +108,7 @@ public class MetaDataTableImpl implements MetaDataTable {
                             placeholders.put("table", table.getName());
                             String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-                            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+                            SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
                             sqlScript.execute(jdbcTemplate);
                             return null;
                         }
@@ -150,7 +150,7 @@ public class MetaDataTableImpl implements MetaDataTable {
                 placeholders.put("table", table.getName());
                 String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-                final SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+                final SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
                 sqlScript.execute(jdbcTemplate);
 
                 LOG.debug("Metadata table " + table + " created.");
@@ -209,7 +209,7 @@ public class MetaDataTableImpl implements MetaDataTable {
 
                 String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders, dbSupport);
+                SqlScript sqlScript = new SqlScript(sourceNoPlaceholders);
 
                 sqlScript.execute(jdbcTemplate);
             } else {
@@ -452,7 +452,7 @@ public class MetaDataTableImpl implements MetaDataTable {
 
             String sourceNoPlaceholders = new PlaceholderReplacer(placeholders, "${", "}").replacePlaceholders(source);
 
-            new SqlScript(sourceNoPlaceholders, dbSupport).execute(jdbcTemplate);
+            new SqlScript(sourceNoPlaceholders).execute(jdbcTemplate);
         } else {
             try {
                 jdbcTemplate.update("UPDATE " + table

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -56,23 +56,24 @@ public class CompositeMigrationResolver implements MigrationResolver {
     /**
      * Creates a new CompositeMigrationResolver.
      *
-     * @param dbSupport                The database-specific support.
-     * @param scanner                  The Scanner for loading migrations on the classpath.
+     * @param dbSupport                    The database-specific support.
+     * @param classLoader                      The classloader for loading migrations on the classpath.
      * @param configuration            The Flyway configuration.
-     * @param locations                The locations where migrations are located.
-     * @param placeholderReplacer      The placeholder replacer to use.
-     * @param customMigrationResolvers Custom Migration Resolvers.
+     * @paramlocations                    The locations where migrations are located.
+
+     * @param placeholderReplacer          The placeholder replacer to use.
+     * @param customMigrationResolvers     Custom Migration Resolvers.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, Scanner scanner, FlywayConfiguration configuration, Locations locations,
+    public CompositeMigrationResolver(DbSupport dbSupport, ClassLoader classLoader, FlywayConfiguration configuration, Locations locations,
                                       PlaceholderReplacer placeholderReplacer,
                                       MigrationResolver... customMigrationResolvers) {
         if (!configuration.isSkipDefaultResolvers()) {
 
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, scanner, locations, placeholderReplacer, configuration));
-            migrationResolvers.add(new JdbcMigrationResolver(scanner, locations, configuration));
+            migrationResolvers.add(new SqlMigrationResolver(dbSupport, classLoader, locations, placeholderReplacer, configuration));
+            migrationResolvers.add(new JdbcMigrationResolver(classLoader, locations, configuration));
 
-            if (new FeatureDetector(scanner.getClassLoader()).isSpringJdbcAvailable()) {
-                migrationResolvers.add(new SpringJdbcMigrationResolver(scanner, locations, configuration));
+            if (new FeatureDetector(classLoader).isSpringJdbcAvailable()) {
+                migrationResolvers.add(new SpringJdbcMigrationResolver(classLoader, locations, configuration));
             }
         }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -19,7 +19,6 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.spring.SpringJdbcMigrationResolver;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
@@ -47,14 +46,13 @@ public class CompositeMigrationResolver implements MigrationResolver {
     /**
      * Creates a new CompositeMigrationResolver.
      *
-     * @param dbSupport                    The database-specific support.
      * @param configuration                The Flyway configuration.
      */
-    public CompositeMigrationResolver(DbSupport dbSupport, FlywayConfiguration configuration) {
+    public CompositeMigrationResolver(FlywayConfiguration configuration) {
 
         if (!configuration.isSkipDefaultResolvers()) {
 
-            migrationResolvers.add(new SqlMigrationResolver(dbSupport, configuration));
+            migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), configuration));
             migrationResolvers.add(ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), configuration));
 
             if (new FeatureDetector(configuration.getClassLoader()).isSpringJdbcAvailable()) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -57,13 +57,11 @@ public class JdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The base packages on the classpath where to migrations are located.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public JdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -58,12 +58,12 @@ public class JdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param locations     The base packages on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public JdbcMigrationResolver(Scanner scanner, Locations locations, FlywayConfiguration configuration) {
+    public JdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
         this.locations = locations;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolver.java
@@ -19,6 +19,7 @@ import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
@@ -38,11 +39,7 @@ import java.util.List;
  * Migration resolver for Jdbc migrations. The classes must have a name like R__My_description, V1__Description
  * or V1_1_3__Description.
  */
-public class JdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base package on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class JdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -54,22 +51,16 @@ public class JdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public JdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) {
                 continue;
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -15,25 +15,23 @@
  */
 package org.flywaydb.core.internal.resolver.spring;
 
+import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.MigrationInfoProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.MigrationInfoHelper;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
-import org.flywaydb.core.internal.resolver.jdbc.JdbcMigrationExecutor;
 import org.flywaydb.core.internal.util.*;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,11 +39,7 @@ import java.util.List;
  * Migration resolver for Spring Jdbc migrations. The classes must have a name like V1 or V1_1_3 or V1__Description
  * or V1_1_3__Description.
  */
-public class SpringJdbcMigrationResolver implements MigrationResolver {
-    /**
-     * The base packages on the classpath where to migrations are located.
-     */
-    private final Locations locations;
+public class SpringJdbcMigrationResolver implements MigrationResolver, ConfigurationAware {
 
     /**
      * The Scanner to use.
@@ -57,22 +51,16 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      */
     private FlywayConfiguration configuration;
 
-    /**
-     * Creates a new instance.
-     *
-     * @param configuration The configuration to inject (if necessary) in the migration classes.
-     */
-    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
-        this.locations = new Locations(configuration.getLocations());
-        this.scanner = Scanner.create(configuration.getClassLoader());
+    public void setFlywayConfiguration(FlywayConfiguration configuration) {
         this.configuration = configuration;
+        this.scanner = Scanner.create(configuration.getClassLoader());
     }
 
     @Override
     public List<ResolvedMigration> resolveMigrations() {
         List<ResolvedMigration> migrations = new ArrayList<ResolvedMigration>();
 
-        for (Location location : locations.getLocations()) {
+        for (Location location : new Locations(configuration.getLocations()).getLocations()) {
             if (!location.isClassPath()) {
                 continue;
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -61,12 +61,12 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param locations     The base packages on the classpath where to migrations are located.
-     * @param scanner       The Scanner for loading migrations on the classpath.
+     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(Scanner scanner, Locations locations, FlywayConfiguration configuration) {
+    public SpringJdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
         this.locations = locations;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classLoader);
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolver.java
@@ -60,13 +60,11 @@ public class SpringJdbcMigrationResolver implements MigrationResolver {
     /**
      * Creates a new instance.
      *
-     * @param locations     The base packages on the classpath where to migrations are located.
-     * @param classLoader   The classloader for loading migrations on the classpath.
      * @param configuration The configuration to inject (if necessary) in the migration classes.
      */
-    public SpringJdbcMigrationResolver(ClassLoader classLoader, Locations locations, FlywayConfiguration configuration) {
-        this.locations = locations;
-        this.scanner = Scanner.create(classLoader);
+    public SpringJdbcMigrationResolver(FlywayConfiguration configuration) {
+        this.locations = new Locations(configuration.getLocations());
+        this.scanner = Scanner.create(configuration.getClassLoader());
         this.configuration = configuration;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationExecutor.java
@@ -17,10 +17,8 @@ package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.MigrationExecutor;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
 
 import java.sql.Connection;
@@ -29,15 +27,6 @@ import java.sql.Connection;
  * Database migration based on a sql file.
  */
 public class SqlMigrationExecutor implements MigrationExecutor {
-    /**
-     * Database-specific support.
-     */
-    private final DbSupport dbSupport;
-
-    /**
-     * The placeholder replacer to apply to sql migration scripts.
-     */
-    private final PlaceholderReplacer placeholderReplacer;
 
     /**
      * The Resource pointing to the sql script.
@@ -58,16 +47,11 @@ public class SqlMigrationExecutor implements MigrationExecutor {
 
     /**
      * Creates a new sql script migration based on this sql script.
-     *
-     * @param dbSupport           The database-specific support.
-     * @param sqlScriptResource   The resource containing the sql script.
-     * @param placeholderReplacer The placeholder replacer to apply to sql migration scripts.
+     *  @param sqlScriptResource   The resource containing the sql script.
      * @param configuration       The Flyway configuration.
      */
-    public SqlMigrationExecutor(DbSupport dbSupport, Resource sqlScriptResource, PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
-        this.dbSupport = dbSupport;
+    public SqlMigrationExecutor(Resource sqlScriptResource, FlywayConfiguration configuration) {
         this.sqlScriptResource = sqlScriptResource;
-        this.placeholderReplacer = placeholderReplacer;
         this.configuration = configuration;
     }
 
@@ -78,7 +62,7 @@ public class SqlMigrationExecutor implements MigrationExecutor {
 
     private synchronized SqlScript getSqlScript() {
         if (sqlScript == null) {
-            sqlScript = new SqlScript(dbSupport, sqlScriptResource, placeholderReplacer, configuration.getEncoding(), configuration.isAllowMixedMigrations());
+            sqlScript = new SqlScript(sqlScriptResource, configuration);
         }
         return sqlScript;
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -75,15 +75,15 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
-     * @param scanner                      The Scanner for loading migrations on the classpath.
+     * @param classloader                  The classloader for loading migrations from the classpath.
      * @param locations                    The locations on the classpath where to migrations are located.
      * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
      * @param configuration                The Flyway configuration.
      */
-    public SqlMigrationResolver(DbSupport dbSupport, Scanner scanner, Locations locations,
+    public SqlMigrationResolver(DbSupport dbSupport, ClassLoader classloader, Locations locations,
                                 PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
         this.dbSupport = dbSupport;
-        this.scanner = scanner;
+        this.scanner = Scanner.create(classloader);
         this.locations = locations;
         this.placeholderReplacer = placeholderReplacer;
         this.configuration = configuration;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -75,18 +75,24 @@ public class SqlMigrationResolver implements MigrationResolver {
      * Creates a new instance.
      *
      * @param dbSupport                    The database-specific support.
-     * @param classloader                  The classloader for loading migrations from the classpath.
-     * @param locations                    The locations on the classpath where to migrations are located.
-     * @param placeholderReplacer          The placeholder replacer to apply to sql migration scripts.
-     * @param configuration                The Flyway configuration.
+     * @param configuration                The configuration object.
      */
-    public SqlMigrationResolver(DbSupport dbSupport, ClassLoader classloader, Locations locations,
-                                PlaceholderReplacer placeholderReplacer, FlywayConfiguration configuration) {
+    public SqlMigrationResolver(DbSupport dbSupport, FlywayConfiguration configuration) {
         this.dbSupport = dbSupport;
-        this.scanner = Scanner.create(classloader);
-        this.locations = locations;
-        this.placeholderReplacer = placeholderReplacer;
+        this.scanner = Scanner.create(configuration.getClassLoader());
+        this.locations = new Locations(configuration.getLocations());
+        this.placeholderReplacer = createPlaceholderReplacer(configuration);
         this.configuration = configuration;
+    }
+
+    /**
+     * @return A new, fully configured, PlaceholderReplacer.
+     */
+    private PlaceholderReplacer createPlaceholderReplacer(FlywayConfiguration config) {
+        if (config.isPlaceholderReplacement()) {
+            return new PlaceholderReplacer(config.getPlaceholders(), config.getPlaceholderPrefix(), config.getPlaceholderSuffix());
+        }
+        return PlaceholderReplacer.NO_PLACEHOLDERS;
     }
 
     public List<ResolvedMigration> resolveMigrations() {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
@@ -19,7 +19,7 @@ import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
 
 /**
- * Utility class for interfaced based injection.
+ * Utility class for interface based injection.
  */
 public class ConfigurationInjectionUtils {
 
@@ -30,13 +30,13 @@ public class ConfigurationInjectionUtils {
     /**
      * Injects the given flyway configuration into the target object if target implements the
      * {@link ConfigurationAware} interface. Does nothing if target is not configuration aware.
-     *
      * @param target The object to inject the configuration into.
      * @param configuration The configuration to inject.
      */
-    public static void injectFlywayConfiguration(Object target, FlywayConfiguration configuration) {
+    public static <T> T injectFlywayConfiguration(T target, FlywayConfiguration configuration) {
         if (target instanceof ConfigurationAware) {
             ((ConfigurationAware) target).setFlywayConfiguration(configuration);
         }
+        return target;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/ConfigurationInjectionUtils.java
@@ -39,4 +39,5 @@ public class ConfigurationInjectionUtils {
         }
         return target;
     }
+
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/PlaceholderReplacer.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/PlaceholderReplacer.java
@@ -16,6 +16,7 @@
 package org.flywaydb.core.internal.util;
 
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,6 +65,18 @@ public class PlaceholderReplacer {
         this.placeholders = placeholders;
         this.placeholderPrefix = placeholderPrefix;
         this.placeholderSuffix = placeholderSuffix;
+    }
+
+    /**
+     * Creates a new PlaceholderReplacer from an existing flyway configuration.
+     * @param configuration the FlywayConfiguration to use
+     * @return A new replacer instance, never null
+     */
+    public static PlaceholderReplacer createFrom(FlywayConfiguration configuration) {
+        if (configuration.isPlaceholderReplacement()) {
+            return new PlaceholderReplacer(configuration.getPlaceholders(), configuration.getPlaceholderPrefix(), configuration.getPlaceholderSuffix());
+        }
+        return PlaceholderReplacer.NO_PLACEHOLDERS;
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/Scanner.java
@@ -18,10 +18,14 @@ package org.flywaydb.core.internal.util.scanner;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ResourceAndClassScanner;
 import org.flywaydb.core.internal.util.scanner.classpath.android.AndroidScanner;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathScanner;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemScanner;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Scanner for Resources and Classes.
@@ -32,13 +36,48 @@ public class Scanner {
     private final ClassLoader classLoader;
     private final FileSystemScanner fileSystemScanner = new FileSystemScanner();
 
-    public Scanner(ClassLoader classLoader) {
+    private Scanner(ClassLoader classLoader) {
         this.classLoader = classLoader;
         if (new FeatureDetector(classLoader).isAndroidAvailable()) {
             resourceAndClassScanner = new AndroidScanner(classLoader);
         } else {
             resourceAndClassScanner = new ClassPathScanner(classLoader);
         }
+    }
+
+    private static Map<ClassLoader, WeakReference<Scanner>> scannerCache = new WeakHashMap<ClassLoader, WeakReference<Scanner>>();
+
+    /**
+     * Create or retrieves a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key.
+     * @param classLoader The classloader to scan.
+     * @return A new or existing Scanner instance, never null.
+     */
+    public static synchronized Scanner create(ClassLoader classLoader) {
+        WeakReference<Scanner> result = scannerCache.get(classLoader);
+
+        if (result == null || result.get() == null) {
+            return createNew(classLoader);
+        }
+
+        return result.get();
+    }
+
+    /**
+     * Creates a new instance of Scanner. Instances are weakly cached with
+     * their classpath as key. This method is necessary when flyway is methods are called a) multiple times
+     * in one run, b) using the same classloader and c) when the classpath of the classloader changes between
+     * invocations. This can happen for example in the Maven plugin in a "clean migrate" scenario, where between
+     * the clean step an the migrate step source code is compiled / copied and the classloader extended (with the
+     * target/classes folder, Maven 2 did create a new classloader, thus the problem did not occur).
+     * @param classLoader The classloader to scan.
+     * @return A new Scanner instance, never null.
+     */
+    public static synchronized Scanner createNew(ClassLoader classLoader) {
+        WeakReference<Scanner> result = new WeakReference<Scanner>(new Scanner(classLoader));
+        scannerCache.put(classLoader, result);
+
+        return result.get();
     }
 
     /**

--- a/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/FlywaySmallTest.java
@@ -21,6 +21,7 @@ import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.metadatatable.MetaDataTable;
+import org.flywaydb.core.internal.resolver.MyConfigurationAwareCustomMigrationResolver;
 import org.flywaydb.core.internal.resolver.MyCustomMigrationResolver;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
 import org.junit.Test;
@@ -207,5 +208,18 @@ public class FlywaySmallTest {
         } catch (FlywayException e) {
             //expected
         }
+    }
+
+    @Test
+    public void customResolversHaveConfigurationInjected() {
+        MyConfigurationAwareCustomMigrationResolver configResolver = new MyConfigurationAwareCustomMigrationResolver();
+
+        Flyway flyway = new Flyway();
+        flyway.setDataSource("jdbc:h2:mem:flyway_test;DB_CLOSE_DELAY=-1", "sa", "");
+        flyway.setResolvers(configResolver);
+
+        flyway.migrate();
+
+        configResolver.assertFlywayConfigurationIsSet();
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/SqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/SqlScriptSmallTest.java
@@ -35,7 +35,9 @@ public class SqlScriptSmallTest {
     /**
      * Class under test.
      */
-    private SqlScript sqlScript = new SqlScript("", new MySQLDbSupport(null));
+    private SqlScript sqlScript = new SqlScript("");
+
+    private DbSupport dbSupport = new MySQLDbSupport(null);
 
     /**
      * Input lines.
@@ -45,14 +47,14 @@ public class SqlScriptSmallTest {
     @Test
     public void stripSqlCommentsNoComment() {
         lines.add("select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals("select * from table", sqlStatements.get(0).getSql());
     }
 
     @Test
     public void stripSqlCommentsSingleLineComment() {
         lines.add("--select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(0, sqlStatements.size());
     }
 
@@ -60,7 +62,7 @@ public class SqlScriptSmallTest {
     public void stripSqlCommentsMultiLineCommentSingleLine() {
         lines.add("/*comment line*/");
         lines.add("select * from table;");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals("select * from table", sqlStatements.get(0).getSql());
     }
 
@@ -68,7 +70,7 @@ public class SqlScriptSmallTest {
     public void stripSqlCommentsMultiLineCommentMultipleLines() {
         lines.add("/*comment line");
         lines.add("more comment text*/");
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(0, sqlStatements.size());
     }
 
@@ -78,7 +80,7 @@ public class SqlScriptSmallTest {
         lines.add("from mytable");
         lines.add("where col1 > 10;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -99,7 +101,7 @@ public class SqlScriptSmallTest {
         lines.add("DELIMITER ;");
         lines.add("*/");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(1, sqlStatements.size());
 
         SqlStatement sqlStatement = sqlStatements.get(0);
@@ -122,7 +124,7 @@ public class SqlScriptSmallTest {
         lines.add("--these statements are imported the above multiline is detected");
         lines.add("INSERT INTO mytable (id, data1, data2)VALUES (5,1,'hi');");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(2, sqlStatements.size());
 
         assertEquals(6, sqlStatements.get(0).getLineNumber());
@@ -140,7 +142,7 @@ public class SqlScriptSmallTest {
         lines.add("select 4;");
         lines.add("$$");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertEquals(4, sqlStatements.size());
 
         assertEquals("select 1", sqlStatements.get(0).getSql());
@@ -155,7 +157,7 @@ public class SqlScriptSmallTest {
         lines.add("DROP TABLE IF EXISTS account;");
         lines.add("/*!40101 SET character_set_client = utf8 */;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(3, sqlStatements.size());
 
@@ -172,7 +174,7 @@ public class SqlScriptSmallTest {
         }
         lines.add("(1, '2', '3', '4');");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -187,7 +189,7 @@ public class SqlScriptSmallTest {
         lines.add("-----------------------------------------*/");
         lines.add("SELECT 1;");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -204,7 +206,7 @@ public class SqlScriptSmallTest {
         lines.add("Please find your quote attached in PDF format.'");
         lines.add("where templatename = 'quote_template';");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -227,7 +229,7 @@ public class SqlScriptSmallTest {
         lines.add("");
         lines.add("update emailtemplate set body = 'Howdy';");
 
-        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines);
+        List<SqlStatement> sqlStatements = sqlScript.linesToStatements(lines, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(3, sqlStatements.size());
 
@@ -250,7 +252,7 @@ public class SqlScriptSmallTest {
         placeholders.put("or_replace", "OR REPLACE");
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(placeholders, "${", "}");
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(placeholderReplacer.replacePlaceholders(source));
+        List<SqlStatement> sqlStatements = sqlScript.parse(placeholderReplacer.replacePlaceholders(source), dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -268,7 +270,7 @@ public class SqlScriptSmallTest {
                 "    Please find your quote attached in PDF format.'\n" +
                 "where templatename = 'quote_template'";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -283,7 +285,7 @@ public class SqlScriptSmallTest {
                 "    set   body='Thanks !' /* my pleasure */\n" +
                 "  and  subject = 'To our favorite customer!'";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(1, sqlStatements.size());
 
@@ -299,7 +301,7 @@ public class SqlScriptSmallTest {
                 "INSERT INTO `bonlayout` (`vertriebslinie`, `lang`, `position`, `layout`) VALUES ('CH01RE', 'en', 'EC_KNR_1_0', '<RIGHT>Account #: \n" +
                 "___________________________</RIGHT>');";
 
-        List<SqlStatement> sqlStatements = sqlScript.parse(source);
+        List<SqlStatement> sqlStatements = sqlScript.parse(source, dbSupport);
         assertNotNull(sqlStatements);
         assertEquals(2, sqlStatements.size());
     }
@@ -309,7 +311,7 @@ public class SqlScriptSmallTest {
     public void parseWithTrailingComment() {
         String sql = "ALTER TABLE A RENAME TO B; -- trailing comment\r\n" +
                 "ALTER TABLE B RENAME TO C;";
-        List<SqlStatement> statements = sqlScript.parse(sql);
+        List<SqlStatement> statements = sqlScript.parse(sql, dbSupport);
         assertEquals(2, statements.size());
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -42,6 +42,7 @@ import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
@@ -72,8 +73,10 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
     }
 
     protected void assertChecksum(MigrationInfo migrationInfo) {
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, FlywayConfigurationForTests.createWithLocations(getBasedir() + "/default"));
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(
+                new SqlMigrationResolver(),
+                FlywayConfigurationForTests.createWithLocations(getBasedir() + "/default"));
+
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -74,7 +74,7 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
     @Override
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, Thread.currentThread().getContextClassLoader(),
                 new Locations(getBasedir() + "/default"),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2zos/DB2zOSMigrationMediumTest.java
@@ -71,13 +71,9 @@ public class DB2zOSMigrationMediumTest extends MigrationTestCase {
         }
     }
 
-    @Override
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Locations(getBasedir() + "/default"),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                FlywayConfigurationForTests.create());
+                dbSupport, FlywayConfigurationForTests.createWithLocations(getBasedir() + "/default"));
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/enterprisedb/EnterpriseDBSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/enterprisedb/EnterpriseDBSqlScriptSmallTest.java
@@ -34,8 +34,9 @@ public class EnterpriseDBSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/enterprisedb/sql/placeholders/V1__Placeholders.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        EnterpriseDBDbSupport dbSupport = new EnterpriseDBDbSupport(null);
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(3, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertEquals(27, sqlStatements.get(1).getLineNumber());
@@ -48,8 +49,8 @@ public class EnterpriseDBSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/enterprisedb/sql/function/V2__FunctionWithConditionals.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(1, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertTrue(sqlStatements.get(0).getSql().contains("/* for the rich */"));
@@ -60,8 +61,8 @@ public class EnterpriseDBSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/enterprisedb/sql/function/V1__Function.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(5, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertEquals(33, sqlStatements.get(1).getLineNumber());
@@ -76,8 +77,8 @@ public class EnterpriseDBSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/enterprisedb/sql/package/V1__Package.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(2, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(30, sqlStatements.get(1).getLineNumber());
@@ -115,8 +116,8 @@ public class EnterpriseDBSqlScriptSmallTest {
                 "END <trigger-name>;\n" +
                 "/";
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(1, sqlStatements.size());
     }
 
@@ -138,8 +139,8 @@ public class EnterpriseDBSqlScriptSmallTest {
                 "AND D.IDS = IDS\n" +
                 ");";
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(1, sqlStatements.size());
     }
 
@@ -175,8 +176,8 @@ public class EnterpriseDBSqlScriptSmallTest {
                 "\n" +
                 "EXECUTE set_right_value_for_sequence('SEQ_ATR', 'TOTCATTRIB', 'ATTRIB_ID');";
 
-        SqlScript sqlScript = new SqlScript(source, new EnterpriseDBDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new EnterpriseDBDbSupport(null));
         assertEquals(2, sqlStatements.size());
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mysql/MySQLSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mysql/MySQLSqlScriptSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.dbsupport.mysql;
 
+import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.dbsupport.SqlStatement;
 import org.junit.Test;
@@ -22,20 +23,22 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test for MySQL SqlScript.
  */
 public class MySQLSqlScriptSmallTest {
+
+    private DbSupport dbSupport = new MySQLDbSupport(null);;
+
     @Test
     public void multiLineCommentDirective() throws Exception {
         String source = "/*!50001 CREATE ALGORITHM=UNDEFINED */\n" +
                 "/*!50013 DEFINER=`user`@`%` SQL SECURITY DEFINER */\n" +
                 "/*!50001 VIEW `viewname` AS select `t`.`id` AS `someId`,`t`.`name` AS `someName` from `someTable` `t` where `t`.`state` = 0 */;\n";
 
-        SqlScript sqlScript = new SqlScript(source, new MySQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
         assertEquals(1, sqlStatements.get(0).getLineNumber());
     }
@@ -48,8 +51,8 @@ public class MySQLSqlScriptSmallTest {
                 "`name` varchar(10)\n" +
                 ") ENGINE=MyISAM */;\n" +                
                 "INSERT INTO tablename VALUES ('a','b');";
-        SqlScript sqlScript = new SqlScript(source, new MySQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(3, sqlStatements.size());
         assertEquals(1, sqlStatements.get(0).getLineNumber());
         assertEquals(2, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/oracle/OracleSqlScriptSmallTest.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.dbsupport.oracle;
 
+import org.flywaydb.core.internal.dbsupport.DbSupport;
 import org.flywaydb.core.internal.dbsupport.SqlScript;
 import org.flywaydb.core.internal.dbsupport.SqlStatement;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
@@ -29,13 +30,16 @@ import static org.junit.Assert.assertTrue;
  * Test for OracleSqlScript.
  */
 public class OracleSqlScriptSmallTest {
+    
+    private DbSupport dbSupport = new OracleDbSupport(null);
+    
     @Test
     public void parseSqlStatements() throws Exception {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/placeholders/V1__Placeholders.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(3, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertEquals(27, sqlStatements.get(1).getLineNumber());
@@ -48,8 +52,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/function/V2__FunctionWithConditionals.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
         assertEquals(18, sqlStatements.get(0).getLineNumber());
         assertTrue(sqlStatements.get(0).getSql().contains("/* for the rich */"));
@@ -60,8 +64,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/function/V1__Function.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(5, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(26, sqlStatements.get(1).getLineNumber());
@@ -76,8 +80,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/package/V1__Package.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(2, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(33, sqlStatements.get(1).getLineNumber());
@@ -88,8 +92,8 @@ public class OracleSqlScriptSmallTest {
         String source = new ClassPathResource("migration/dbsupport/oracle/sql/qquote/V1__Q_Quote.sql",
                 Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(12, sqlStatements.size());
     }
 
@@ -125,8 +129,8 @@ public class OracleSqlScriptSmallTest {
                 "END <trigger-name>;\n" +
                 "/";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
     }
 
@@ -148,8 +152,8 @@ public class OracleSqlScriptSmallTest {
                 "AND D.IDS = IDS\n" +
                 ");";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(1, sqlStatements.size());
     }
 
@@ -185,8 +189,8 @@ public class OracleSqlScriptSmallTest {
                 "\n" +
                 "EXECUTE set_right_value_for_sequence('SEQ_ATR', 'TOTCATTRIB', 'ATTRIB_ID');";
 
-        SqlScript sqlScript = new SqlScript(source, new OracleDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(dbSupport);
         assertEquals(2, sqlStatements.size());
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlScriptSmallTest.java
@@ -33,8 +33,8 @@ public class PostgreSQLSqlScriptSmallTest {
         String source = new ClassPathResource(
                 "migration/dbsupport/postgresql/sql/dollar/V2__Even_more_dollars.sql", Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new PostgreSQLDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new PostgreSQLDbSupport(null));
         assertEquals(3, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(23, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerMigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerMigrationTestCase.java
@@ -341,7 +341,7 @@ public abstract class SQLServerMigrationTestCase extends MigrationTestCase {
         Schema schema = dbSupport.getOriginalSchema();
 
         new SqlScript(new ClassPathResource("migration/dbsupport/sqlserver/createMSDBTools.sql",
-                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8"), dbSupport).
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8")).
                 execute(jdbcTemplate);
 
         try {
@@ -349,7 +349,7 @@ public abstract class SQLServerMigrationTestCase extends MigrationTestCase {
         } finally {
             try {
                 new SqlScript(new ClassPathResource("migration/dbsupport/sqlserver/dropMSDBTools.sql",
-                        Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8"), dbSupport).
+                        Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8")).
                         execute(jdbcTemplate);
             } catch (Exception e) {
                 // Swallow to prevent override of test raised exception.
@@ -362,7 +362,7 @@ public abstract class SQLServerMigrationTestCase extends MigrationTestCase {
         Schema schema = dbSupport.getOriginalSchema();
 
         new SqlScript(new ClassPathResource("migration/dbsupport/sqlserver/createMSDBTools.sql",
-                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8"), dbSupport).
+                Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8")).
                 execute(jdbcTemplate);
 
         try {
@@ -378,7 +378,7 @@ public abstract class SQLServerMigrationTestCase extends MigrationTestCase {
         } finally {
             try {
                 new SqlScript(new ClassPathResource("migration/dbsupport/sqlserver/dropMSDBTools.sql",
-                        Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8"), dbSupport).
+                        Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8")).
                         execute(jdbcTemplate);
             } catch (Exception e) {
                 // Swallow to prevent override of test raised exception.

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSqlScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSqlScriptSmallTest.java
@@ -33,8 +33,8 @@ public class VerticaSqlScriptSmallTest {
         String source = new ClassPathResource(
                 "migration/dbsupport/vertica/sql/dollar/V1__Dollar.sql", Thread.currentThread().getContextClassLoader()).loadAsString("UTF-8");
 
-        SqlScript sqlScript = new SqlScript(source, new VerticaDbSupport(null));
-        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements();
+        SqlScript sqlScript = new SqlScript(source);
+        List<SqlStatement> sqlStatements = sqlScript.getSqlStatements(new VerticaDbSupport(null));
         assertEquals(10, sqlStatements.size());
         assertEquals(17, sqlStatements.get(0).getLineNumber());
         assertEquals(19, sqlStatements.get(1).getLineNumber());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -38,7 +38,7 @@ public class CompositeMigrationResolverSmallTest {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1");
         config.setResolvers(new MyCustomMigrationResolver());
 
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
@@ -142,7 +142,7 @@ public class CompositeMigrationResolverSmallTest {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy");
         config.setSkipDefaultResolvers(true);
 
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -22,7 +22,6 @@ import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.util.*;
@@ -36,13 +35,10 @@ import static org.junit.Assert.assertTrue;
 public class CompositeMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsMultipleLocations() {
-        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1");
+        config.setResolvers(new MyCustomMigrationResolver());
 
-        PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                Thread.currentThread().getContextClassLoader(), config,
-                new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                placeholderReplacer, new MyCustomMigrationResolver());
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
         List<ResolvedMigration> migrationList = new ArrayList<ResolvedMigration>(migrations);
@@ -143,13 +139,10 @@ public class CompositeMigrationResolverSmallTest {
 
     @Test
     public void skipDefaultResolvers() {
-        FlywayConfigurationForTests config = FlywayConfigurationForTests.create();
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy");
         config.setSkipDefaultResolvers(true);
 
-        MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                Thread.currentThread().getContextClassLoader(), config,
-                new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
-                PlaceholderReplacer.NO_PLACEHOLDERS);
+        MigrationResolver migrationResolver = new CompositeMigrationResolver(null, config);
 
         Collection<ResolvedMigration> migrations = migrationResolver.resolveMigrations();
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolverSmallTest.java
@@ -40,7 +40,7 @@ public class CompositeMigrationResolverSmallTest {
 
         PlaceholderReplacer placeholderReplacer = new PlaceholderReplacer(new HashMap<String, String>(), "${", "}");
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                Thread.currentThread().getContextClassLoader(), config,
                 new Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
                 placeholderReplacer, new MyCustomMigrationResolver());
 
@@ -147,7 +147,7 @@ public class CompositeMigrationResolverSmallTest {
         config.setSkipDefaultResolvers(true);
 
         MigrationResolver migrationResolver = new CompositeMigrationResolver(null,
-                new Scanner(Thread.currentThread().getContextClassLoader()), config,
+                Thread.currentThread().getContextClassLoader(), config,
                 new Locations("migration/outoforder", "org/flywaydb/core/internal/resolver/jdbc/dummy"),
                 PlaceholderReplacer.NO_PLACEHOLDERS);
 

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MyConfigurationAwareCustomMigrationResolver.java
@@ -17,6 +17,14 @@ package org.flywaydb.core.internal.resolver;
 
 import org.flywaydb.core.api.configuration.ConfigurationAware;
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 /**
 * Created by Axel on 3/7/14.
@@ -30,7 +38,13 @@ public class MyConfigurationAwareCustomMigrationResolver extends MyCustomMigrati
         this.flywayConfiguration = flywayConfiguration;
     }
 
-    public boolean isFlywayConfigurationSet() {
-        return flywayConfiguration != null;
+    @Override
+    public List<ResolvedMigration> resolveMigrations() {
+        assertFlywayConfigurationIsSet();
+        return new ArrayList<ResolvedMigration>();
+    }
+
+    public void assertFlywayConfigurationIsSet() {
+        assertThat(flywayConfiguration, is(notNullValue()));
     }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -24,6 +24,7 @@ import org.flywaydb.core.internal.resolver.jdbc.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -43,15 +44,14 @@ public class JdbcMigrationResolverSmallTest {
     @Test(expected = FlywayException.class)
     public void broken() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
-        new JdbcMigrationResolver(config).resolveMigrations();
+        ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
 
-        JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(config);
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -78,7 +78,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -87,7 +87,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
+        JdbcMigrationResolver jdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new JdbcMigrationResolver(), FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -42,13 +42,16 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/error");
+        new JdbcMigrationResolver(config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/jdbc/dummy");
+
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -75,7 +78,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -84,7 +87,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(FlywayConfigurationForTests.create());
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationResolverSmallTest.java
@@ -15,8 +15,8 @@
  */
 package org.flywaydb.core.internal.resolver.jdbc;
 
-import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.jdbc.dummy.V2__InterfaceBasedMigration;
@@ -38,18 +38,17 @@ import static org.junit.Assert.assertNull;
  * Test for JdbcMigrationResolver.
  */
 public class JdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test(expected = FlywayException.class)
     public void broken() {
-        new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
+        new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/error"), config).resolveMigrations();
     }
 
     @Test
     public void resolveMigrations() throws SQLException {
         JdbcMigrationResolver jdbcMigrationResolver =
-                new JdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
+                new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/jdbc/dummy"), config);
         Collection<ResolvedMigration> migrations = jdbcMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -76,7 +75,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -85,7 +84,7 @@ public class JdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(scanner, null, null);
+        JdbcMigrationResolver jdbcMigrationResolver = new JdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = jdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.internal.resolver.spring.dummy.Version3dot5;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.scanner.Scanner;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -41,8 +42,7 @@ public class SpringJdbcMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
-        SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -61,7 +61,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -70,7 +70,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SpringJdbcMigrationResolver(), config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -36,13 +36,12 @@ import static org.junit.Assert.assertNull;
  * Test for SpringJdbcMigrationResolver.
  */
 public class SpringJdbcMigrationResolverSmallTest {
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
     private final FlywayConfiguration config = FlywayConfigurationForTests.create();
 
     @Test
     public void resolveMigrations() {
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(scanner, new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -61,7 +60,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -70,7 +69,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(scanner, null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationResolverSmallTest.java
@@ -40,8 +40,9 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrations() {
+        FlywayConfiguration config = FlywayConfigurationForTests.createWithLocations("org/flywaydb/core/internal/resolver/spring/dummy");
         SpringJdbcMigrationResolver springJdbcMigrationResolver =
-                new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), new Locations("org/flywaydb/core/internal/resolver/spring/dummy"), config);
+                new SpringJdbcMigrationResolver(config);
         Collection<ResolvedMigration> migrations = springJdbcMigrationResolver.resolveMigrations();
 
         assertEquals(2, migrations.size());
@@ -60,7 +61,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void conventionOverConfiguration() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new V2__InterfaceBasedMigration());
         assertEquals("2", migrationInfo.getVersion().toString());
         assertEquals("InterfaceBasedMigration", migrationInfo.getDescription());
@@ -69,7 +70,7 @@ public class SpringJdbcMigrationResolverSmallTest {
 
     @Test
     public void explicitInfo() {
-        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(Thread.currentThread().getContextClassLoader(), null, null);
+        SpringJdbcMigrationResolver springJdbcMigrationResolver = new SpringJdbcMigrationResolver(config);
         ResolvedMigration migrationInfo = springJdbcMigrationResolver.extractMigrationInfo(new Version3dot5());
         assertEquals("3.5", migrationInfo.getVersion().toString());
         assertEquals("Three Dot Five", migrationInfo.getDescription());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -19,6 +19,7 @@ import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,7 +41,7 @@ public class SqlMigrationResolverMediumTest {
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:" + new File(path).getPath());
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(null, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.junit.Test;
 
 import java.io.File;
@@ -42,7 +41,7 @@ public class SqlMigrationResolverMediumTest {
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, new Scanner(Thread.currentThread().getContextClassLoader()),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
                         FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverMediumTest.java
@@ -18,8 +18,7 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,10 +39,8 @@ public class SqlMigrationResolverMediumTest {
         @SuppressWarnings("ConstantConditions")
         String path = URLDecoder.decode(getClass().getClassLoader().getResource("migration/subdir").getPath(), "UTF-8");
 
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:" + new File(path).getPath()), PlaceholderReplacer.NO_PLACEHOLDERS,
-                        FlywayConfigurationForTests.create());
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:" + new File(path).getPath());
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(null, config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -17,6 +17,7 @@ package org.flywaydb.core.internal.resolver.sql;
 
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
@@ -33,10 +34,12 @@ import static org.junit.Assert.*;
  */
 public class SqlMigrationResolverSmallTest {
 
+    private FlywayConfigurationForTests config;
+
     @Test
     public void resolveMigrations() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("migration/subdir"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("migration/subdir");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -56,8 +59,7 @@ public class SqlMigrationResolverSmallTest {
     public void resolveMigrationsRoot() {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "");
         config.setRepeatableSqlMigrationPrefix("X");
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -65,16 +67,16 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsNonExisting() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         sqlMigrationResolver.resolveMigrations();
     }
 
     @Test
     public void extractScriptName() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -83,8 +85,8 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameRootLocation() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations(""));
+        config = FlywayConfigurationForTests.createWithLocations("");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -93,8 +95,8 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void extractScriptNameFileSystemPrefix() {
-        SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir"));
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir");
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),
                 new Location("filesystem:/some/dir")));

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -18,8 +18,6 @@ package org.flywaydb.core.internal.resolver.sql;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -38,8 +36,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("migration/subdir"));
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -57,10 +54,10 @@ public class SqlMigrationResolverSmallTest {
 
     @Test
     public void resolveMigrationsRoot() {
-        FlywayConfigurationForTests configuration = FlywayConfigurationForTests.createWithPrefix("CheckValidate");
-        configuration.setRepeatableSqlMigrationPrefix("X");
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "");
+        config.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
+                new SqlMigrationResolver(null, config);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -69,8 +66,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("CheckValidate", "non/existing"));
 
         sqlMigrationResolver.resolveMigrations();
     }
@@ -78,8 +74,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithPrefixAndLocations("db_", "db/migration"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -89,8 +84,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
-                        PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations(""));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.sql", Thread.currentThread().getContextClassLoader()),
@@ -100,8 +94,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
-                        new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
+                new SqlMigrationResolver(null, FlywayConfigurationForTests.createWithLocations("filesystem:/some/dir"));
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),
                 new Location("filesystem:/some/dir")));

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolverSmallTest.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
 import org.junit.Test;
@@ -36,12 +35,10 @@ import static org.junit.Assert.*;
  */
 public class SqlMigrationResolverSmallTest {
 
-    private final Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader());
-
     @Test
     public void resolveMigrations() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("migration/subdir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
 
@@ -63,7 +60,7 @@ public class SqlMigrationResolverSmallTest {
         FlywayConfigurationForTests configuration = FlywayConfigurationForTests.createWithPrefix("CheckValidate");
         configuration.setRepeatableSqlMigrationPrefix("X");
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""), PlaceholderReplacer.NO_PLACEHOLDERS, configuration);
 
         // changed to 3 as new test cases are added for SybaseASE and DB2
         assertEquals(3, sqlMigrationResolver.resolveMigrations().size());
@@ -72,7 +69,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void resolveMigrationsNonExisting() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("non/existing"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("CheckValidate"));
 
         sqlMigrationResolver.resolveMigrations();
@@ -81,7 +78,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("db/migration"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -92,7 +89,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner, new Locations(""),
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(), new Locations(""),
                         PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.sql", sqlMigrationResolver.extractScriptName(
@@ -103,7 +100,7 @@ public class SqlMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         SqlMigrationResolver sqlMigrationResolver =
-                new SqlMigrationResolver(null, scanner,
+                new SqlMigrationResolver(null, Thread.currentThread().getContextClassLoader(),
                         new Locations("filesystem:/some/dir"), PlaceholderReplacer.NO_PLACEHOLDERS, FlywayConfigurationForTests.create());
 
         assertEquals("V3.171__patch.sql", sqlMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.sql"),

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -30,11 +30,8 @@ import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.flywaydb.core.internal.resolver.FlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.sql.SqlMigrationResolver;
-import org.flywaydb.core.internal.util.Location;
-import org.flywaydb.core.internal.util.Locations;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.jdbc.DriverDataSource;
-import org.flywaydb.core.internal.util.scanner.Scanner;
+import org.flywaydb.core.internal.util.ConfigurationInjectionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -301,7 +298,7 @@ public abstract class MigrationTestCase {
     private void assertChecksum(MigrationInfo migrationInfo) {
         FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations(getBasedir());
 
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(dbSupport, config);
+        SqlMigrationResolver sqlMigrationResolver = ConfigurationInjectionUtils.injectFlywayConfiguration(new SqlMigrationResolver(), config);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -298,12 +298,10 @@ public abstract class MigrationTestCase {
      * @param migrationInfo
      *            The migration to check.
      */
-    protected void assertChecksum(MigrationInfo migrationInfo) {
-        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, Thread.currentThread().getContextClassLoader(),
-                new Locations(getBasedir()),
-                PlaceholderReplacer.NO_PLACEHOLDERS,
-                FlywayConfigurationForTests.create());
+    private void assertChecksum(MigrationInfo migrationInfo) {
+        FlywayConfigurationForTests config = FlywayConfigurationForTests.createWithLocations(getBasedir());
+
+        SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(dbSupport, config);
         List<ResolvedMigration> migrations = sqlMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {
             if (migration.getVersion().toString().equals(migrationInfo.getVersion().toString())) {

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MigrationTestCase.java
@@ -300,7 +300,7 @@ public abstract class MigrationTestCase {
      */
     protected void assertChecksum(MigrationInfo migrationInfo) {
         SqlMigrationResolver sqlMigrationResolver = new SqlMigrationResolver(
-                dbSupport, new Scanner(Thread.currentThread().getContextClassLoader()),
+                dbSupport, Thread.currentThread().getContextClassLoader(),
                 new Locations(getBasedir()),
                 PlaceholderReplacer.NO_PLACEHOLDERS,
                 FlywayConfigurationForTests.create());


### PR DESCRIPTION
part of implementation of #1567.

Similar to #1570. This PR changes the `SqlMigrationResolver` to also use a default constructor and injection of FlywayConfiguration. However, since it depended on an instance of `DbSupport` this is somewhat bigger:

- Take all necessary information from FlywayConfiguration
- inject Flyway configuration via ConfigurationAware
- Don't pass down DbSupport (it is only ever needed in SqlScript)
- SqlScript obtains its DbSupport via DbFactory (cheap since the connection is reused)
- Don't pass down placeholders, they can be created from FlywayConfiguration

This PR includes #1570 as well as #1569 and #1568 

I would suggest merging them all together, which would keep the history cleaner (since they are all related)