### PR TITLE
Allow JdbcMigrations to be non-transactional

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/BaseJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/BaseJdbcMigration.java
@@ -31,4 +31,9 @@ public abstract class BaseJdbcMigration implements JdbcMigration, ConfigurationA
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
         this.flywayConfiguration = flywayConfiguration;
     }
+
+    @Override
+    public boolean executeInTransaction() {
+        return true;
+    }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/jdbc/JdbcMigration.java
@@ -28,7 +28,7 @@ import java.sql.Connection;
  * the master {@link org.flywaydb.core.api.configuration.FlywayConfiguration} is automatically injected upon creation,
  * which is especially useful for getting placeholder and schema information.</p>
  *
- * It is encouraged not to implement this interface directly and subclass {@link JdbcMigration} instead.
+ * It is encouraged not to implement this interface directly and subclass {@link BaseJdbcMigration} instead.
  */
 public interface JdbcMigration {
     /**
@@ -39,4 +39,13 @@ public interface JdbcMigration {
      * @throws Exception when the migration failed.
      */
     void migrate(Connection connection) throws Exception;
+
+    /**
+     * Whether the execution should take place inside a transaction. Almost all implementation should return {@code true}.
+     * This however makes it possible to execute certain migrations outside a transaction. This is useful for databases
+     * like PostgreSQL where certain statement can only execute outside a transaction.
+     *
+     * @return {@code true} if a transaction should be used (highly recommended), or {@code false} if not.
+     */
+    boolean executeInTransaction();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/BaseSpringJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/BaseSpringJdbcMigration.java
@@ -31,4 +31,9 @@ public abstract class BaseSpringJdbcMigration implements SpringJdbcMigration, Co
     public void setFlywayConfiguration(FlywayConfiguration flywayConfiguration) {
         this.flywayConfiguration = flywayConfiguration;
     }
+
+    @Override
+    public boolean executeInTransaction() {
+        return true;
+    }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/SpringJdbcMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/migration/spring/SpringJdbcMigration.java
@@ -39,4 +39,13 @@ public interface SpringJdbcMigration {
      * @throws Exception when the migration failed.
      */
     void migrate(JdbcTemplate jdbcTemplate) throws Exception;
+
+    /**
+     * Whether the execution should take place inside a transaction. Almost all implementation should return {@code true}.
+     * This however makes it possible to execute certain migrations outside a transaction. This is useful for databases
+     * like PostgreSQL where certain statement can only execute outside a transaction.
+     *
+     * @return {@code true} if a transaction should be used (highly recommended), or {@code false} if not.
+     */
+    boolean executeInTransaction();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/jdbc/JdbcMigrationExecutor.java
@@ -53,6 +53,6 @@ public class JdbcMigrationExecutor implements MigrationExecutor {
 
     @Override
     public boolean executeInTransaction() {
-        return true;
+        return jdbcMigration.executeInTransaction();
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringJdbcMigrationExecutor.java
@@ -55,6 +55,6 @@ public class SpringJdbcMigrationExecutor implements MigrationExecutor {
 
     @Override
     public boolean executeInTransaction() {
-        return true;
+        return springJdbcMigration.executeInTransaction();
     }
 }


### PR DESCRIPTION
Currently it is not possible for JdbcMigrations (and SpringJdbcMigrations) to be non-transactional.

This PR allows to override JdbcMigrations (and SpringJdbcMigrations) to mark them as non-transactional.

Please let me know if there are any questions. Documentation PR: https://github.com/flyway/flywaydb.org/pull/103