### PR TITLE
Not worked migration when plsql contains CASE statement

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/oracle/OracleParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/oracle/OracleParser.java
@@ -361,8 +361,8 @@ public class OracleParser extends Parser {
         String keywordText = keyword.getText();
         int parensDepth = keyword.getParensDepth();
 
-        if ("BEGIN".equals(keywordText) || "CASE".equals(keywordText)
-                || (("IF".equals(keywordText) || "LOOP".equals(keywordText)) && !containsWithinLast(1, tokens, parensDepth, "END"))
+        if ("BEGIN".equals(keywordText) || (("IF".equals(keywordText)
+                || "CASE".equals(keywordText) || "LOOP".equals(keywordText)) && !containsWithinLast(1, tokens, parensDepth, "END"))
                 || ("TRIGGER".equals(keywordText) && containsWithinLast(1, tokens, parensDepth, "COMPOUND"))
                 || (("AS".equals(keywordText) || "IS".equals(keywordText)) && (
                 containsWithinLast(4, tokens, parensDepth, "PACKAGE")


### PR DESCRIPTION
When migration is:
`CREATE OR REPLACE PACKAGE test AS
  LS_TEST_IDENTIFIERS VARCHAR2(1 CHAR) := 'R';
  FUNCTION FT( AS_IDENTIFIER VARCHAR2 ) RETURN VARCHAR2;
END TEST;
/

CREATE OR REPLACE PACKAGE BODY TEST AS
  FUNCTION FT (AS_IDENTIFIER VARCHAR2) RETURN VARCHAR2 IS
  BEGIN
      CASE LS_TEST_IDENTIFIERS
        WHEN  'R' THEN
            RETURN AS_IDENTIFIER;
        END CASE ;
  END FT;
END TEST;
/
`
and method adjustBlockDepth is:

`    @Override
    protected void adjustBlockDepth(ParserContext context, List<Token> tokens, Token keyword) {
        String keywordText = keyword.getText();
        int parensDepth = keyword.getParensDepth();

        if ("BEGIN".equals(keywordText) || "CASE".equals(keywordText)
                || (("IF".equals(keywordText) || "LOOP".equals(keywordText)) && !containsWithinLast(1, tokens, parensDepth, "END"))
                || ("TRIGGER".equals(keywordText) && containsWithinLast(1, tokens, parensDepth, "COMPOUND"))
                || (("AS".equals(keywordText) || "IS".equals(keywordText)) && (
                containsWithinLast(4, tokens, parensDepth, "PACKAGE")
                        || containsWithinLast(3, tokens, parensDepth, "PACKAGE", "BODY")
                        || containsWithinLast(3, tokens, parensDepth, "TYPE", "BODY")))
        ) {
            context.increaseBlockDepth();
        } else if ("END".equals(keywordText)) {
            context.decreaseBlockDepth();
        }
    }`

migration not worked.

But, if method adjustBlockDepth is:
`    @Override
    protected void adjustBlockDepth(ParserContext context, List<Token> tokens, Token keyword) {
        String keywordText = keyword.getText();
        int parensDepth = keyword.getParensDepth();

        if ("BEGIN".equals(keywordText) || (("IF".equals(keywordText)
                || "CASE".equals(keywordText) || "LOOP".equals(keywordText)) && !containsWithinLast(1, tokens, parensDepth, "END"))
                || ("TRIGGER".equals(keywordText) && containsWithinLast(1, tokens, parensDepth, "COMPOUND"))
                || (("AS".equals(keywordText) || "IS".equals(keywordText)) && (
                containsWithinLast(4, tokens, parensDepth, "PACKAGE")
                        || containsWithinLast(3, tokens, parensDepth, "PACKAGE", "BODY")
                        || containsWithinLast(3, tokens, parensDepth, "TYPE", "BODY")))
        ) {
            context.increaseBlockDepth();
        } else if ("END".equals(keywordText)) {
            context.decreaseBlockDepth();
        }
    }`

migration ok.
