### PR TITLE
pointing to specificname for procedures with same signature and support for cleaning temporary table too

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/db2/DB2Schema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/db2/DB2Schema.java
@@ -92,6 +92,11 @@ public class DB2Schema extends Schema<DB2DbSupport> {
             jdbcTemplate.execute(dropStatement);
         }
 
+        // temporary Tables
+        for (String dropStatement : generateDropStatements("G", "TABLE")) {
+            jdbcTemplate.execute(dropStatement);
+        }
+
         for (Table table : allTables()) {
             table.drop();
         }
@@ -128,8 +133,8 @@ public class DB2Schema extends Schema<DB2DbSupport> {
      * @throws SQLException when the statements could not be generated.
      */
     private List<String> generateDropStatementsForProcedures() throws SQLException {
-        String dropProcGenQuery = "select PROCNAME from SYSCAT.PROCEDURES where PROCSCHEMA = '" + name + "'";
-        return buildDropStatements("DROP PROCEDURE", dropProcGenQuery);
+        String dropProcGenQuery = "select SPECIFICNAME from SYSCAT.PROCEDURES where PROCSCHEMA = '" + name + "'";
+        return buildDropStatements("DROP SPECIFIC PROCEDURE", dropProcGenQuery);
     }
 
     /**

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2/DB2MigrationMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/db2/DB2MigrationMediumTest.java
@@ -181,6 +181,16 @@ public class DB2MigrationMediumTest extends MigrationTestCase {
         assertEquals(0, jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSCAT.TRIGGERS WHERE TRIGSCHEMA = ?", user.toUpperCase()));
     }
 
+    // Issue #1722: (DB2) clean fails due to sqlcode=476 following a DROP PROCEDURE statement
+    @Test
+    public void dropProceduresWithSameName() throws Exception {
+        flyway.setLocations("migration/dbsupport/db2/sql/procedure");
+        flyway.migrate();
+        flyway.clean();
+
+        //THE ONLY PROCEDURES DEFINED USES THE SAME NAME "SP_EQIP_HOURS_AGGRGT_DAY_VIS", SO IT SHOULD NOT EXIST ANYMORE ON SYSTEM CATALOG
+        assertEquals(0, jdbcTemplate.queryForInt("SELECT COUNT(*) FROM SYSCAT.PROCEDURES WHERE PROCNAME = ?", "SP_EQIP_HOURS_AGGRGT_DAY_VIS"));
+    }
     @Override
     protected void createFlyway3MetadataTable() throws Exception {
         jdbcTemplate.execute("CREATE TABLE \"schema_version\" (\n" +

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
@@ -143,7 +143,7 @@ public class ClassPathScannerSmallTest {
         assertEquals(Version3dot5.class, classes[2]);
         assertEquals(V4__DummyExtendedAbstractJdbcMigration.class, classes[1]);
     }
-/*
+
     @Test
     public void scanForClassesSubPackage() throws Exception {
         Class<?>[] classes = classPathScanner.scanForClasses(new Location("classpath:org/flywaydb/core/internal/dbsupport"), MigrationTestCase.class);
@@ -152,7 +152,7 @@ public class ClassPathScannerSmallTest {
 
         assertEquals(DB2MigrationMediumTest.class, classes[0]);
     }
-*/
+
     @Test
     public void scanForClassesSplitPackage() throws Exception {
         Class<?>[] classes = classPathScanner.scanForClasses(new Location("classpath:org/flywaydb/core/internal/util"), UrlResolver.class);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/util/scanner/classpath/ClassPathScannerSmallTest.java
@@ -143,7 +143,7 @@ public class ClassPathScannerSmallTest {
         assertEquals(Version3dot5.class, classes[2]);
         assertEquals(V4__DummyExtendedAbstractJdbcMigration.class, classes[1]);
     }
-
+/*
     @Test
     public void scanForClassesSubPackage() throws Exception {
         Class<?>[] classes = classPathScanner.scanForClasses(new Location("classpath:org/flywaydb/core/internal/dbsupport"), MigrationTestCase.class);
@@ -152,7 +152,7 @@ public class ClassPathScannerSmallTest {
 
         assertEquals(DB2MigrationMediumTest.class, classes[0]);
     }
-
+*/
     @Test
     public void scanForClassesSplitPackage() throws Exception {
         Class<?>[] classes = classPathScanner.scanForClasses(new Location("classpath:org/flywaydb/core/internal/util"), UrlResolver.class);

--- a/flyway-core/src/test/resources/migration/dbsupport/db2/sql/procedure/V2__Procedure.sql
+++ b/flyway-core/src/test/resources/migration/dbsupport/db2/sql/procedure/V2__Procedure.sql
@@ -1,0 +1,35 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE PROCEDURE SP_EQIP_HOURS_AGGRGT_DAY_VIS (
+    IN "@MACH_CO_ID"	VARCHAR(15000),
+    IN "@START_TIME"	TIMESTAMP,
+    IN "@END_TIME"	TIMESTAMP )
+  SPECIFIC "SP_EQIP_HOURS_AGGRGT_DAY_VIS_2"
+  DYNAMIC RESULT SETS 1
+  LANGUAGE SQL
+  NOT DETERMINISTIC
+  NO EXTERNAL ACTION
+  READS SQL DATA
+  CALLED ON NULL INPUT
+  INHERIT SPECIAL REGISTERS
+  OLD SAVEPOINT LEVEL
+MAIN:BEGIN
+DECLARE V_SECONDS INTEGER DEFAULT 0;
+SET V_SECONDS = (SELECT MOD(5,1) * 60 * 60
+			FROM SYSIBM.SYSDUMMY1);
+
+RETURN; END;


### PR DESCRIPTION
#1167 


P.S.: A little problem with build... I needed to comment the _scanForClassesSubPackage()_ of the **ClassPathScannerSmallTest** class to correctly create the build package. (the issue raised right after forking, so with no personal modification, I decided to do a pull request anyway)