### PR TITLE
Made logging level in doMigrateGroup() consistent with rest of file

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -346,7 +346,7 @@ public class DbMigrate {
             } catch (SQLException e) {
                 throw new FlywayMigrateSqlException(migration, isOutOfOrder, e);
             }
-            LOG.debug("Successfully completed migration of " + migrationText);
+            LOG.info("Successfully completed migration of " + migrationText);
 
             for (final FlywayCallback callback : configuration.getCallbacks()) {
                 callback.afterEachMigrate(connectionUserObjects, migration);


### PR DESCRIPTION
The changed line paired with an info level statement so it seemed to be missing unless running at log level debug. All other logging in the class except this one line is also at the info level.