### PR TITLE
Add configuration option to restore original state

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -792,6 +792,9 @@ public class Flyway implements Configuration {
         return configuration.isSkipDefaultCallbacks();
     }
 
+    @Override
+    public boolean isRestoreOriginalState() { return configuration.isRestoreOriginalState(); }
+
     /**
      * Set the callbacks for lifecycle notifications.
      *
@@ -833,6 +836,15 @@ public class Flyway implements Configuration {
      */
     public void setSkipDefaultCallbacks(boolean skipDefaultCallbacks) {
         configuration.setSkipDefaultCallbacks(skipDefaultCallbacks);
+    }
+
+    /**
+     * Whether Flyway should restore the original state.
+     *
+     * @param restoreOriginalState Whether to restore the original state. <p>(default: true)</p>
+     */
+    public void setRestoreOriginalState(boolean restoreOriginalState) {
+        configuration.setRestoreOriginalState(restoreOriginalState);
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -285,6 +285,11 @@ public class ClassicConfiguration implements Configuration {
     private boolean skipDefaultCallbacks;
 
     /**
+     * Whether Flyway should restore the original state <p>(default:true)</p>
+     */
+    private boolean restoreOriginalState = true;
+
+    /**
      * The custom MigrationResolvers to be used in addition to the built-in ones for resolving Migrations to apply.
      * <p>(default: none)</p>
      */
@@ -1220,6 +1225,11 @@ public class ClassicConfiguration implements Configuration {
         return skipDefaultCallbacks;
     }
 
+    @Override
+    public boolean isRestoreOriginalState() {
+        return restoreOriginalState;
+    }
+
     /**
      * Set the callbacks for lifecycle notifications.
      *
@@ -1256,6 +1266,15 @@ public class ClassicConfiguration implements Configuration {
      */
     public void setSkipDefaultCallbacks(boolean skipDefaultCallbacks) {
         this.skipDefaultCallbacks = skipDefaultCallbacks;
+    }
+
+    /**
+     * Whether Flyway should skip the call to restore the original state
+     *
+     * @param restoreOriginalState Whether to restore the original state. <p>(default: true)</p>
+     */
+    public void setRestoreOriginalState(boolean restoreOriginalState) {
+        this.restoreOriginalState = restoreOriginalState;
     }
 
     /**
@@ -1359,6 +1378,7 @@ public class ClassicConfiguration implements Configuration {
         setResolvers(configuration.getResolvers());
         setSchemas(configuration.getSchemas());
         setSkipDefaultCallbacks(configuration.isSkipDefaultCallbacks());
+        setRestoreOriginalState(configuration.isRestoreOriginalState());
         setSkipDefaultResolvers(configuration.isSkipDefaultResolvers());
         setSqlMigrationPrefix(configuration.getSqlMigrationPrefix());
         setSqlMigrationSeparator(configuration.getSqlMigrationSeparator());
@@ -1530,6 +1550,10 @@ public class ClassicConfiguration implements Configuration {
         Boolean skipDefaultCallbacksProp = getBooleanProp(props, ConfigUtils.SKIP_DEFAULT_CALLBACKS);
         if (skipDefaultCallbacksProp != null) {
             setSkipDefaultCallbacks(skipDefaultCallbacksProp);
+        }
+        Boolean restoreOriginalStateProp = getBooleanProp(props, ConfigUtils.RESTORE_ORIGINAL_STATE);
+        if (restoreOriginalStateProp != null) {
+            setRestoreOriginalState(restoreOriginalStateProp);
         }
 
         Map<String, String> placeholdersFromProps = new HashMap<>(getPlaceholders());

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -89,6 +89,13 @@ public interface Configuration {
     boolean isSkipDefaultCallbacks();
 
     /**
+     * Whether Flyway should restore the original state.
+     *
+     * @return Whether to restore the original state. (default: true)
+     */
+    boolean isRestoreOriginalState();
+
+    /**
      * The file name prefix for versioned SQL migrations.
      * <p>Versioned SQL migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
      * which using the defaults translates to V1.1__My_description.sql</p>

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -762,6 +762,12 @@ public class FluentConfiguration implements Configuration {
         return config.isSkipDefaultCallbacks();
     }
 
+    @Override
+    public boolean isRestoreOriginalState() {
+        return config.isRestoreOriginalState();
+    }
+
+
     /**
      * Set the callbacks for lifecycle notifications.
      *

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -88,6 +88,7 @@ public class ConfigUtils {
     public static final String RESOLVERS = "flyway.resolvers";
     public static final String SCHEMAS = "flyway.schemas";
     public static final String SKIP_DEFAULT_CALLBACKS = "flyway.skipDefaultCallbacks";
+    public static final String RESTORE_ORIGINAL_STATE = "flyway.restoreOriginalState";
     public static final String SKIP_DEFAULT_RESOLVERS = "flyway.skipDefaultResolvers";
     public static final String SQL_MIGRATION_PREFIX = "flyway.sqlMigrationPrefix";
     public static final String SQL_MIGRATION_SEPARATOR = "flyway.sqlMigrationSeparator";
@@ -170,6 +171,11 @@ public class ConfigUtils {
                 @Override
                 public boolean isSkipDefaultCallbacks() {
                     return configuration.isSkipDefaultCallbacks();
+                }
+
+                @Override
+                public boolean isRestoreOriginalState() {
+                    return configuration.isRestoreOriginalState();
                 }
 
                 @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/Connection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/Connection.java
@@ -40,6 +40,12 @@ public abstract class Connection<D extends Database> implements Closeable {
      */
     private boolean originalAutoCommit;
 
+    /**
+     * The configuration
+     */
+    private final Configuration configuration;
+
+
     protected Connection(Configuration configuration, D database, java.sql.Connection connection
             , boolean originalAutoCommit, int nullType
 
@@ -48,6 +54,7 @@ public abstract class Connection<D extends Database> implements Closeable {
     ) {
         this.database = database;
         this.originalAutoCommit = originalAutoCommit;
+        this.configuration = configuration;
 
 
 
@@ -177,10 +184,12 @@ public abstract class Connection<D extends Database> implements Closeable {
      * Restores this connection to its original state.
      */
     public final void restoreOriginalState() {
-        try {
-            doRestoreOriginalState();
-        } catch (SQLException e) {
-            throw new FlywaySqlException("Unable to restore connection to its original state", e);
+        if (configuration.isRestoreOriginalState()) {
+            try {
+                doRestoreOriginalState();
+            } catch (SQLException e) {
+                throw new FlywaySqlException("Unable to restore connection to its original state", e);
+            }
         }
     }
 


### PR DESCRIPTION
This is a new feature to add a configuration option to toggle off the restoreOriginalState call which is executed at various places throughout the code.

The existing code causes a problem when trying to solve an issue which is encountered when we perform migrations using different users. The database objects end up being owned by the user which ran the migration which we attempt to solve by setting the role used by the migration. The RESET ROLE call breaks the attempted fix.

I have attempted to work around this by using beforeMigrate and beforeEachMigrate callbacks, but this does not work for the schema history table (This broke around Version 5.0.7).