### PR TITLE
New option to allow for 'Ignored' migrations in 'validate' command: ignoreIgnoredMigrations

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -176,6 +176,17 @@ flyway.url=
 # true to continue normally and log a warning, false to fail fast with an exception. (default: false)
 # flyway.ignoreMissingMigrations=
 
+# Ignore ignored migrations when reading the schema history table. These are migrations that were added in between
+# already migrated migrations in this version. For example: we have migrations available on the classpath with
+# versions from 1.0 to 3.0. The schema history table indicates that version 1 was finished on 1.0.15, and the next
+# one was 2.0.0. But with the next release a new migration was added to version 1: 1.0.16. Such scenario is ignored
+# by migrate command, but by default is rejected by validate. When ignoreIgnoredMigrations is enabled, such case
+# will not be reported by validate command. This is useful for situations where one must be able to deliver
+# complete set of migrations in a delivery package for multiple versions of the product, and allows for further
+# development of older versions.
+# true to continue normally, false to fail fast with an exception. (default: false)
+# flyway.ignoreIgnoredMigrations=
+
 # Ignore future migrations when reading the schema history table. These are migrations that were performed by a
 # newer deployment of the application that are not yet available in this version. For example: we have migrations
 # available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -273,6 +273,7 @@ public class Main {
         LOG.info("skipDefaultCallbacks         : Skips default callbacks (sql)");
         LOG.info("validateOnMigrate            : Validate when running migrate");
         LOG.info("ignoreMissingMigrations      : Allow missing migrations when validating");
+        LOG.info("ignoreIgnoredMigrations      : Allow ignored migrations when validating");
         LOG.info("ignoreFutureMigrations       : Allow future migrations when validating");
         LOG.info("cleanOnValidationError       : Automatically clean on a validation error");
         LOG.info("cleanDisabled                : Whether to disable clean");

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -268,6 +268,21 @@ public interface FlywayConfiguration {
     boolean isIgnoreMissingMigrations();
 
     /**
+     * Ignore ignored migrations when reading the schema history table. These are migrations that were added in between
+     * already migrated migrations in this version. For example: we have migrations available on the classpath with
+     * versions from 1.0 to 3.0. The schema history table indicates that version 1 was finished on 1.0.15, and the next
+     * one was 2.0.0. But with the next release a new migration was added to version 1: 1.0.16. Such scenario is ignored
+     * by migrate command, but by default is rejected by validate. When ignoreIgnoredMigrations is enabled, such case
+     * will not be reported by validate command. This is useful for situations where one must be able to deliver
+     * complete set of migrations in a delivery package for multiple versions of the product, and allows for further
+     * development of older versions.
+     *
+     * @return {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    boolean isIgnoreIgnoredMigrations();
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbInfo.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbInfo.java
@@ -64,7 +64,7 @@ public class DbInfo {
 
             MigrationInfoServiceImpl migrationInfoService =
                     new MigrationInfoServiceImpl(migrationResolver, schemaHistory, configuration.getTarget(),
-                            configuration.isOutOfOrder(), true, true, true);
+                            configuration.isOutOfOrder(), true, true, true, true);
             migrationInfoService.refresh();
 
             for (final FlywayCallback callback : effectiveCallbacks) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -194,7 +194,7 @@ public class DbMigrate {
      */
     private Integer migrateGroup(boolean firstRun) {
         MigrationInfoServiceImpl infoService =
-                new MigrationInfoServiceImpl(migrationResolver, schemaHistory, configuration.getTarget(), configuration.isOutOfOrder(), true, true, true);
+                new MigrationInfoServiceImpl(migrationResolver, schemaHistory, configuration.getTarget(), configuration.isOutOfOrder(), true, true, true, true);
         infoService.refresh();
 
         MigrationVersion currentSchemaVersion = MigrationVersion.EMPTY;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbRepair.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbRepair.java
@@ -90,7 +90,7 @@ public class DbRepair {
         this.database = database;
         this.connection = database.getMainConnection();
         this.schema = schema;
-        this.migrationInfoService = new MigrationInfoServiceImpl(migrationResolver, schemaHistory, MigrationVersion.LATEST, true, true, true, true);
+        this.migrationInfoService = new MigrationInfoServiceImpl(migrationResolver, schemaHistory, MigrationVersion.LATEST, true, true, true, true, true);
         this.schemaHistory = schemaHistory;
         this.callbacks = callbacks;
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbValidate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbValidate.java
@@ -85,6 +85,11 @@ public class DbValidate {
     private final boolean missing;
 
     /**
+     * Whether ignored migrations are allowed.
+     */
+    private final boolean ignored;
+
+    /**
      * Whether future migrations are allowed.
      */
     private final boolean future;
@@ -111,7 +116,7 @@ public class DbValidate {
      * @param callbacks         The lifecycle callbacks.
      */
     public DbValidate(Database database, SchemaHistory schemaHistory, Schema schema, MigrationResolver migrationResolver,
-                      MigrationVersion target, boolean outOfOrder, boolean pending, boolean missing, boolean future,
+                      MigrationVersion target, boolean outOfOrder, boolean pending, boolean missing, boolean ignored, boolean future,
                       List<FlywayCallback> callbacks) {
         this.connection = database.getMainConnection();
         this.schemaHistory = schemaHistory;
@@ -121,6 +126,7 @@ public class DbValidate {
         this.outOfOrder = outOfOrder;
         this.pending = pending;
         this.missing = missing;
+        this.ignored = ignored;
         this.future = future;
         this.callbacks = callbacks;
     }
@@ -159,7 +165,7 @@ public class DbValidate {
                 public Pair<Integer, String> call() {
                     connection.changeCurrentSchemaTo(schema);
                     MigrationInfoServiceImpl migrationInfoService =
-                            new MigrationInfoServiceImpl(migrationResolver, schemaHistory, target, outOfOrder, pending, missing, future);
+                            new MigrationInfoServiceImpl(migrationResolver, schemaHistory, target, outOfOrder, pending, missing, ignored, future);
 
                     migrationInfoService.refresh();
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -63,6 +63,7 @@ public class ConfigUtils {
     public static final String GROUP = "flyway.group";
     public static final String IGNORE_FUTURE_MIGRATIONS = "flyway.ignoreFutureMigrations";
     public static final String IGNORE_MISSING_MIGRATIONS = "flyway.ignoreMissingMigrations";
+    public static final String IGNORE_IGNORED_MIGRATIONS = "flyway.ignoreIgnoredMigrations";
     public static final String INSTALLED_BY = "flyway.installedBy";
     public static final String LOCATIONS = "flyway.locations";
     public static final String MIXED = "flyway.mixed";

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -174,6 +174,9 @@ public class ConfigUtils {
         if ("FLYWAY_IGNORE_MISSING_MIGRATIONS".equals(key)) {
             return IGNORE_MISSING_MIGRATIONS;
         }
+        if ("FLYWAY_IGNORE_IGNORED_MIGRATIONS".equals(key)) {
+            return IGNORE_IGNORED_MIGRATIONS;
+        }
         if ("FLYWAY_INSTALLED_BY".equals(key)) {
             return INSTALLED_BY;
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoContext.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoContext.java
@@ -40,6 +40,11 @@ public class MigrationInfoContext {
     public boolean missing;
 
     /**
+     * Whether ignored migrations are allowed.
+     */
+    public boolean ignored;
+
+    /**
      * Whether future migrations are allowed.
      */
     public boolean future;
@@ -81,6 +86,7 @@ public class MigrationInfoContext {
         if (outOfOrder != that.outOfOrder) return false;
         if (pending != that.pending) return false;
         if (missing != that.missing) return false;
+        if (ignored != that.ignored) return false;
         if (future != that.future) return false;
         if (target != null ? !target.equals(that.target) : that.target != null) return false;
         if (schema != null ? !schema.equals(that.schema) : that.schema != null) return false;
@@ -96,6 +102,7 @@ public class MigrationInfoContext {
         int result = (outOfOrder ? 1 : 0);
         result = 31 * result + (pending ? 1 : 0);
         result = 31 * result + (missing ? 1 : 0);
+        result = 31 * result + (ignored ? 1 : 0);
         result = 31 * result + (future ? 1 : 0);
         result = 31 * result + (target != null ? target.hashCode() : 0);
         result = 31 * result + (schema != null ? schema.hashCode() : 0);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
@@ -258,7 +258,7 @@ public class MigrationInfoImpl implements MigrationInfo {
             return "Detected applied migration not resolved locally: " + getVersion();
         }
 
-        if (!context.pending && MigrationState.PENDING == getState() || MigrationState.IGNORED == getState()) {
+        if (!context.pending && MigrationState.PENDING == getState() || (!context.ignored && MigrationState.IGNORED == getState())) {
             if (getVersion() != null) {
                 return "Detected resolved migration not applied to database: " + getVersion();
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoServiceImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoServiceImpl.java
@@ -75,6 +75,11 @@ public class MigrationInfoServiceImpl implements MigrationInfoService {
     private final boolean missing;
 
     /**
+     * Whether ignored migrations are allowed.
+     */
+    private final boolean ignored;
+
+    /**
      * Whether future migrations are allowed.
      */
     private final boolean future;
@@ -93,17 +98,19 @@ public class MigrationInfoServiceImpl implements MigrationInfoService {
      * @param outOfOrder        Allows migrations to be run "out of order".
      * @param pending           Whether pending migrations are allowed.
      * @param missing           Whether missing migrations are allowed.
+     * @param ignored           Whether ignored migrations are allowed.
      * @param future            Whether future migrations are allowed.
      */
     public MigrationInfoServiceImpl(MigrationResolver migrationResolver,
                                     SchemaHistory schemaHistory,
-                                    MigrationVersion target, boolean outOfOrder, boolean pending, boolean missing, boolean future) {
+                                    MigrationVersion target, boolean outOfOrder, boolean pending, boolean missing, boolean ignored, boolean future) {
         this.migrationResolver = migrationResolver;
         this.schemaHistory = schemaHistory;
         this.target = target;
         this.outOfOrder = outOfOrder;
         this.pending = pending;
         this.missing = missing;
+        this.ignored = ignored;
         this.future = future;
     }
 
@@ -118,6 +125,7 @@ public class MigrationInfoServiceImpl implements MigrationInfoService {
         context.outOfOrder = outOfOrder;
         context.pending = pending;
         context.missing = missing;
+        context.ignored = ignored;
         context.future = future;
         context.target = target;
 

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -219,6 +219,21 @@ public class FlywayExtension {
     public Boolean ignoreMissingMigrations;
 
     /**
+     * Ignore ignored migrations when reading the schema history table. These are migrations that were added in between
+     * already migrated migrations in this version. For example: we have migrations available on the classpath with
+     * versions from 1.0 to 3.0. The schema history table indicates that version 1 was finished on 1.0.15, and the next
+     * one was 2.0.0. But with the next release a new migration was added to version 1: 1.0.16. Such scenario is ignored
+     * by migrate command, but by default is rejected by validate. When ignoreIgnoredMigrations is enabled, such case
+     * will not be reported by validate command. This is useful for situations where one must be able to deliver
+     * complete set of migrations in a delivery package for multiple versions of the product, and allows for further
+     * development of older versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    public Boolean ignoreIgnoredMigrations;
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -246,6 +246,21 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     public Boolean ignoreMissingMigrations;
 
     /**
+     * Ignore ignored migrations when reading the schema history table. These are migrations that were added in between
+     * already migrated migrations in this version. For example: we have migrations available on the classpath with
+     * versions from 1.0 to 3.0. The schema history table indicates that version 1 was finished on 1.0.15, and the next
+     * one was 2.0.0. But with the next release a new migration was added to version 1: 1.0.16. Such scenario is ignored
+     * by migrate command, but by default is rejected by validate. When ignoreIgnoredMigrations is enabled, such case
+     * will not be reported by validate command. This is useful for situations where one must be able to deliver
+     * complete set of migrations in a delivery package for multiple versions of the product, and allows for further
+     * development of older versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    public Boolean ignoreIgnoredMigrations;
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0
@@ -437,6 +452,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         putIfSet(conf, ConfigUtils.VALIDATE_ON_MIGRATE, validateOnMigrate, extension.validateOnMigrate);
         putIfSet(conf, ConfigUtils.CLEAN_ON_VALIDATION_ERROR, cleanOnValidationError, extension.cleanOnValidationError);
         putIfSet(conf, ConfigUtils.IGNORE_MISSING_MIGRATIONS, ignoreMissingMigrations, extension.ignoreMissingMigrations);
+        putIfSet(conf, ConfigUtils.IGNORE_IGNORED_MIGRATIONS, ignoreIgnoredMigrations, extension.ignoreIgnoredMigrations);
         putIfSet(conf, ConfigUtils.IGNORE_FUTURE_MIGRATIONS, ignoreFutureMigrations, extension.ignoreFutureMigrations);
         putIfSet(conf, ConfigUtils.CLEAN_DISABLED, cleanDisabled, extension.cleanDisabled);
         putIfSet(conf, ConfigUtils.BASELINE_ON_MIGRATE, baselineOnMigrate, extension.baselineOnMigrate);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -286,6 +286,22 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private Boolean ignoreMissingMigrations;
 
     /**
+     * Ignore ignored migrations when reading the schema history table. These are migrations that were added in between
+     * already migrated migrations in this version. For example: we have migrations available on the classpath with
+     * versions from 1.0 to 3.0. The schema history table indicates that version 1 was finished on 1.0.15, and the next
+     * one was 2.0.0. But with the next release a new migration was added to version 1: 1.0.16. Such scenario is ignored
+     * by migrate command, but by default is rejected by validate. When ignoreIgnoredMigrations is enabled, such case
+     * will not be reported by validate command. This is useful for situations where one must be able to deliver
+     * complete set of migrations in a delivery package for multiple versions of the product, and allows for further
+     * development of older versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    @Parameter(property = ConfigUtils.IGNORE_IGNORED_MIGRATIONS)
+    private Boolean ignoreIgnoredMigrations;
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0
@@ -572,6 +588,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
             putIfSet(conf, ConfigUtils.OUT_OF_ORDER, outOfOrder);
             putIfSet(conf, ConfigUtils.TARGET, target);
             putIfSet(conf, ConfigUtils.IGNORE_MISSING_MIGRATIONS, ignoreMissingMigrations);
+            putIfSet(conf, ConfigUtils.IGNORE_IGNORED_MIGRATIONS, ignoreIgnoredMigrations);
             putIfSet(conf, ConfigUtils.IGNORE_FUTURE_MIGRATIONS, ignoreFutureMigrations);
             putIfSet(conf, ConfigUtils.PLACEHOLDER_REPLACEMENT, placeholderReplacement);
             putIfSet(conf, ConfigUtils.PLACEHOLDER_PREFIX, placeholderPrefix);


### PR DESCRIPTION
This is a pull request for issue #1865. 

The main change was done in MigrationInfoImpl class, where the new configuration flag is actually checked. All other changes are done taking as an example "flyway.ignoreMissingMigrations" configuration flag. I added a new option: "flyway.ignoreIgnoredMigrations". All changes in code take place next to a "missing" boolean flag.

I tried to follow all the conventions already applied in code. Also description of the configuration option in flyway.conf was done so that it is as similar to the description of surrounding "ignore..." flags, as possible.