### PR TITLE
Spanner support with Open Source JDBC driver

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseFactory.java
@@ -21,6 +21,8 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.callback.CallbackExecutor;
 import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.cloudspanner.CloudSpannerDatabase;
+import org.flywaydb.core.internal.database.cloudspanner.CloudSpannerParser;
 import org.flywaydb.core.internal.database.cockroachdb.CockroachDBDatabase;
 import org.flywaydb.core.internal.database.cockroachdb.CockroachDBParser;
 import org.flywaydb.core.internal.database.cockroachdb.CockroachDBRetryingStrategy;
@@ -134,6 +136,8 @@ public class DatabaseFactory {
 
 
                 );
+            case CLOUDSPANNER:
+                return new CloudSpannerDatabase(configuration, jdbcConnectionFactory);
             case DB2:
                 return new DB2Database(configuration, jdbcConnectionFactory
 
@@ -280,6 +284,8 @@ public class DatabaseFactory {
         final DatabaseType databaseType = jdbcConnectionFactory.getDatabaseType();
 
         switch (databaseType) {
+            case CLOUDSPANNER:
+                return new CloudSpannerParser(configuration, parsingContext);
             case COCKROACHDB:
                 return new CockroachDBParser(configuration, parsingContext);
             case DB2:

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerConnection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.database.base.Connection;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+
+public class CloudSpannerConnection extends Connection<CloudSpannerDatabase> {
+
+
+    protected CloudSpannerConnection(CloudSpannerDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
+        return "";
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new CloudSpannerSchema(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public <T> T lock(Table table, Callable<T> callable)  {
+        //return new ClousSpannerLockTemplate(jdbcTemplate, table.toString().hashCode()).execute(callable);
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            RuntimeException rethrow;
+            if (e instanceof RuntimeException) {
+                rethrow = (RuntimeException) e;
+            } else {
+                rethrow = new FlywayException(e);
+            }
+            throw rethrow;
+        }
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerDatabase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;
+
+import java.sql.DatabaseMetaData;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+
+import java.sql.Connection;
+
+public class CloudSpannerDatabase extends Database<CloudSpannerConnection> {
+    public CloudSpannerDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory) {
+        super(configuration, jdbcConnectionFactory);
+    }
+
+    @Override
+    protected CloudSpannerConnection doGetConnection(Connection connection) {
+        return new CloudSpannerConnection(this, connection);
+    }
+
+    @Override
+    public void ensureSupported() {
+
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    Connection getNewRawConnection() {
+        return jdbcConnectionFactory.openConnection();
+    }
+
+    @Override
+    public boolean supportsChangingCurrentSchema() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "true";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "false";
+    }
+
+    @Override
+    protected String doQuote(String identifier) {
+        return "`" + identifier + "`";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        return false;
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "" +
+                "START BATCH DDL;" +
+                "CREATE TABLE " + table.getName() + " (\n" +
+                "    installed_rank INT64 NOT NULL,\n" +
+                "    version STRING(50),\n" +
+                "    description STRING(200) NOT NULL,\n" +
+                "    type STRING(20) NOT NULL,\n" +
+                "    script STRING(1000) NOT NULL,\n" +
+                "    checksum INT64,\n" +
+                "    installed_by STRING(100) NOT NULL,\n" +
+                "    installed_on TIMESTAMP OPTIONS (allow_commit_timestamp=true),\n" +
+                "    execution_time INT64 NOT NULL,\n" +
+                "    success BOOL NOT NULL\n" +
+                ") PRIMARY KEY (installed_rank DESC);\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "") +
+                "CREATE INDEX " + table.getName() + "_s_idx ON " + table.getName() + " (\"success\");" +
+                "RUN BATCH;";
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;
+
+import java.util.List;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.parser.Token;
+
+public class CloudSpannerParser  extends Parser {
+    private static final Log LOG = LogFactory.getLog(CloudSpannerParser.class);
+    public CloudSpannerParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration,parsingContext, 3);
+    }
+
+    @Override
+    protected char getIdentifierQuote() {
+        return '`';
+    }
+
+    protected char getAlternativeIdentifierQuote() {
+        return '\"';
+    }
+
+    @Override
+    protected Boolean detectCanExecuteInTransaction(String simplifiedStatement,
+                                                    List<Token> keywords) {
+        LOG.debug("checking if [" + simplifiedStatement + "] can run in transaction");
+        // Flyway tries to do hold transaction in which migration will happen
+        return false;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerSchema.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.List;
+
+public class CloudSpannerSchema extends Schema<CloudSpannerDatabase, CloudSpannerTable> {
+    /**
+     * Creates a new schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public CloudSpannerSchema(JdbcTemplate jdbcTemplate, CloudSpannerDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return name.equals("");
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+
+        try (Connection c = database.getNewRawConnection()){
+            Statement s = c.createStatement();
+            s.execute("SET READONLY = true");
+            s.close();
+            try(ResultSet tables = c.getMetaData().getTables("", "", null, null)){
+                return !tables.next();
+            }
+        }
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        throw new SQLFeatureNotSupportedException("CREATE DATABASE not supported");
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        throw new SQLFeatureNotSupportedException("DROP DATABASE not supported");
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        throw new SQLFeatureNotSupportedException("CLEAN DATABASE not supported");
+
+    }
+
+    @Override
+    protected CloudSpannerTable[] doAllTables() throws SQLException {
+        List<CloudSpannerTable> tablesList = new ArrayList<>();
+        try (Connection c = database.getNewRawConnection()) {
+            Statement s = c.createStatement();
+            s.execute("SET READONLY = true");
+            s.close();
+            ResultSet tablesRs = c.getMetaData().getTables("", "", null, null);
+            while (tablesRs.next()) {
+                tablesList.add(new CloudSpannerTable(jdbcTemplate, database, this,
+                        tablesRs.getString("TABLE_NAME")));
+            }
+            tablesRs.close();
+        }
+
+        CloudSpannerTable[] tables = new CloudSpannerTable[tablesList.size()];
+        return tablesList.toArray(tables);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new CloudSpannerTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerTable.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;
+
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class CloudSpannerTable extends Table<CloudSpannerDatabase, CloudSpannerSchema> {
+
+
+    /**
+     * Creates a new table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public CloudSpannerTable(JdbcTemplate jdbcTemplate, CloudSpannerDatabase database, CloudSpannerSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        try (Connection c = database.getNewRawConnection()){
+            Statement s = c.createStatement();
+            s.execute("SET READONLY = true");
+            s.close();
+            try(ResultSet tables = c.getMetaData().getTables("", "", this.name, null)){
+                return tables.next();
+            }
+        }
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        try(Statement statement = jdbcTemplate.getConnection().createStatement()){
+            statement.execute("DROP TABLE " + database.quote(name));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return database.quote(name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2020 Redgate Software Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.database.cloudspanner;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/DatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/DatabaseType.java
@@ -29,6 +29,7 @@ import java.sql.Types;
  */
 @SuppressWarnings("SqlDialectInspection")
 public enum DatabaseType {
+    CLOUDSPANNER("Cloud Spanner", Types.NULL, true),
     COCKROACHDB("CockroachDB", Types.NULL, false),
     DB2("DB2", Types.VARCHAR, true),
 
@@ -142,6 +143,9 @@ public enum DatabaseType {
         }
         if (databaseProductName.startsWith("Snowflake")) {
             return SNOWFLAKE;
+        }
+        if (databaseProductName.startsWith("Google Cloud Spanner")) {
+            return CLOUDSPANNER;
         }
         throw new FlywayException("Unsupported Database: " + databaseProductName);
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/DriverDataSource.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/DriverDataSource.java
@@ -65,8 +65,8 @@ public class DriverDataSource implements DataSource {
         SQLLITE("jdbc:sqlite:", "org.sqlite.JDBC"),
         SQLSERVER("jdbc:sqlserver:", "com.microsoft.sqlserver.jdbc.SQLServerDriver"),
         SYBASE("jdbc:sybase:", "com.sybase.jdbc4.jdbc.SybDriver"),
-        TEST_CONTAINERS("jdbc:tc:", "org.testcontainers.jdbc.ContainerDatabaseDriver");
-
+        TEST_CONTAINERS("jdbc:tc:", "org.testcontainers.jdbc.ContainerDatabaseDriver"),
+        GOOGLE_CLOUD_SPANNER("jdbc:cloudspanner:","com.google.cloud.spanner.jdbc.JdbcDriver");
         DriverType(String prefix, String driverClass) {
             this.prefix = prefix;
             this.driverClass = driverClass;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
@@ -306,7 +306,7 @@ public class JdbcTemplate {
                     while (resultSet.next()) {
                         List<String> row = new ArrayList<>();
                         for (int i = 1; i <= columnCount; i++) {
-                            row.add(resultSet.getString(i));
+                            row.add(resultSet.getObject(i).toString());
                         }
                         data.add(row);
                     }


### PR DESCRIPTION
Hi,
Due to open sourcing Spanner driver and it's better support for DML and DDL it is possible to integrate it with flyway.
There are still things not supported like transactional ddl/dml.
Also due to the fact that information schema needs read only connection I had to use raw connection instead of jdbcTemplate.

please take a look.