### PR TITLE
Add environment variable for defaultSchema

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -151,6 +151,9 @@ public class ConfigUtils {
         if ("FLYWAY_CONNECT_RETRIES".equals(key)) {
             return CONNECT_RETRIES;
         }
+        if ("FLYWAY_DEFAULT_SCHEMA".equals(key)) {
+            return DEFAULT_SCHEMA;
+        }
         if ("FLYWAY_DRIVER".equals(key)) {
             return DRIVER;
         }


### PR DESCRIPTION
There is currently no way to define the default schema through environment variables.