### PR TITLE
Fixes gh #1305

### DIFF
--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -46,6 +46,7 @@ import java.util.Properties;
  * @requiresDependencyResolution test
  * @configurator include-project-dependencies
  * @phase pre-integration-test
+ * @threadSafe
  */
 @SuppressWarnings({"JavaDoc", "FieldCanBeLocal", "UnusedDeclaration"})
 abstract class AbstractFlywayMojo extends AbstractMojo {


### PR DESCRIPTION
Looking at the guidelines at  https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3 and the code - there seems to be no shared state - and hence OK to set @threadSafe 