### PR TITLE
Flyway 5.0 Crash on Android

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
@@ -214,6 +214,9 @@ public class DatabaseFactory {
      * @return The filtered url.
      */
     static String filterUrl(String url) {
+        if (url == null) {
+            return "";
+        }
         int questionMark = url.indexOf("?");
         if (questionMark >= 0 && !url.contains("?databaseName=")) {
             url = url.substring(0, questionMark);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabase.java
@@ -16,10 +16,10 @@
 package org.flywaydb.core.internal.database.sqlite;
 
 import org.flywaydb.core.api.configuration.FlywayConfiguration;
-import org.flywaydb.core.api.errorhandler.ErrorHandler;
 import org.flywaydb.core.internal.database.Database;
 import org.flywaydb.core.internal.database.SqlScript;
 import org.flywaydb.core.internal.exception.FlywayDbUpgradeRequiredException;
+import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.scanner.Resource;
 
 import java.sql.Connection;
@@ -63,8 +63,14 @@ public class SQLiteDatabase extends Database<SQLiteConnection> {
     protected final void ensureSupported() {
         String version = majorVersion + "." + minorVersion;
 
-        if (majorVersion < 3) {
+        FeatureDetector featureDetector = new FeatureDetector(configuration.getClassLoader());
+
+        if (majorVersion < 3 && !featureDetector.isAndroidAvailable()) {
             throw new FlywayDbUpgradeRequiredException("SQLite", version, "3.7.2");
+        }
+
+        if (majorVersion < 1 && featureDetector.isAndroidAvailable()) {
+            throw new FlywayDbUpgradeRequiredException("SQLite", version, "1.0.3");
         }
     }
 


### PR DESCRIPTION
When upgrading an existing Android app from Flyway 4.2 to 5.0.7, Flyway crashes with the following stack trace:
```
    Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.indexOf(java.lang.String)' on a null object reference
        at org.flywaydb.core.internal.database.DatabaseFactory.filterUrl(DatabaseFactory.java:204)
        at org.flywaydb.core.internal.database.DatabaseFactory.getJdbcUrl(DatabaseFactory.java:191)
        at org.flywaydb.core.internal.database.DatabaseFactory.createDatabase(DatabaseFactory.java:72)
        at org.flywaydb.core.Flyway.execute(Flyway.java:1634)
        at org.flywaydb.core.Flyway.info(Flyway.java:1321)
```
This is caused by `connection.getMetaData().getURL()` returning `null` when using SQLite and SQLDroidDriver as recommended. This is fixed in [this commit](../commit/545fd46c8dde422276e2f2215e3e1311a973c17d).

When fixed, another problem occurs:  Flyway complains that the SQLite version has to be at least 3.7.2, which:

- was not true with Flyway 4.
- is not compliant which [documentation on SQLite on Android](https://flywaydb.org/documentation/database/sqlite).

This is fixed in the [second commit](../commit/abc699d50f34cf6075d83c2d9a4cc559a19f6a7d).

Both these commits make Flyway working just fine on Android with SQLite and SQLDroidDriver.
