### PR TITLE
Use Windows CLASSPATH environment variable

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.cmd
+++ b/flyway-commandline/src/main/assembly/flyway.cmd
@@ -31,8 +31,11 @@ if exist "%INSTALLDIR%\jre\bin\java.exe" (
   set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
  )
 )
+SET CP=
 
-%JAVA_CMD% -cp "%INSTALLDIR%\lib\*;%INSTALLDIR%\drivers\*" org.flywaydb.commandline.Main %*
+IF DEFINED CLASSPATH ( SET CP=%CLASSPATH%;)
+
+%JAVA_CMD% -cp "%CP%%INSTALLDIR%\lib\*;%INSTALLDIR%\drivers\*" org.flywaydb.commandline.Main %*
 
 @REM Exit using the same code returned from Java
 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
Added a check to see if CLASSPATH environment variable is set. If yes, then add the classpath variable to the java command classpath option