### PR TITLE
Fixes #1654: Switch to a spin pg_try_advisory_lock

### DIFF
--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLConcurrentMigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLConcurrentMigrationMediumTest.java
@@ -56,4 +56,16 @@ public class PostgreSQLConcurrentMigrationMediumTest extends ConcurrentMigration
         return new DriverDataSource(Thread.currentThread().getContextClassLoader(), null,
                 jdbcUrl, JDBC_USER, JDBC_PASSWORD);
     }
+
+    protected String getBasedir() {
+        return "migration/dbsupport/postgresql/sql/concurrent";
+    }
+
+    @Override
+    protected boolean isMixed() {
+        // V1_1__View.sql has both a SELECT pg_sleep and CREATE INDEX CONCURRENTLY to help
+        // to reproduce the deadlock which can occur with the use of advisory locks.
+        // See #1654 for details.
+        return true;
+    }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/ConcurrentMigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/ConcurrentMigrationTestCase.java
@@ -113,6 +113,10 @@ public abstract class ConcurrentMigrationTestCase {
         return "concurrent_test";
     }
 
+    protected boolean isMixed() {
+        return false;
+    }
+
     /**
      * Creates the datasource for this testcase based on these optional custom properties from the user home.
      *
@@ -178,6 +182,7 @@ public abstract class ConcurrentMigrationTestCase {
         placeholders.put("schema", schemaQuoted);
 
         newFlyway.setPlaceholders(placeholders);
+        newFlyway.setMixed(isMixed());
         newFlyway.setBaselineVersionAsString("0.1");
         return newFlyway;
     }

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1_1__View.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1_1__View.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE VIEW ${schema}.all_misters AS SELECT * FROM ${schema}.test_user WHERE name LIKE 'Mr.%';
+
+-- The pg_sleep is just to simulate creating an index concurrently
+-- on a large table which can trigger a deadlock in combination with
+-- the use of advisory locks. The sleep is not strictly required for
+-- the deadlock to occur.
+SELECT pg_sleep(1);
+
+CREATE INDEX CONCURRENTLY idx_test_user_name ON ${schema}.test_user(name);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1_2__Populate_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1_2__Populate_table.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+INSERT INTO ${schema}.test_user (name, id) VALUES ('Mr. Iße T', 1);
+INSERT INTO ${schema}.test_user (name, id) VALUES ('Mr. Semicolon;', 2);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1__First.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V1__First.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${schema}.test_user (
+  id INT NOT NULL,
+  name VARCHAR(25) NOT NULL,  -- this is a valid comment
+  PRIMARY KEY(name)  /* and so is this ! */
+);

--- a/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V2_0__Add_foreign_key_and_super_mega_humongous_padding_to_exceed_the_maximum_column_length_in_the_metadata_table.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/postgresql/sql/concurrent/V2_0__Add_foreign_key_and_super_mega_humongous_padding_to_exceed_the_maximum_column_length_in_the_metadata_table.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE ${schema}.couple (
+  id INT NOT NULL,
+  name1 VARCHAR(25) NOT NULL,
+  name2 VARCHAR(25) NOT NULL,
+  PRIMARY KEY(id),
+  CONSTRAINT couple_user1_fk FOREIGN KEY (name1) REFERENCES ${schema}.test_user(name),
+  CONSTRAINT couple_user2_fk FOREIGN KEY (name2) REFERENCES ${schema}.test_user(name)
+);
+
+INSERT INTO ${schema}.couple (id, name1, name2) VALUES (1, 'Mr. Iße T', 'Mr. Semicolon;');


### PR DESCRIPTION
Postgres can deadlock with a pending pg_advisory_lock and
a long running CREATE INDEX CONCURRENTLY statement.

* Reproduce the deadlock in PostgreSQLConcurrentMigrationMediumTest
  with a modified version of the regular ConcurrentMigrationMediumTest
* Modify PostgreSQLAdvisoryLockTemplate to spin until
  pg_try_advisory_lock returns true or it is interrupted
* Sleep for 100ms on failed attempt to acquire the advisory lock