### PR TITLE
Bump mariadb to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.h2>1.4.193</version.h2>
         <version.hsqldb>2.3.4</version.hsqldb>
         <version.jtds>1.3.1</version.jtds>
-        <version.mariadb>1.4.5</version.mariadb>
+        <version.mariadb>2.1.0</version.mariadb>
         <version.postgresql>9.4.1208.jre6</version.postgresql>
         <version.sqlite>3.7.15-M1</version.sqlite>
         <version.phoenix>4.4.0-HBase-0.98</version.phoenix>


### PR DESCRIPTION
Since Java 8 is now the new minimum supported version for 5.0, now would be a good time to migrate MariaDB to 2.1.0.

https://mariadb.com/kb/en/mariadb/about-mariadb-connector-j/