### PR TITLE
Fix SSH Tunnel Bug on macOS 10.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.h2>1.4.193</version.h2>
         <version.hsqldb>2.3.4</version.hsqldb>
         <version.jtds>1.3.1</version.jtds>
-        <version.mariadb>1.4.5</version.mariadb>
+        <version.mariadb>2.0.2</version.mariadb>
         <version.postgresql>9.4.1208.jre6</version.postgresql>
         <version.sqlite>3.7.15-M1</version.sqlite>
         <version.phoenix>4.4.0-HBase-0.98</version.phoenix>


### PR DESCRIPTION
This commit upgrades the mariadb-java-client library to fix the SSH
tunnel bug described in https://github.com/flyway/flyway/issues/1667

mariadb-java-client 1.4.5 has a bug that prevents a connection over an
SSH tunnel on macOS 10.12.