### PR TITLE
Convert classpath with cygpath if it is available regardless of uname output

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -56,7 +56,7 @@ if $linux; then
 fi
 
 if `command -v cygpath > /dev/null`; then
-  CP=$(cygpath -pw "$CP")
+  CP=`cygpath -pw "$CP"`
 fi
 
 "$JAVA_CMD" $JAVA_ARGS -cp "$CP" org.flywaydb.commandline.Main "$@"

--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -15,11 +15,9 @@
 # limitations under the License.
 #
 
-# Detect cygwin
-cygwin=false
+# Detect OS
 linux=false
 case "`uname`" in
-  CYGWIN*|MINGW*) cygwin=true;;
   Linux*) linux=true;;
 esac
 
@@ -57,7 +55,7 @@ if $linux; then
   JAVA_ARGS=-Djava.security.egd=file:/dev/../dev/urandom
 fi
 
-if $cygwin; then
+if `command -v cygpath > /dev/null`; then
   CP=$(cygpath -pw "$CP")
 fi
 


### PR DESCRIPTION
This is a possible fix for #1642.

Cygwin detection fails on [Git for Windows](https://git-scm.com/) because `uname` returns `MSYS_NT-10.0` which does not match the known patterns. Instead of expanding the patterns, a more generic solution is to use `cygpath` if there is such a command.

I was not able to find any case in Google when `cygpath` was installed on a non-Windows system, therefore I think it is safe to assume that if `cygpath` is available, the classpath needs to be converted to a Windows path list. A better solution would be to let `cygpath` detect the system, but unfortunately this is not supported.

This pull request also replaces the `$(...)` syntax with backticks when calling `cygpath` to make the script more consistent. If this change poses an issue, please let me know and I will revert it.