### PR TITLE
Gradle Plugin: Fix reading CONFIG_FILES from project properties

### DIFF
--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -745,7 +745,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         }
 
         if (getProject().getProperties().containsKey(ConfigUtils.CONFIG_FILES)) {
-            for (String file : StringUtils.tokenizeToStringArray(System.getProperties().getProperty(ConfigUtils.CONFIG_FILES), ",")) {
+            for (String file : StringUtils.tokenizeToStringArray(String.valueOf(getProject().getProperties().get(ConfigUtils.CONFIG_FILES)), ",")) {
                 configFiles.add(toFile(file));
             }
             return configFiles;


### PR DESCRIPTION
Hello,
thanks for great plugin :)

I have found a small issue in the Gradle Plugin:
When reading CONFIG_FILES from getProject().getProperties(), it was wrongly read from System.getProperties()

Greetings
Kevin