### PR TITLE
Fixes #2198: fixed resource scanning for felix 6.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>3.2.0</version>
                 </plugin>
 
 


### PR DESCRIPTION
@axelfontaine 
you will need to upgrade maven-bundle-plugin to 3.2.0 to handle java 8
```
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>3.2.0</version>
                 </plugin>
``` 