### PR TITLE
Adding comment surrounding usage of Oracle TNS Connection string

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -190,7 +190,7 @@ flyway.url=
 # <<blank>> for the current database user of the connection. (default: <<blank>>).
 # flyway.installedBy=
 
-# Comma-separated list of the fully qualified calss names of handlers for errors and warnings that occur during a
+# Comma-separated list of the fully qualified class names of handlers for errors and warnings that occur during a
 # migration. This can be used to customize Flyway's behavior by for example
 # throwing another runtime exception, outputting a warning or suppressing the error instead of throwing a FlywayException.
 # ErrorHandlers are invoked in order until one reports to have successfully handled the errors or warnings.

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -19,6 +19,7 @@
 # --------
 # Most drivers are included out of the box.
 # * = driver must be downloaded and installed in /drivers manually
+# ** = TNS_ADMIN environmental variable must be set to directory of where tnsnames.ora file resides
 # CockroachDB       : jdbc:postgresql://<host>:<port>/<database>?<key1>=<value1>&<key2>=<value2>...
 # DB2*              : jdbc:db2://<host>:<port>/<database>
 # Derby             : jdbc:derby:<subsubprotocol>:<databaseName><;attribute=value>
@@ -27,6 +28,7 @@
 # MariaDB           : jdbc:mariadb://<host>:<port>/<database>?<key1>=<value1>&<key2>=<value2>...
 # MySQL             : jdbc:mysql://<host>:<port>/<database>?<key1>=<value1>&<key2>=<value2>...
 # Oracle*           : jdbc:oracle:thin:@//<host>:<port>/<service>
+# Oracle (TNS)**    : jdbc:oracle:thin:@<tns_entry>
 # PostgreSQL        : jdbc:postgresql://<host>:<port>/<database>?<key1>=<value1>&<key2>=<value2>...
 # SAP HANA*         : jdbc:sap://<host>:<port>/?databaseName=<database>
 # SQL Server        : jdbc:sqlserver:////<host>:<port>;databaseName=<database>


### PR DESCRIPTION
Minor update to the example flyway.conf file bundled with the command line to explicitly show connections to oracle databases can be made using TNS names