### PR TITLE
log with debug level in case sqlState is 00000

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/sqlscript/DefaultSqlScriptExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/sqlscript/DefaultSqlScriptExecutor.java
@@ -278,7 +278,7 @@ public class DefaultSqlScriptExecutor implements SqlScriptExecutor {
 
 
                 if ("00000".equals(warning.getState())) {
-                    LOG.info("DB: " + warning.getMessage());
+                    LOG.debug("DB: " + warning.getMessage());
                 } else {
                     LOG.warn("DB: " + warning.getMessage()
                             + " (SQL State: " + warning.getState() + " - Error Code: " + warning.getCode() + ")");


### PR DESCRIPTION
SQLState 00000 indicates a **successful completion** of a query.
In this case the warnings are not really warnings but mere debug information on what was executed.

e.g.
DB: Run command: ALTER TABLE my_table DROP CONSTRAINT IF EXISTS my_constraint;

on log-level INFO it should be sufficient to see which migration is currently running. logging out all the individual queries that have been executed (successfully) should be only done for debugging purposes.