### PR TITLE
Fix for #1733. Support for Redshift JDBC 4.2

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -44,6 +44,9 @@ public class DriverDataSource implements DataSource {
     private static final String MYSQL_JDBC_URL_PREFIX = "jdbc:mysql:";
     private static final String ORACLE_JDBC_URL_PREFIX = "jdbc:oracle:";
     private static final String MYSQL_5_JDBC_DRIVER = "com.mysql.jdbc.Driver";
+    private static final String REDSHIFT_JDBC_42_DRIVER = "com.amazon.redshift.jdbc42.Driver";
+    private static final String REDSHIFT_JDBC_41_DRIVER = "com.amazon.redshift.jdbc41.Driver";
+    private static final String REDSHIFT_JDBC_4_DRIVER = "com.amazon.redshift.jdbc4.Driver";
 
     /**
      * The JDBC Driver instance to use.
@@ -240,7 +243,13 @@ public class DriverDataSource implements DataSource {
         }
 
         if (url.startsWith("jdbc:redshift:")) {
-            return "com.amazon.redshift.jdbc4.Driver";
+            if (ClassUtils.isPresent(REDSHIFT_JDBC_42_DRIVER, classLoader)) {
+                return REDSHIFT_JDBC_42_DRIVER;
+            }
+            if (ClassUtils.isPresent(REDSHIFT_JDBC_41_DRIVER, classLoader)) {
+                return REDSHIFT_JDBC_41_DRIVER;
+            }
+            return REDSHIFT_JDBC_4_DRIVER;
         }
 
         return null;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -315,7 +315,7 @@ public class DriverDataSource implements DataSource {
 
         if (url.startsWith("jdbc:redshift:")) {
             // The new format of Redshift JDBC urls, using the new Redshift-specific JDBC driver:
-            return "com.amazon.redshift.jdbc41.Driver";
+            return "com.amazon.redshift.jdbc.Driver";
         }
 
         if (url.startsWith("jdbc:jtds:")) {


### PR DESCRIPTION
Redshift has unified it's driver class name across different JDBC versions in version 1.2.1 (dated November 2016)

This was not always the case and there are different class names for drivers in versions prior to 1.2.1, used for different JDBC compatibility packages : http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html.

![Note about driver vaesions](https://user-images.githubusercontent.com/3283086/29793103-ee951acc-8c42-11e7-98a1-c020f1cc75fe.png)

This PR resolves this, by using the universal driver name as the main strategy (compatible with drivers 1.2.1+) and dedicated class names as fallback (by checking if that class exists on classpath) for older drivers.