### PR TITLE
Applying patch to make Vertica work

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaSchema.java
@@ -24,7 +24,6 @@ import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
 import org.flywaydb.core.internal.dbsupport.Schema;
 import org.flywaydb.core.internal.dbsupport.Table;
 import org.flywaydb.core.internal.dbsupport.Type;
-import org.flywaydb.core.internal.dbsupport.postgresql.PostgreSQLTable;
 
 public class VerticaSchema extends Schema<VerticaDbSupport> {
 
@@ -158,14 +157,14 @@ public class VerticaSchema extends Schema<VerticaDbSupport> {
 
         Table[] tables = new Table[tableNames.size()];
         for (int i = 0; i < tableNames.size(); i++) {
-            tables[i] = new PostgreSQLTable(jdbcTemplate, dbSupport, this, tableNames.get(i));
+            tables[i] = new VerticaTable(jdbcTemplate, dbSupport, this, tableNames.get(i));
         }
         return tables;
     }
 
     @Override
     public Table getTable(String tableName) {
-        return new PostgreSQLTable(jdbcTemplate, dbSupport, this, tableName);
+        return new VerticaTable(jdbcTemplate, dbSupport, this, tableName);
     }
 
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/vertica/VerticaTable.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2017 Boxfuse GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.dbsupport.vertica;
+
+import org.flywaydb.core.internal.dbsupport.DbSupport;
+import org.flywaydb.core.internal.dbsupport.JdbcTemplate;
+import org.flywaydb.core.internal.dbsupport.Schema;
+import org.flywaydb.core.internal.dbsupport.Table;
+
+import java.sql.SQLException;
+
+public class VerticaTable extends Table {
+
+    public VerticaTable(JdbcTemplate jdbcTemplate, DbSupport dbSupport, Schema schema, String name) {
+        super(jdbcTemplate, dbSupport, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE "+ dbSupport.quote(schema.getName(), name) + " CASCADE");
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
+            "   SELECT 1\n" +
+            "   FROM v_catalog.tables \n" +
+            "   WHERE table_schema = ?\n" +
+            "   AND table_name = ?\n" +
+            ")", schema.getName(), name);
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
+    }
+}


### PR DESCRIPTION
- vertica doesnt use the information_schema table, it uses v_catalog
- flyway 4.2.0 pre-patch was using PSQL as a template for vertica
- the patch provides vertica-specific handling
- details: https://github.com/flyway/flyway/issues/1685