### PR TITLE
Fix slow doEmpty by using EVENT_OBJECT_SCHEMA (#2123)

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLSchema.java
@@ -56,7 +56,7 @@ public class MySQLSchema extends Schema<MySQLDatabase, MySQLTable> {
                         + "(SELECT 1 as found FROM information_schema.tables WHERE table_schema=?) UNION ALL "
                         + "(SELECT 1 as found FROM information_schema.views WHERE table_schema=? LIMIT 1) UNION ALL "
                         + "(SELECT 1 as found FROM information_schema.table_constraints WHERE table_schema=? LIMIT 1) UNION ALL "
-                        + "(SELECT 1 as found FROM information_schema.triggers WHERE trigger_schema=? LIMIT 1) UNION ALL "
+                        + "(SELECT 1 as found FROM information_schema.triggers WHERE event_object_schema=?  LIMIT 1) UNION ALL "
                         + "(SELECT 1 as found FROM information_schema.routines WHERE routine_schema=? LIMIT 1)"
                         // #2410 Unlike MySQL, MariaDB 10.0 and newer don't allow the events table to be queried
                         // when the event scheduled is DISABLED or in some rare cases OFF


### PR DESCRIPTION
Associated issue: #2123

This fix improves the performance of `MySQLSchema.doEmpty` for MySQL 5.7 without changing the expected behavior.

The subquery `SELECT 1 as found FROM information_schema.triggers WHERE trigger_schema=? AND  LIMIT 1` is changed to `SELECT 1 as found FROM information_schema.triggers WHERE event_object_schema=? AND  LIMIT 1` (`WHERE trigger_schema=?` becomes `WHERE event_object_schema=?`).

As specified here: https://dev.mysql.com/doc/mysql-infoschema-excerpt/5.7/en/triggers-table.html, "every trigger is associated with exactly one table" and `EVENT_OBJECT_SCHEMA` is the "schema (database) in which this table occurs" and `TRIGGER_SCHEMA` is the "name of the schema (database) to which the trigger belongs". If a trigger belongs to a table that belongs to schema X, then that trigger must belong to schema X. Thus, if one's goal is to find if there are any triggers associated with a specific schema, one can filter by `EVENT_OBJECT_SCHEMA`.

As specified here: https://dev.mysql.com/doc/refman/5.7/en/information-schema-optimization.html, filtering by `EVENT_OBJECT_SCHEMA` is faster than filtering by `TRIGGER_SCHEMA` because it is a "Column to specify to avoid data directory scan".