### PR TITLE
Compare function(s) should return -1 || 0 || 1

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/MigrationVersion.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/MigrationVersion.java
@@ -190,28 +190,28 @@ public final class MigrationVersion implements Comparable<MigrationVersion> {
 
         if (this == EMPTY) {
             if (o == EMPTY) return 0;
-            else return Integer.MIN_VALUE;
+            else return -1;
         }
 
         if (this == CURRENT) {
-            return o == CURRENT ? 0 : Integer.MIN_VALUE;
+            return o == CURRENT ? 0 : -1;
         }
 
         if (this == LATEST) {
             if (o == LATEST) return 0;
-            else return Integer.MAX_VALUE;
+            else return 1;
         }
 
         if (o == EMPTY) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         if (o == CURRENT) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         if (o == LATEST) {
-            return Integer.MIN_VALUE;
+            return -1;
         }
         final List<BigInteger> parts1 = versionParts;
         final List<BigInteger> parts2 = o.versionParts;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptCallbackFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/callback/SqlScriptCallbackFactory.java
@@ -158,10 +158,10 @@ public class SqlScriptCallbackFactory {
             int result = event.compareTo(o.event);
             if (result == 0) {
                 if (description == null) {
-                    return Integer.MIN_VALUE;
+                    return -1;
                 }
                 if (o.description == null) {
-                    return Integer.MAX_VALUE;
+                    return 1;
                 }
                 result = description.compareTo(o.description);
             }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
@@ -356,31 +356,31 @@ public class MigrationInfoImpl implements MigrationInfo {
 
         // Below baseline migrations come before applied ones
         if (state == MigrationState.BELOW_BASELINE && oState.isApplied()) {
-            return Integer.MIN_VALUE;
+            return -1;
         }
         if (state.isApplied() && oState == MigrationState.BELOW_BASELINE) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         if (state == MigrationState.IGNORED && oState.isApplied()) {
             if (getVersion() != null && o.getVersion() != null) {
                 return getVersion().compareTo(o.getVersion());
             }
-            return Integer.MIN_VALUE;
+            return -1;
         }
         if (state.isApplied() && oState == MigrationState.IGNORED) {
             if (getVersion() != null && o.getVersion() != null) {
                 return getVersion().compareTo(o.getVersion());
             }
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         // Sort installed before pending
         if (getInstalledRank() != null) {
-            return Integer.MIN_VALUE;
+            return -1;
         }
         if (o.getInstalledRank() != null) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         // No migration installed, sort according to other criteria
@@ -406,10 +406,10 @@ public class MigrationInfoImpl implements MigrationInfo {
 
         // One versioned and one repeatable migration: versioned migration goes before repeatable one
         if (getVersion() != null) {
-            return Integer.MIN_VALUE;
+            return -1;
         }
         if (o.getVersion() != null) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
 
         // Two repeatable migrations: sort by description

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
@@ -43,10 +43,10 @@ public class ResolvedMigrationComparator implements Comparator<ResolvedMigration
             return v;
         }
         if (o1.getVersion() != null) {
-            return Integer.MIN_VALUE;
+            return -1;
         }
         if (o2.getVersion() != null) {
-            return Integer.MAX_VALUE;
+            return 1;
         }
         return o1.getDescription().compareTo(o2.getDescription());
     }


### PR DESCRIPTION
Using Integer.MIN_VALUE is dangerous because of this property: Integer.MIN_VALUE * -1 == Integer.MIN_VALUE
If someone would try to reverse ordering using these compare function, it would result in *surprising results*