### PR TITLE
Fixed #2467: Restore H2 database support

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
@@ -153,9 +153,9 @@ public class DatabaseFactory {
 
 
 
-
-
-
+                );
+            case H2:	
+                return new H2Database(configuration, jdbcConnectionFactory
 
 
 


### PR DESCRIPTION
This PR restores the support for H2 which was accidentally
removed in
https://github.com/flyway/flyway/commit/f9bd09b70249acfa380e698b7491b41b9b1d57f7#diff-27056a4ea3c4eb4f1d78e57eac7598e8L151-L152