### PR TITLE
Allow comment blocks before stored procs/views/etc in SQL Server

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
@@ -48,4 +48,12 @@ public class SQLServerSqlStatementBuilder extends SqlStatementBuilder {
 
         return token;
     }
+
+    /**
+     * @return {@code true} because we want all comments sent to the database.
+     */
+    @Override
+    public boolean isCommentDirective(String line) {
+        return true;
+    }
 }


### PR DESCRIPTION
update SQLServerSqlStatementBuilder.java so that every comment is seen as a directive and sent to sql server. This will prevent comment headers from being removed. 
https://github.com/flyway/flyway/issues/1362