### PR TITLE
Fixes #1983: Failure on creation of a schema history table on an empty database

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/JdbcTableSchemaHistory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/JdbcTableSchemaHistory.java
@@ -123,6 +123,7 @@ class JdbcTableSchemaHistory extends SchemaHistory {
                 database.getCreateScript(table).execute(jdbcTemplate);
                 LOG.debug("Created Schema History table: " + table);
             } catch (FlywayException e) {
+                rollback();
                 if (++retries >= 10) {
                     throw e;
                 }
@@ -133,6 +134,17 @@ class JdbcTableSchemaHistory extends SchemaHistory {
                     // Ignore
                 }
             }
+        }
+    }
+
+    private void rollback() {
+        final java.sql.Connection jdbcConnection = connection.getJdbcConnection();
+        try {
+            if (!jdbcConnection.getAutoCommit()) {
+                jdbcConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            //Ignore
         }
     }
 


### PR DESCRIPTION
A transaction should be rolled back after an error if autoCommit mode is set to false. Every error spoils the transaction.