### PR TITLE
Fix a minor typo in Javadoc

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/callback/FlywayCallback.java
@@ -22,7 +22,7 @@ import java.sql.Connection;
 
 /**
  * This is the main callback interface that should be implemented to get access to flyway lifecycle notifications.
- * Simply add code to the callback method you are interested in having. A convenience implementation will all methods
+ * Simply add code to the callback method you are interested in having. A convenience implementation with all methods
  * doing nothing is provided with {@link BaseFlywayCallback}. To ensure backward compatibility, you are encouraged
  * to subclass that class instead of implementing this interface directly.
  *


### PR DESCRIPTION
While reading the FlywayCallback docs faced that typo and changed it from **will** to **with**