### PR TITLE
PostgreSQL: Use system catalogs for Table.doExists() & Schema.doEmpty()

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
@@ -48,7 +48,7 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDbSupport> {
 
     @Override
     protected boolean doEmpty() throws SQLException {
-        return jdbcTemplate.queryForBoolean("SELECT EXISTS (   SELECT 1\n" +
+        return !jdbcTemplate.queryForBoolean("SELECT EXISTS (   SELECT 1\n" +
                 "   FROM   pg_catalog.pg_class c\n" +
                 "   JOIN   pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n" +
                 "   WHERE  n.nspname = ?)", name);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLSchema.java
@@ -48,10 +48,10 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDbSupport> {
 
     @Override
     protected boolean doEmpty() throws SQLException {
-        int objectCount = jdbcTemplate.queryForInt(
-                "SELECT count(*) FROM information_schema.tables WHERE table_schema=? AND table_type='BASE TABLE'",
-                name);
-        return objectCount == 0;
+        return jdbcTemplate.queryForBoolean("SELECT EXISTS (   SELECT 1\n" +
+                "   FROM   pg_catalog.pg_class c\n" +
+                "   JOIN   pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n" +
+                "   WHERE  n.nspname = ?)", name);
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/postgresql/PostgreSQLTable.java
@@ -47,10 +47,12 @@ public class PostgreSQLTable extends Table {
     protected boolean doExists() throws SQLException {
         return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
                 "   SELECT 1\n" +
-                "   FROM   information_schema.tables \n" +
-                "   WHERE  table_schema = ?\n" +
-                "   AND    table_name = ?\n" +
-                ")", schema.getName(), name);
+                "   FROM   pg_catalog.pg_class c\n" +
+                "   JOIN   pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n" +
+                "   WHERE  n.nspname = ?\n" +
+                "   AND    c.relname = ?\n" +
+                "   AND    c.relkind = 'r'    -- only tables\n" +
+                "   );", schema.getName(), name);
     }
 
     @Override


### PR DESCRIPTION
Speed up PostgreSQLTable.doExists()
Also speed up PostgreSQLSchema.doEmpty() - but this is not called as often as the 
former one

Issue:
https://github.com/flyway/flyway/issues/1701 - Table.exists() very slow in Postgres Environments with a lot of objects