### PR TITLE
Add an 'ignorePendingMigrations' configuration option

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -210,6 +210,13 @@ flyway.url=
 # true to continue normally, false to fail fast with an exception. (default: false)
 # flyway.ignoreIgnoredMigrations=
 
+# Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+# classpath but have not yet been were performed by an application deployment.
+# This can be useful for verifying that in-development migration changes don't contain any validation-breaking changes
+# of migrations that have already been applied to a production environment, e.g. as part of a CI/CD process, without
+# failing because of the existence of new migration versions. (default: false)
+# flyway.ignorePendingMigrations=
+
 # Ignore future migrations when reading the schema history table. These are migrations that were performed by a
 # newer deployment of the application that are not yet available in this version. For example: we have migrations
 # available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -211,7 +211,7 @@ flyway.url=
 # flyway.ignoreIgnoredMigrations=
 
 # Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-# classpath but have not yet been were performed by an application deployment.
+# classpath but have not yet been performed by an application deployment.
 # This can be useful for verifying that in-development migration changes don't contain any validation-breaking changes
 # of migrations that have already been applied to a production environment, e.g. as part of a CI/CD process, without
 # failing because of the existence of new migration versions. (default: false)

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -283,6 +283,7 @@ public class Main {
         LOG.info("validateOnMigrate            : Validate when running migrate");
         LOG.info("ignoreMissingMigrations      : Allow missing migrations when validating");
         LOG.info("ignoreIgnoredMigrations      : Allow ignored migrations when validating");
+        LOG.info("ignorePendingMigrations      : Allow pending migrations when validating");
         LOG.info("ignoreFutureMigrations       : Allow future migrations when validating");
         LOG.info("cleanOnValidationError       : Automatically clean on a validation error");
         LOG.info("cleanDisabled                : Whether to disable clean");

--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -681,7 +681,7 @@ public class Flyway implements Configuration {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -209,7 +209,7 @@ public class ClassicConfiguration implements Configuration {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment.
+     * classpath but have not yet been performed by an application deployment.
      * This can be useful for verifying that in-development migration changes don't contain any validation-breaking changes
      * of migrations that have already been applied to a production environment, e.g. as part of a CI/CD process, without
      * failing because of the existence of new migration versions.
@@ -848,7 +848,7 @@ public class ClassicConfiguration implements Configuration {
     
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -208,6 +208,18 @@ public class ClassicConfiguration implements Configuration {
     private boolean ignoreIgnoredMigrations;
 
     /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment.
+     * This can be useful for verifying that in-development migration changes don't contain any validation-breaking changes
+     * of migrations that have already been applied to a production environment, e.g. as part of a CI/CD process, without
+     * failing because of the existence of new migration versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    private boolean ignorePendingMigrations;
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0
@@ -482,6 +494,11 @@ public class ClassicConfiguration implements Configuration {
     @Override
     public boolean isIgnoreIgnoredMigrations() {
         return ignoreIgnoredMigrations;
+    }
+
+    @Override
+    public boolean isIgnorePendingMigrations() {
+        return ignorePendingMigrations;
     }
 
     @Override
@@ -827,6 +844,20 @@ public class ClassicConfiguration implements Configuration {
      */
     public void setIgnoreIgnoredMigrations(boolean ignoreIgnoredMigrations) {
         this.ignoreIgnoredMigrations = ignoreIgnoredMigrations;
+    }
+    
+    /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     *
+     * @param ignorePendingMigrations {@code true} to continue normally, {@code false} to fail fast with an exception.
+     *                                (default: {@code false})
+     */
+    public void setIgnorePendingMigrations(boolean ignorePendingMigrations) {
+        this.ignorePendingMigrations = ignorePendingMigrations;
     }
 
     /**
@@ -1391,6 +1422,7 @@ public class ClassicConfiguration implements Configuration {
         setIgnoreFutureMigrations(configuration.isIgnoreFutureMigrations());
         setIgnoreMissingMigrations(configuration.isIgnoreMissingMigrations());
         setIgnoreIgnoredMigrations(configuration.isIgnoreIgnoredMigrations());
+        setIgnorePendingMigrations(configuration.isIgnorePendingMigrations());
         setInstalledBy(configuration.getInstalledBy());
         setLocations(configuration.getLocations());
         setMixed(configuration.isMixed());
@@ -1546,6 +1578,10 @@ public class ClassicConfiguration implements Configuration {
         Boolean ignoreIgnoredMigrationsProp = getBooleanProp(props, ConfigUtils.IGNORE_IGNORED_MIGRATIONS);
         if (ignoreIgnoredMigrationsProp != null) {
             setIgnoreIgnoredMigrations(ignoreIgnoredMigrationsProp);
+        }
+        Boolean ignorePendingMigrationsProp = getBooleanProp(props, ConfigUtils.IGNORE_PENDING_MIGRATIONS);
+        if (ignorePendingMigrationsProp != null) {
+            setIgnorePendingMigrations(ignorePendingMigrationsProp);
         }
         Boolean ignoreFutureMigrationsProp = getBooleanProp(props, ConfigUtils.IGNORE_FUTURE_MIGRATIONS);
         if (ignoreFutureMigrationsProp != null) {

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -275,7 +275,7 @@ public interface Configuration {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -274,6 +274,18 @@ public interface Configuration {
     boolean isIgnoreIgnoredMigrations();
 
     /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     *
+     * @return {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    boolean isIgnorePendingMigrations();
+
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -422,7 +422,7 @@ public class FluentConfiguration implements Configuration {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -150,6 +150,11 @@ public class FluentConfiguration implements Configuration {
     }
 
     @Override
+    public boolean isIgnorePendingMigrations() {
+        return config.isIgnorePendingMigrations();
+    }
+    
+    @Override
     public boolean isIgnoreFutureMigrations() {
         return config.isIgnoreFutureMigrations();
     }
@@ -415,6 +420,21 @@ public class FluentConfiguration implements Configuration {
         return this;
     }
 
+    /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     *
+     * @param ignorePendingMigrations {@code true} to continue normally, {@code false} to fail fast with an exception.
+     *                                (default: {@code false})
+     */
+    public FluentConfiguration ignorePendingMigrations(boolean ignorePendingMigrations) {
+        config.setIgnorePendingMigrations(ignorePendingMigrations);
+        return this;
+    }
+    
     /**
      * Whether to ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -78,6 +78,7 @@ public class ConfigUtils {
     public static final String IGNORE_FUTURE_MIGRATIONS = "flyway.ignoreFutureMigrations";
     public static final String IGNORE_MISSING_MIGRATIONS = "flyway.ignoreMissingMigrations";
     public static final String IGNORE_IGNORED_MIGRATIONS = "flyway.ignoreIgnoredMigrations";
+    public static final String IGNORE_PENDING_MIGRATIONS = "flyway.ignorePendingMigrations";
     public static final String INSTALLED_BY = "flyway.installedBy";
     public static final String LICENSE_KEY = "flyway.licenseKey";
     public static final String LOCATIONS = "flyway.locations";
@@ -264,6 +265,11 @@ public class ConfigUtils {
                 @Override
                 public boolean isIgnoreIgnoredMigrations() {
                     return configuration.isIgnoreIgnoredMigrations();
+                }
+
+                @Override
+                public boolean isIgnorePendingMigrations() {
+                    return configuration.isIgnorePendingMigrations();
                 }
 
                 @Override

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -234,6 +234,18 @@ public class FlywayExtension {
     public Boolean ignoreIgnoredMigrations;
 
     /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    public Boolean ignorePendingMigrations;
+    
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -235,7 +235,7 @@ public class FlywayExtension {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -275,7 +275,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -274,6 +274,18 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     public Boolean ignoreIgnoredMigrations;
 
     /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    public Boolean ignorePendingMigrations;
+    
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0
@@ -551,6 +563,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         putIfSet(conf, ConfigUtils.CLEAN_ON_VALIDATION_ERROR, cleanOnValidationError, extension.cleanOnValidationError);
         putIfSet(conf, ConfigUtils.IGNORE_MISSING_MIGRATIONS, ignoreMissingMigrations, extension.ignoreMissingMigrations);
         putIfSet(conf, ConfigUtils.IGNORE_IGNORED_MIGRATIONS, ignoreIgnoredMigrations, extension.ignoreIgnoredMigrations);
+        putIfSet(conf, ConfigUtils.IGNORE_PENDING_MIGRATIONS, ignorePendingMigrations, extension.ignorePendingMigrations);
         putIfSet(conf, ConfigUtils.IGNORE_FUTURE_MIGRATIONS, ignoreFutureMigrations, extension.ignoreFutureMigrations);
         putIfSet(conf, ConfigUtils.CLEAN_DISABLED, cleanDisabled, extension.cleanDisabled);
         putIfSet(conf, ConfigUtils.BASELINE_ON_MIGRATE, baselineOnMigrate, extension.baselineOnMigrate);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -306,7 +306,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
 
     /**
      * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
-     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * classpath but have not yet been performed by an application deployment. This can be useful for verifying
      * that in-development migration changes don't contain any validation-breaking changes of migrations that have
      * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
      * existence of new migration versions.

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -305,6 +305,19 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private Boolean ignoreIgnoredMigrations;
 
     /**
+     * Ignore pending migrations when reading the schema history table. These are migrations that are available on the
+     * classpath but have not yet been were performed by an application deployment. This can be useful for verifying
+     * that in-development migration changes don't contain any validation-breaking changes of migrations that have
+     * already been applied to a production environment, e.g. as part of a CI/CD process, without failing because of the
+     * existence of new migration versions.
+     * <p>
+     * {@code true} to continue normally, {@code false} to fail fast with an exception.
+     * (default: {@code false})
+     */
+    @Parameter(property = ConfigUtils.IGNORE_PENDING_MIGRATIONS)
+    private Boolean ignorePendingMigrations;
+    
+    /**
      * Ignore future migrations when reading the schema history table. These are migrations that were performed by a
      * newer deployment of the application that are not yet available in this version. For example: we have migrations
      * available on the classpath up to version 3.0. The schema history table indicates that a migration to version 4.0


### PR DESCRIPTION
This adds an 'ignorePendingMigrations' option to suppress validation errors caused by the availability of not-yet-applied migrations (feature request #2128).

My use case is for a CI/CD pipeline - while developers are working on a feature branch they should be able to create and modify migrations for that feature.  However, we should be able to detect and break the build when changes are made to versioned migrations that have already been applied to (e.g.) our production database.  Running `flyway validate` with `ignorePendingMigrations=true` supports this scenario and is consistent with the existing `ignore*Migrations` options.