### PR TITLE
Allow setting flyway.url=<valid-url> at the top of flyway.conf.

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -40,7 +40,7 @@
 # SQLite            : jdbc:sqlite:<database>
 # Sybase ASE        : jdbc:jtds:sybase://<host>:<port>/<database>
 # Redshift*         : jdbc:redshift://<host>:<port>/<database>
-flyway.url=
+# flyway.url=
 
 # Fully qualified classname of the JDBC driver (autodetected by default based on flyway.url)
 # flyway.driver=


### PR DESCRIPTION
Addresses a recent open issue (and two other closed ones). One simple line.