### PR TITLE
Fix # 1747 Could not find a valid Docker environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
-dist: precise
+dist: trusty
 sudo: required
 language: java
 jdk:
   - oraclejdk8
 services:
   - mysql
-  - docker
 before_install:
   - mysql --verbose -uroot < ./flyway-core/src/test/resources/migration/dbsupport/mysql/createDatabase.sql
   - echo "mariadb.url=jdbc:mariadb://localhost/flyway_maria_db" > ~/flyway-mediumtests.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ services:
 before_install:
   - mysql --verbose -uroot < ./flyway-core/src/test/resources/migration/dbsupport/mysql/createDatabase.sql
   - echo "mariadb.url=jdbc:mariadb://localhost/flyway_maria_db" > ~/flyway-mediumtests.properties
-install: "sh ./mvnw install -P-CommercialDBTest,-CommandlinePlatformAssemblies"
+install: "sh ./mvnw install -q -P-CommercialDBTest,-CommandlinePlatformAssemblies"
 before_script: echo OK
 script: echo Done.


### PR DESCRIPTION
This fixes the core test error "Could not find a valid Docker environment." Travis was also complaining (and still is complaining) about the amount of logging, so I set maven quiet attribute which cut verbosity a great deal. 
