### PR TITLE
Fixed typo in MigrationType Javadoc

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/MigrationType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/MigrationType.java
@@ -25,7 +25,7 @@ public enum MigrationType {
     SCHEMA(true, false),
 
     /**
-     * Bseline migration.
+     * Baseline migration.
      */
     BASELINE(true, false),
 


### PR DESCRIPTION
Changed typo 'Bseline' to 'Baseline'