### PR TITLE
Do not delete types that extensions depend on when cleaning PostgreSql

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
@@ -146,9 +146,11 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDatabase> {
         List<Map<String, String>> rows =
                 jdbcTemplate.queryForList(
                         "select typname, typcategory from pg_catalog.pg_type t "
+                                + "left join pg_depend dep on dep.objid = t.oid and dep.deptype = 'e' "
                                 + "where (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid)) and "
                                 + "NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid) and "
-                                + "t.typnamespace in (select oid from pg_catalog.pg_namespace where nspname = ?)",
+                                + "t.typnamespace in (select oid from pg_catalog.pg_namespace where nspname = ?) and "
+                                + "dep.objid is null",
                         name);
 
         List<String> statements = new ArrayList<>();


### PR DESCRIPTION
I cannot use `clean` in one of my projects, because I am using the btree_gist extension. I alway get the following error:

> ERROR: cannot drop type gbtreekey4 because extension btree_gist requires it

This PR prevents that these types are dropped. Basically this is an extension to commit 444f077116b45260d7f99aa931d41ccb59553c8a which did the same for routines and views.