### PR TITLE
For Postgresql migrations, add support for "DROP INDEX CONCURRENTLY .*",

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSqlStatementBuilder.java
@@ -73,7 +73,7 @@ public class PostgreSQLSqlStatementBuilder extends SqlStatementBuilder {
 
         if (statementStart.matches("(CREATE|DROP) (DATABASE|TABLESPACE) .*")
                 || statementStart.matches("ALTER SYSTEM .*")
-                || statementStart.matches("CREATE( UNIQUE)? INDEX CONCURRENTLY .*")
+                || statementStart.matches("(CREATE|DROP)( UNIQUE)? INDEX CONCURRENTLY .*")
                 || statementStart.matches("REINDEX( VERBOSE)? (SCHEMA|DATABASE|SYSTEM) .*")
                 || statementStart.matches("VACUUM .*")
                 || statementStart.matches("DISCARD ALL .*")


### PR DESCRIPTION
which must run outside of a transaction.
https://www.postgresql.org/docs/9.6/static/sql-dropindex.html