### PR TITLE
#1675: Forcing flyway to fail if there is a compilation error in oracle sql procedure

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/JdbcTemplate.java
@@ -270,6 +270,10 @@ public class JdbcTemplate {
                 while (warning != null) {
                     if ("00000".equals(warning.getSQLState())) {
                         LOG.info("DB: " + warning.getMessage());
+                    } else if (("99999".equals(warning.getSQLState())) && (warning.getErrorCode() == 17110)) {
+                        LOG.error("DB: " + warning.getMessage()
+                                + " (SQL State: " + warning.getSQLState() + " - Error Code: " + warning.getErrorCode() + ")");
+                        throw new SQLException(warning.getMessage(), warning.getSQLState(), warning.getErrorCode(), warning.getCause());
                     } else {
                         LOG.warn("DB: " + warning.getMessage()
                                 + " (SQL State: " + warning.getSQLState() + " - Error Code: " + warning.getErrorCode() + ")");


### PR DESCRIPTION
This pull request is to address the issue #1675 . With this code, Flyway will throw an error and mark the execution as "failed" if there is a compilation failure in Oracle sql stored procedures. However, the stacktrace did not provide us the root cause of the compilation failure which needs to be enhanced further. 

Note: In Oracle SQL developer, the complete stacktrace is shown when we provide an option called "show errors". We need to find an alternative for this option in jdbc.