### PR TITLE
JavaUtilLog doesn't need to be instantiated with ClassUtils

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/LogCreatorFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/LogCreatorFactory.java
@@ -43,7 +43,7 @@ public class LogCreatorFactory {
             return ClassUtils.instantiate(ApacheCommonsLogCreator.class.getName(), classLoader);
         }
         if (fallbackLogCreator == null) {
-            return ClassUtils.instantiate(JavaUtilLogCreator.class.getName(), classLoader);
+            return new JavaUtilLogCreator();
         }
         return fallbackLogCreator;
     }


### PR DESCRIPTION
#2114
Using the context classloader in static context still doesn't allow for using slf4j or commons logging, but this way at least the fallback java util logging can be instantiated and start Flyway normally.