### PR TITLE
Support TestContainers JDBC connection string

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -247,6 +247,10 @@ public class DriverDataSource implements DataSource {
      * @return The Jdbc driver.
      */
     private String detectDriverForUrl(String url) {
+        if (url.startsWith("jdbc:tc:")) {
+            return "org.testcontainers.jdbc.ContainerDatabaseDriver";
+        }
+
         if (url.startsWith("jdbc:db2:")) {
             return "com.ibm.db2.jcc.DB2Driver";
         }


### PR DESCRIPTION
I would like to propose this change in order to support TestContainers JDBC connection string.

This way it will be possible to run database migration scripts against Dockerized database instance started by TestContainers.

Let me know if you have any questions.