### PR TITLE
Enable configFiles configuration for maven plugin

### DIFF
--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -542,6 +542,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
      * <p/>
      * <p>Also configurable with Maven or System Property: ${flyway.configFiles}</p>
      */
+    @Parameter(property = ConfigUtils.CONFIG_FILES)
     private File[] configFiles;
 
     /**


### PR DESCRIPTION
I am not able use multiple config files from pom.xml. After this commit is posible set multiple config files like:
```
<configFiles>
  <configFile>flyway-dev.conf</configFile>
  <configFile>flyway.conf</configFile>
</configFiles>
```