### PR TITLE
Update H2Schema to work with DATABASE_TO_UPPER=false

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
@@ -45,7 +45,7 @@ public class H2Schema extends Schema<H2Database> {
 
     @Override
     protected boolean doExists() throws SQLException {
-        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.schemata WHERE schema_name=?", name) > 0;
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME=?", name) > 0;
     }
 
     @Override
@@ -149,7 +149,7 @@ public class H2Schema extends Schema<H2Database> {
      * @throws java.sql.SQLException when the object names could not be listed.
      */
     private List<String> listObjectNames(String objectType, String querySuffix) throws SQLException {
-        String query = "SELECT " + objectType + "_NAME FROM INFORMATION_SCHEMA." + objectType + "s WHERE " + objectType + "_schema = ?";
+        String query = "SELECT " + objectType + "_NAME FROM INFORMATION_SCHEMA." + objectType + "S WHERE " + objectType + "_SCHEMA = ?";
         if (StringUtils.hasLength(querySuffix)) {
             query += " AND " + querySuffix;
         }


### PR DESCRIPTION
With H2 1.4.198 and DATABASE_TO_UPPER=false, flyway fails being
unable to find the (lowercase) schemata table and related columns.

Updating to use uppercase versions of the same makes things work.
With H2 1.4.197, this change was not necessary for some reason though?