### PR TITLE
supports atomic ddl for mysql > 8

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLDatabase.java
@@ -188,7 +188,7 @@ public class MySQLDatabase extends Database<MySQLConnection> {
 
     @Override
     public boolean supportsDdlTransactions() {
-        return false;
+        return getVersion().isAtLeast("8.0") ? true : false;
     }
 
     @Override


### PR DESCRIPTION
mysql 8 now supports atomic ddl. 
https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html

