### PR TITLE
drop the _pk index to resolve issue with repeatable migrations

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2/upgradeMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/db2/upgradeMetaDataTable.sql
@@ -22,3 +22,4 @@ ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" DROP NOT NULL;
 call ADMIN_CMD('REORG TABLE "${schema}"."${table}"');
 ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
 UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';
+DROP INDEX "${schema}"."${table}_pk";


### PR DESCRIPTION
I believe this drop has to happen after the primary key change, so I put it at the end of the script.  This addresses issue #1586 

I don't see any tests to modify for this change.  I also don't have a build environment set up to test it, but it seems pretty cut and dried.