### PR TITLE
Workaround a bug in windows cmd

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.cmd
+++ b/flyway-commandline/src/main/assembly/flyway.cmd
@@ -19,7 +19,8 @@
 setlocal
 
 @REM Set the current directory to the installation directory
-set INSTALLDIR=%~dp0
+call :getCurrentBatch INSTALLDIR
+set INSTALLDIR=%INSTALLDIR:~0,-10%
 
 if exist "%INSTALLDIR%\jre\bin\java.exe" (
  set JAVA_CMD="%INSTALLDIR%\jre\bin\java.exe"
@@ -43,3 +44,7 @@ if "%JAVA_ARGS%"=="" (
 
 @REM Exit using the same code returned from Java
 EXIT /B %ERRORLEVEL%
+
+:getCurrentBatch variableName
+    set "%~1=%~f0"
+    goto :eof


### PR DESCRIPTION
When calling flyway using System.Diagnostics.Process in .Net to create a database as part of my test suite setup I encountered a bug in Windows CMD with how %~dp0 is resolved, a bit of information and the solution I borrowed from can be found here: https://stackoverflow.com/a/26851883