### PR TITLE
Fixed #1627 Continue classpath scan on AccessControlException

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScanner.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLDecoder;
+import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -192,38 +193,43 @@ public class ClassPathScanner implements ResourceAndClassScanner {
                 if ("file".equals(url.getProtocol())
                         && url.getPath().endsWith(".jar")
                         && !url.getPath().matches(".*" + Pattern.quote("/jre/lib/") + ".*")) {
-                    // All non-system jars on disk
-                    JarFile jarFile;
                     try {
-                        jarFile = new JarFile(url.toURI().getSchemeSpecificPart());
-                    } catch (URISyntaxException ex) {
-                        // Fallback for URLs that are not valid URIs (should hardly ever happen).
-                        jarFile = new JarFile(url.getPath().substring("file:".length()));
-                    }
-
-                    try {
-                        boolean directoryFound = false;
-                        Enumeration<JarEntry> entries = jarFile.entries();
-                        while (entries.hasMoreElements()) {
-                            if (entries.nextElement().isDirectory()) {
-                                directoryFound = true;
-                                break;
-                            }
+                        // All non-system jars on disk
+                        JarFile jarFile;
+                        try {
+                            jarFile = new JarFile(url.toURI().getSchemeSpecificPart());
+                        } catch (URISyntaxException ex) {
+                            // Fallback for URLs that are not valid URIs (should hardly ever happen).
+                            jarFile = new JarFile(url.getPath().substring("file:".length()));
                         }
-                        if (!directoryFound) {
-                            entries = jarFile.entries();
+
+                        try {
+                            boolean directoryFound = false;
+                            Enumeration<JarEntry> entries = jarFile.entries();
                             while (entries.hasMoreElements()) {
-                                String entryName = entries.nextElement().getName();
-                                if (entryName.startsWith(location.getPath())) {
-                                    locationResolved = true;
-                                    if (entryName.endsWith(suffix)) {
-                                        resourceNames.add(entryName);
+                                if (entries.nextElement().isDirectory()) {
+                                    directoryFound = true;
+                                    break;
+                                }
+                            }
+                            if (!directoryFound) {
+                                entries = jarFile.entries();
+                                while (entries.hasMoreElements()) {
+                                    String entryName = entries.nextElement().getName();
+                                    if (entryName.startsWith(location.getPath())) {
+                                        locationResolved = true;
+                                        if (entryName.endsWith(suffix)) {
+                                            resourceNames.add(entryName);
+                                        }
                                     }
                                 }
                             }
+                        } finally {
+                            jarFile.close();
                         }
-                    } finally {
-                        jarFile.close();
+                    } catch (AccessControlException e) {
+                        // Ignore cases where the scanner pokes its nose where it doesn't belong.
+                        LOG.warn("Not allowed to scan url: " + url.getPath());
                     }
                 }
             }


### PR DESCRIPTION
Some environments (like the Google App Engine Jetty Dev Server) pull
in JAR's from the host system that are not allowed to be scanned at
runtime.  This causes an AccessControlException to be thrown by
java.security, which aborts the classpath scan completely and causes
Flyway to fail.  These JAR's will never have DB migrations in them,
so the failure is unnecessary.  Let's catch this exception and just
warn the user instead.