### PR TITLE
CLI: add FLYWAY_EXTRA_ARGS

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -63,9 +63,9 @@ fi
 
 CP="$INSTALLDIR/lib/*:$INSTALLDIR/lib/$FLYWAY_EDITION/*:$INSTALLDIR/drivers/*"
 
-EXTRA_ARGS=
+EXTRA_ARGS=${FLYWAY_EXTRA_ARGS:=}
 if $linux; then
-  EXTRA_ARGS=-Djava.security.egd=file:/dev/../dev/urandom
+  EXTRA_ARGS="$EXTRA_ARGS -Djava.security.egd=file:/dev/../dev/urandom"
 fi
 
 if `command -v cygpath > /dev/null`; then CP=`cygpath -pw "$CP"`; fi


### PR DESCRIPTION
Add environment variable `FLYWAY_EXTRA_ARGS`, need it to support SSL from CLI.

Close #2788.