### PR TITLE
Added support for Firebird database to flyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Windows, macOS, Linux, Java and Android
 Maven and Gradle
 
 #### Supported databases
-Oracle, SQL Server, DB2, MySQL, MariaDB, PostgreSQL, Redshift, CockroachDB, SAP HANA, Sybase ASE, H2, HSQLDB, Derby, SQLite
+Oracle, SQL Server, DB2, MySQL, MariaDB, PostgreSQL, Redshift, CockroachDB, SAP HANA, Sybase ASE, H2, HSQLDB, Derby, SQLite, Firebird
 
 #### Third party plugins
 SBT, Ant, Spring Boot, Grails, Play!, DropWizard, Grunt, Griffon, Ninja, ...

--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -80,13 +80,10 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>
-
-
-
-
-
-
-
+        <dependency>
+            <groupId>org.firebirdsql.jdbc</groupId>
+            <artifactId>jaybird-jdk18</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -139,12 +136,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-
-
-
-
-
 
 
         </plugins>
@@ -235,15 +226,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
-
-
-
-
-
-
-
-
 
 
                 </plugins>

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -34,6 +34,7 @@
 # SQL Server        : jdbc:sqlserver:////<host>:<port>;databaseName=<database>
 # SQLite            : jdbc:sqlite:<database>
 # Sybase ASE        : jdbc:jtds:sybase://<host>:<port>/<database>
+# Firebird          : jdbc:firebirdsql:<native|local|embedded>:<host/port>:<path>
 flyway.url=
 
 # Fully qualified classname of the jdbc driver (autodetected by default based on flyway.url)

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbClean.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbClean.java
@@ -160,7 +160,7 @@ public class DbClean {
         });
         stopWatch.stop();
         LOG.info(String.format("Successfully dropped schema %s (execution time %s)",
-                schema, TimeFormat.format(stopWatch.getTotalTimeMillis())));
+                (schema.getName() == "null") ? "database" : schema, TimeFormat.format(stopWatch.getTotalTimeMillis())));
     }
 
     /**
@@ -182,6 +182,6 @@ public class DbClean {
         });
         stopWatch.stop();
         LOG.info(String.format("Successfully cleaned schema %s (execution time %s)",
-                schema, TimeFormat.format(stopWatch.getTotalTimeMillis())));
+                (schema.getName() == "null") ? "database" : schema, TimeFormat.format(stopWatch.getTotalTimeMillis())));
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
@@ -30,6 +30,7 @@ import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabase;
 import org.flywaydb.core.internal.database.redshift.RedshiftDatabase;
 import org.flywaydb.core.internal.database.saphana.SAPHANADatabase;
 import org.flywaydb.core.internal.database.sqlite.SQLiteDatabase;
+import org.flywaydb.core.internal.database.firebird.FirebirdDatabase;
 import org.flywaydb.core.internal.database.sqlserver.SQLServerDatabase;
 import org.flywaydb.core.internal.database.sybasease.SybaseASEDatabase;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
@@ -173,6 +174,11 @@ public class DatabaseFactory {
 
 
 
+            );
+        }
+
+        if (databaseProductName.startsWith("Firebird")) {
+            return new FirebirdDatabase(configuration, connection
             );
         }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/Schema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/Schema.java
@@ -148,7 +148,7 @@ public abstract class Schema<D extends Database> {
         try {
             doClean();
         } catch (SQLException e) {
-            throw new FlywaySqlException("Unable to clean schema " + this, e);
+            throw new FlywaySqlException("Unable to clean schema" + this, e);
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdConnection.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.flywaydb.core.internal.database.Connection;
+import org.flywaydb.core.internal.database.Schema;
+
+import java.sql.SQLException;
+
+/**
+ * Firebird connection.
+ */
+public class FirebirdConnection extends Connection<FirebirdDatabase> {
+    private static final Log LOG = LogFactory.getLog(FirebirdConnection.class);
+
+    /**
+     * Whether the warning message has already been printed.
+     */
+    private static boolean schemaMessagePrinted;
+
+    FirebirdConnection(FlywayConfiguration configuration, FirebirdDatabase database, java.sql.Connection connection, int nullType
+
+
+
+    ) {
+        super(configuration, database, connection, nullType
+
+
+
+        );
+    }
+
+
+    @Override
+    public void doChangeCurrentSchemaTo(String schema) throws SQLException {
+        if (!schemaMessagePrinted) {
+            LOG.info("Firebird does not support setting the schema. Default schema NOT changed to " + schema);
+            schemaMessagePrinted = true;
+        }
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new FirebirdSchema(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected String doGetCurrentSchemaName() throws SQLException {
+        return "main";
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdDatabase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.api.configuration.FlywayConfiguration;
+import org.flywaydb.core.api.errorhandler.ErrorHandler;
+import org.flywaydb.core.internal.database.Database;
+import org.flywaydb.core.internal.exception.FlywayDbUpgradeRequiredException;
+import org.flywaydb.core.internal.database.SqlScript;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.LoadableResource;
+
+import java.sql.Connection;
+import java.sql.Types;
+
+/**
+ * Firebird database.
+ */
+public class FirebirdDatabase extends Database {
+    /**
+     * Creates a new instance.
+     *
+     * @param configuration The Flyway configuration.
+     * @param connection    The connection to use.
+     */
+    public FirebirdDatabase(FlywayConfiguration configuration, Connection connection
+
+
+
+    ) {
+        super(configuration, connection, Types.VARCHAR
+
+
+
+        );
+    }
+
+    @Override
+    protected org.flywaydb.core.internal.database.Connection getConnection(Connection connection, int nullType) {
+        return new FirebirdConnection(configuration, this, connection, nullType );
+    }
+
+    @Override
+    protected final void ensureSupported() {
+        String version = majorVersion + "." + minorVersion;
+
+        if (majorVersion < 1.5) {
+            throw new FlywayDbUpgradeRequiredException("Firebird", version, "1.5");
+        }
+    }
+
+    @Override
+    public SqlScript createSqlScript(String sqlScriptSource) {
+        return new FirebirdSqlScript(sqlScriptSource);
+    }
+
+    @Override
+    public SqlScript createSqlScript(LoadableResource sqlScriptResource, PlaceholderReplacer placeholderReplacer,
+                                     String encoding, boolean mixed
+
+
+
+    ) {
+        return new FirebirdSqlScript(sqlScriptResource, placeholderReplacer, encoding, mixed
+
+
+
+        );
+    }
+
+    public String getDbName() {
+        return "firebird";
+    }
+
+    @Override
+    protected String doGetCurrentUser() {
+        return "";
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return true;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "1";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "0";
+    }
+
+    @Override
+    public String doQuote(String identifier) {
+        return "\"" + identifier + "\"";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        return true;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSchema.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.internal.util.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.database.Schema;
+import org.flywaydb.core.internal.database.Table;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Firebird implementation of Schema.
+ */
+public class FirebirdSchema extends Schema<FirebirdDatabase> {
+    private static final Log LOG = LogFactory.getLog(FirebirdSchema.class);
+
+    private static final List<String> IGNORED_SYSTEM_TABLE_NAMES =
+            Arrays.asList(
+                    "RDB$BACKUP_HISTORY",
+                    "RDB$CHARACTER_SETS",
+                    "RDB$CHECK_CONSTRAINTS",
+                    "RDB$COLLATIONS",
+                    "RDB$DATABASE",
+                    "RDB$DEPENDENCIES",
+                    "RDB$EXCEPTIONS",
+                    "RDB$FIELDS",
+                    "RDB$FIELD_DIMENSIONS",
+                    "RDB$FILES",
+                    "RDB$FILTERS",
+                    "RDB$FORMATS",
+                    "RDB$FUNCTIONS",
+                    "RDB$FUNCTION_ARGUMENTS",
+                    "RDB$GENERATORS",
+                    "RDB$INDICES",
+                    "RDB$INDEX_SEGMENTS",
+                    "RDB$LOG_FILES",
+                    "RDB$PAGES",
+                    "RDB$PROCEDURES",
+                    "RDB$PROCEDURE_PARAMETERS",
+                    "RDB$REF_CONSTRAINTS",
+                    "RDB$RELATIONS",
+                    "RDB$RELATION_CONSTRAINTS",
+                    "RDB$RELATION_FIELDS",
+                    "RDB$ROLES",
+                    "RDB$SECURITY_CLASSES",
+                    "RDB$TRANSACTIONS",
+                    "RDB$TRIGGERS",
+                    "RDB$TRIGGER_MESSAGES",
+                    "RDB$TYPES",
+                    "RDB$USER_PRIVILEGES",
+                    "RDB$VIEW_RELATIONS");
+
+    /**
+     * Creates a new Firebird schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database    The database-specific support.
+     * @param name         The name of the schema.
+     */
+    FirebirdSchema(JdbcTemplate jdbcTemplate, FirebirdDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        try {
+            doAllTables();
+            return true;
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        Table[] tables = allTables();
+        List<String> tableNames = new ArrayList<>();
+        for (Table table : tables) {
+            String tableName = table.getName();
+            if (!IGNORED_SYSTEM_TABLE_NAMES.contains(tableName)) {
+                tableNames.add(tableName);
+            }
+        }
+        return tableNames.isEmpty();
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        LOG.info("Firebird does not support creating schemas. Schema not created: " + name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        LOG.info("Firebird does not support dropping schemas. Schema not dropped: " + name);
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        //Get all views to drop
+        List<String> viewNames = jdbcTemplate.queryForStringList("select rdb$relation_name\n" +
+                "from rdb$relations\n" +
+                "where rdb$view_blr is not null\n" +
+                "and (rdb$system_flag is null or rdb$system_flag = 0)");
+
+
+
+        for (String viewName : viewNames) {
+            jdbcTemplate.execute("DROP VIEW " + database.quote(name, viewName));
+        }
+
+        for (Table table : allTables()) {
+            table.drop();
+        }
+
+
+        //Set generators to zero
+    }
+
+    @Override
+    public String getName() {
+        return "null";
+    }
+
+
+    @Override
+    protected Table[] doAllTables() throws SQLException {
+        List<String> tableNames = jdbcTemplate.queryForStringList("select rdb$relation_name\n" +
+                "from rdb$relations\n" +
+                "where rdb$view_blr is null\n" +
+                "and (rdb$system_flag is null or rdb$system_flag = 0)");
+
+        Table[] tables = new Table[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new FirebirdTable(jdbcTemplate, database, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new FirebirdTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSqlScript.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSqlScript.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.api.errorhandler.ErrorHandler;
+import org.flywaydb.core.internal.database.Delimiter;
+import org.flywaydb.core.internal.database.SqlScript;
+import org.flywaydb.core.internal.database.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
+import org.flywaydb.core.internal.util.scanner.LoadableResource;
+
+/**
+ * Firebird-specific SQL script.
+ */
+class FirebirdSqlScript extends SqlScript {
+    FirebirdSqlScript(String sqlScriptSource) {
+        super(sqlScriptSource);
+    }
+
+    FirebirdSqlScript(LoadableResource sqlScriptResource, PlaceholderReplacer placeholderReplacer,
+                    String encoding, boolean mixed
+    ) {
+        super(sqlScriptResource, placeholderReplacer, encoding, mixed
+
+
+
+        );
+    }
+
+    @Override
+    protected SqlStatementBuilder createSqlStatementBuilder() {
+        return new FirebirdSqlStatementBuilder(Delimiter.SEMICOLON);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSqlStatementBuilder.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdSqlStatementBuilder.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.internal.database.Delimiter;
+import org.flywaydb.core.internal.database.SqlStatementBuilder;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * FirebirdSqlStatementBuilder borrowed from DB2, use --set term before stored procs or triggers
+ */
+public class FirebirdSqlStatementBuilder extends SqlStatementBuilder {
+    /**
+     * Holds the beginning of the statement.
+     */
+
+    private String statementStart = "";
+
+    FirebirdSqlStatementBuilder(Delimiter defaultDelimiter) {
+        super(defaultDelimiter);
+    }
+
+    /**
+     * The keyword that indicates a change in delimiter.
+     */
+    private static final String DELIMITER_KEYWORD = "--SET TERM";
+
+    /**
+     * Regex to check for a BEGIN statement of a SQL PL block (Optional label followed by BEGIN).
+     */
+    private static final Pattern BEGIN_REGEX = Pattern.compile("((([A-Z]+[A-Z0-9]*)\\s?:\\s?)|(.*\\s))?BEGIN(\\sATOMIC)?(\\s.*)?");
+
+    /**
+     * Regex for keywords that can appear after a string literal without being separated by a space.
+     */
+    private static final Pattern KEYWORDS_AFTER_STRING_LITERAL_REGEX = Pattern.compile("(.*')(DO)(?!.)");
+
+    /**
+     * The labels associated with nested BEGIN ... END blocks.
+     */
+    private Deque<String> beginEndLabels = new LinkedList<>();
+
+
+    /**
+     * The current delimiter to use. This delimiter can be changed
+     * as well as temporarily disabled inside BEGIN END; blocks.
+     */
+    private Delimiter currentDelimiter = defaultDelimiter;
+
+    @Override
+    public Delimiter extractNewDelimiterFromLine(String line) {
+        if (line.toUpperCase().startsWith(DELIMITER_KEYWORD)) {
+            return new Delimiter(line.substring(DELIMITER_KEYWORD.length()).trim(), false);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected boolean isSingleLineComment(String line) {
+        return line.startsWith("--") && !line.startsWith(DELIMITER_KEYWORD);
+    }
+
+    @Override
+    protected String cleanToken(String token) {
+        if (token.startsWith("X'")) {
+            return token.substring(token.indexOf("'"));
+        }
+
+        Matcher afterMatcher = KEYWORDS_AFTER_STRING_LITERAL_REGEX.matcher(token);
+        if (afterMatcher.find()) {
+            token = afterMatcher.group(1);
+        }
+
+        return super.cleanToken(token);
+    }
+
+    @Override
+    protected Delimiter changeDelimiterIfNecessary(String line, Delimiter delimiter) {
+        if (delimiter != null && !delimiter.equals(currentDelimiter)) {
+            // Synchronize current delimiter with main delimiter in case it was changed
+            // due to a --SET TERM directive earlier in the SQL script
+            currentDelimiter = delimiter;
+        }
+
+        if (StringUtils.countOccurrencesOf(statementStart, " ") < 4) {
+            statementStart += line;
+            statementStart += " ";
+        }
+
+        if (!";".equals(currentDelimiter.getDelimiter())) {
+            return currentDelimiter;
+        }
+
+        if (statementStart.matches("^CREATE( OR REPLACE)? (FUNCTION|PROCEDURE|TRIGGER)(\\s.*)?")) {
+            if (isBegin(line) || line.matches("(.*\\s)?CASE(\\sWHEN)?(\\s.*)?")) {
+                beginEndLabels.addLast(extractLabel(line));
+            }
+
+            if (isEnd(line, beginEndLabels.isEmpty() ? null : beginEndLabels.getLast(), currentDelimiter, beginEndLabels.size())) {
+                beginEndLabels.removeLast();
+            }
+        }
+
+        if (!beginEndLabels.isEmpty()) {
+            return null;
+        }
+        return currentDelimiter;
+    }
+
+    static boolean isBegin(String line) {
+        return BEGIN_REGEX.matcher(line).find();
+    }
+
+    static String extractLabel(String line) {
+        Matcher matcher = BEGIN_REGEX.matcher(line);
+        return line.contains(":") && matcher.matches() ? matcher.group(3) : null;
+    }
+
+    static boolean isEnd(String line, String label, Delimiter currentDelimiter, int beginEndDepth) {
+        String actualDelimiter = beginEndDepth > 1 ? ";" : currentDelimiter.getDelimiter();
+
+        return line.matches(
+                // First optionally match preceding part of statement
+                "(.*\\s)?"
+                        // Then require END
+                        + "END"
+                        // Now optionally match label
+                        + (label == null ? "" : "(\\s" + Pattern.quote(label) + ")?")
+                        // Finally optionally match delimiter
+                        + "\\s?(" + Pattern.quote(actualDelimiter) + ")?");
+    }
+
+
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdTable.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 public class FirebirdTable extends Table {
     private static final Log LOG = LogFactory.getLog(FirebirdTable.class);
 
-    private final boolean undroppable = true;
+    private final boolean undroppable = false;
 
     /**
      * Creates a new Firebird table.
@@ -49,7 +49,8 @@ public class FirebirdTable extends Table {
         if (undroppable) {
             LOG.debug("Firebird system table " + this + " cannot be dropped. Ignoring.");
         } else {
-            jdbcTemplate.execute("DROP TABLE " + database.quote(schema.getName(), name));
+            LOG.info("Dropping table "+ database.quote(name));
+            jdbcTemplate.execute("DROP TABLE " + database.quote(name));
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdTable.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.firebird;
+
+import org.flywaydb.core.internal.database.Database;
+import org.flywaydb.core.internal.util.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.database.Schema;
+import org.flywaydb.core.internal.database.Table;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+
+import java.sql.SQLException;
+
+/**
+ * Firebird-specific table.
+ */
+public class FirebirdTable extends Table {
+    private static final Log LOG = LogFactory.getLog(FirebirdTable.class);
+
+    private final boolean undroppable = true;
+
+    /**
+     * Creates a new Firebird table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database    The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public FirebirdTable(JdbcTemplate jdbcTemplate, Database database, Schema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        if (undroppable) {
+            LOG.debug("Firebird system table " + this + " cannot be dropped. Ignoring.");
+        } else {
+            jdbcTemplate.execute("DROP TABLE " + database.quote(schema.getName(), name));
+        }
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+
+        return jdbcTemplate.queryForInt("select count(rdb$relation_name) as countTableName\n" +
+                "from rdb$relations\n" +
+                "where rdb$view_blr is null\n" +
+                "and rdb$relation_name = '"+name+"'\n"+
+                "and (rdb$system_flag is null or rdb$system_flag = 0)") > 0;
+
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        //TODO: Implement Firebird Locking
+    }
+
+    @Override
+    public String toString() {
+        return database.quote(name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2018 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.database.firebird;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/DriverDataSource.java
@@ -47,6 +47,7 @@ public class DriverDataSource implements DataSource {
     private static final String MYSQL_JDBC_DRIVER = "com.mysql.jdbc.Driver";
     private static final String REDSHIFT_JDBC41_DRIVER = "com.amazon.redshift.jdbc41.Driver";
     private static final String SQLDROID_DRIVER = "org.sqldroid.SQLDroidDriver";
+    private static final String FIREBIRD_JDBC_DRIVER = "org.firebirdsql.jdbc.FBDriver";
 
     /**
      * The JDBC Driver instance to use.
@@ -285,6 +286,10 @@ public class DriverDataSource implements DataSource {
                 return SQLDROID_DRIVER;
             }
             return "org.sqlite.JDBC";
+        }
+
+        if (url.startsWith("jdbc:firebirdsql:")) {
+            return FIREBIRD_JDBC_DRIVER;
         }
 
         if (url.startsWith("jdbc:sqldroid:")) {

--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/database/firebird/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/database/firebird/createMetaDataTable.sql
@@ -1,0 +1,35 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+-- noinspection SqlDialectInspectionForFile
+
+--
+-- Copyright 2010-2018 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE "${table}" (
+    "installed_rank" INTEGER NOT NULL,
+    "version" VARCHAR(50) DEFAULT NULL,
+    "description" VARCHAR(200) NOT NULL,
+    "type" VARCHAR(20) NOT NULL,
+    "script" VARCHAR(1000) NOT NULL,
+    "checksum" INTEGER DEFAULT NULL,
+    "installed_by" VARCHAR(100) NOT NULL,
+    "installed_on" TIMESTAMP DEFAULT 'now' NOT NULL,
+    "execution_time" INTEGER NOT NULL,
+    "success" INTEGER NOT NULL,
+    PRIMARY KEY ("installed_rank")
+);
+
+CREATE INDEX "${table}_s_idx" ON "${table}" (success);

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,6 @@
         <developerConnection>scm:git:https://github.com/flyway/flyway.git</developerConnection>
 
 
-
-
-
-
         <tag>HEAD</tag>
     </scm>
     <developers>
@@ -68,15 +64,6 @@
         <module>flyway-commandline</module>
 
 
-
-
-
-
-
-
-
-
-
     </modules>
 
     <distributionManagement>
@@ -91,11 +78,6 @@
             <name>Nexus Release Repository</name>
             <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
-
-
-
-
-
 
 
     </distributionManagement>
@@ -119,14 +101,6 @@
         </repository>
 
 
-
-
-
-
-
-
-
-
     </repositories>
 
     <properties>
@@ -141,6 +115,7 @@
         <version.mssql-jdbc>6.2.2.jre7</version.mssql-jdbc>
         <version.postgresql>42.1.4.jre6</version.postgresql>
         <version.sqlite>3.20.1</version.sqlite>
+        <version.firebird>3.0.3</version.firebird>
         <version.osgi>4.3.1</version.osgi>
         <version.equinox>3.12.0</version.equinox>
         <version.equinoxcommon>3.9.0</version.equinoxcommon>
@@ -246,6 +221,12 @@
                 <optional>true</optional>
             </dependency>
             <dependency>
+                <groupId>org.firebirdsql.jdbc</groupId>
+                <artifactId>jaybird-jdk18</artifactId>
+                <version>${version.firebird}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
                 <groupId>org.mariadb.jdbc</groupId>
                 <artifactId>mariadb-java-client</artifactId>
                 <version>${version.mariadb}</version>
@@ -257,60 +238,6 @@
                 <version>${version.jtds}</version>
                 <optional>true</optional>
             </dependency>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
             <dependency>
@@ -393,19 +320,6 @@
     <build>
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -433,14 +347,6 @@
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>2.3.7</version>
                 </plugin>
-
-
-
-
-
-
-
-
 
 
                 <plugin>
@@ -478,27 +384,6 @@
             </plugins>
         </pluginManagement>
         <plugins>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
             <plugin>
@@ -596,69 +481,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
             <plugin>


### PR DESCRIPTION
This is still in testing phase as I have not completed dropping of stored procedures and resetting of generators but passes my basic tests which I need it for.  Also changed wording a bit for the schema stuff as Firebird is a non schema databases, the way I implemented may not be acceptable but would be easy to change, I had no joy returning a null for schema name, it evaluated to ""null"" so went with simple "null" as text return in Schema name over ride.  There will be other databases without schemas so instead of referring to schema now it says database?

Inside migrations:
Use --set term; to indicate stored procedure, I would not try migrate more than one multiline sql object at this time.