### PR TITLE
Persist comment blocks on sql server, per issue 1362

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlserver/SQLServerSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlserver/SQLServerSqlStatementBuilder.java
@@ -72,4 +72,12 @@ public class SQLServerSqlStatementBuilder extends SqlStatementBuilder {
 
         return token;
     }
+    /**
+    * @return Whether the current statement is only closed comments so far and can be discarded,
+    * on SQL Server, we never want to discard comments.
+    */
+    @Override
+    public boolean canDiscard() {
+        return false;
+    }
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilderSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/sqlserver/SQLServerSqlStatementBuilderSmallTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2017 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.sqlserver;
+
+import org.flywaydb.core.internal.util.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Test for SQLServerSqlStatementBuilder.
+ */
+public class SQLServerSqlStatementBuilderSmallTest {
+    /**
+     * Class under test.
+     */
+    private SQLServerSqlStatementBuilder statementBuilder = new SQLServerSqlStatementBuilder();
+
+    @Test
+    public void go() {
+        String sqlScriptSource = "DROP VIEW dbo.TESTVIEW\n" +
+                "GO\n";
+
+        String[] lines = StringUtils.tokenizeToStringArray(sqlScriptSource, "\n");
+        for (String line : lines) {
+            statementBuilder.addLine(line);
+        }
+
+        assertTrue(statementBuilder.isTerminated());
+    }
+
+    @Test
+    public void likeNoSpace() {
+        String sqlScriptSource = "ALTER TRIGGER CUSTOMER_INSERT ON CUSTOMER AFTER\n" +
+                "INSERT AS\n" +
+                "BEGIN\n" +
+                "    SELECT TOP 1 1 FROM CUSTOMER WHERE [name] LIKE'%test';\n" +
+                "END\n" +
+                "GO";
+
+        String[] lines = StringUtils.tokenizeToStringArray(sqlScriptSource, "\n");
+        for (String line : lines) {
+            statementBuilder.addLine(line);
+        }
+
+        assertTrue(statementBuilder.isTerminated());
+    }
+    
+    @Test
+    public void retainComments(){
+        String sqlScriptSource = 
+        "--Comment\n" +
+        "-- Comment\n" +
+        "/* block */" +
+        "/*" +
+        "* Multiline" +
+        "*/" +
+        "ALTER TRIGGER CUSTOMER_INSERT ON CUSTOMER AFTER\n" +
+                "INSERT AS\n" +
+                "BEGIN\n" +
+                "    SELECT TOP 1 1 FROM CUSTOMER WHERE [name] LIKE'%test';\n" +
+                "END";
+    
+        String[] lines = StringUtils.tokenizeToStringArray(sqlScriptSource, "\n");
+        for (String line : lines) {
+            statementBuilder.addLine(line);
+            assertTrue(statementBuilder.canDiscard() == false);
+        }
+    }
+}


### PR DESCRIPTION
update SQLServerSqlStatementBuilder.java so that no comments are discarded. This will prevent comment headers from being removed.
https://github.com/flyway/flyway/issues/1362 
see comments on https://github.com/flyway/flyway/pull/1767.
If this is the correct direction, then i will be happy to write a test around it. 