### PR TITLE
Persist comment blocks before stored procs/views per issue 1362

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
@@ -50,10 +50,11 @@ public class SQLServerSqlStatementBuilder extends SqlStatementBuilder {
     }
 
     /**
-     * @return {@code true} because we want all comments sent to the database.
-     */
+    * @return Whether the current statement is only closed comments so far and can be discarded.
+    * on SQL Server, we never want to discard comments.
+    */
     @Override
-    public boolean isCommentDirective(String line) {
-        return true;
+    public boolean canDiscard() {
+        return false;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilder.java
@@ -48,4 +48,12 @@ public class SQLServerSqlStatementBuilder extends SqlStatementBuilder {
 
         return token;
     }
+
+    /**
+     * @return {@code true} because we want all comments sent to the database.
+     */
+    @Override
+    public boolean isCommentDirective(String line) {
+        return true;
+    }
 }


### PR DESCRIPTION
update SQLServerSqlStatementBuilder.java so that no comments are discarded. This will prevent comment headers from being removed.
https://github.com/flyway/flyway/issues/1362 
see comments on https://github.com/flyway/flyway/pull/1767.
If this is the correct direction, then i will be happy to write a test around it. 