### PR TITLE
#2698. Configure custom comparator defining repeatable migrations order.

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -109,6 +109,10 @@
 # defined by 'flyway.resolvers' are used. (default: false)
 # flyway.skipDefaultResolvers=
 
+# Fully qualified class name of custom Comparator to determine the order of repeatable migrations
+# By default repeatable migrations are ordered by description.
+# flyway.repeatableMigrationComparator=
+
 # Comma-separated list of directories containing JDBC drivers and Java-based migrations.
 # (default: <INSTALL-DIR>/jars)
 # flyway.jarDirs=

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -306,6 +306,7 @@ public class Main {
         LOG.info("locations                    : Classpath locations to scan recursively for migrations");
         LOG.info("resolvers                    : Comma-separated list of custom MigrationResolvers");
         LOG.info("skipDefaultResolvers         : Skips default resolvers (jdbc, sql and Spring-jdbc)");
+        LOG.info("repeatableMigrationComparator: Fully qualified class name of repeatable migrations comparator");
         LOG.info("sqlMigrationPrefix           : File name prefix for versioned SQL migrations");
         LOG.info("undoSqlMigrationPrefix       : [" + "pro] File name prefix for undo SQL migrations");
         LOG.info("repeatableSqlMigrationPrefix : File name prefix for repeatable SQL migrations");

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -24,23 +24,23 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.configuration.ConfigUtils;
 import org.flywaydb.core.internal.jdbc.DriverDataSource;
 import org.flywaydb.core.internal.license.Edition;
+import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.util.ClassUtils;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.StringUtils;
 
 import javax.sql.DataSource;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -389,80 +389,12 @@ public class ClassicConfiguration implements Configuration {
      */
     private String installedBy;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    /**
+     * The {@link Comparator} to determine the order of repeatable migrations.
+     * <p>
+     * By default repeatable migrations are applied in the order of their description.
+     */
+    private Comparator<ResolvedMigration> repeatableMigrationComparator = ResolvedMigrationComparator.DEFAULT_REPEATABLE_MIGRATION_COMPARATOR;
 
     /**
      * Creates a new default configuration.
@@ -724,6 +656,11 @@ public class ClassicConfiguration implements Configuration {
 
     }
 
+    @Override
+    public Comparator<ResolvedMigration> getRepeatableMigrationComparator() {
+        return repeatableMigrationComparator;
+    }
+
     /**
      * Sets the stream where to output the SQL statements of a migration dry run. {@code null} to execute the SQL statements
      * directly against the database. The stream when be closing when Flyway finishes writing the output.
@@ -870,6 +807,25 @@ public class ClassicConfiguration implements Configuration {
             installedBy = null;
         }
         this.installedBy = installedBy;
+    }
+
+    /**
+     * Sets the {@link Comparator} to determine the order of repeatable migrations.
+     *
+     * @param repeatableMigrationComparator The comparator to determine the order of repeatable migrations.
+     */
+    public void setRepeatableMigrationComparator(Comparator<ResolvedMigration> repeatableMigrationComparator) {
+        this.repeatableMigrationComparator = repeatableMigrationComparator;
+    }
+
+    /**
+     * Sets custom {@link Comparator} to determine the order of repeatable migrations.
+     *
+     * @param comparator The fully qualified class name of the custom {@link Comparator} to determine the order of repeatable migrations.
+     */
+    public void setRepeatableMigrationComparatorAsClassName(String comparator) {
+        Comparator<ResolvedMigration> repeatableMigrationComparator = ClassUtils.instantiate(comparator, classLoader);
+        setRepeatableMigrationComparator(repeatableMigrationComparator);
     }
 
     /**
@@ -1643,6 +1599,7 @@ public class ClassicConfiguration implements Configuration {
         setTablespace(configuration.getTablespace());
         setTarget(configuration.getTarget());
         setValidateOnMigrate(configuration.isValidateOnMigrate());
+        setRepeatableMigrationComparator(configuration.getRepeatableMigrationComparator());
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -20,10 +20,12 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.Callback;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
 
 import javax.sql.DataSource;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.Comparator;
 import java.util.Map;
 
 /**
@@ -515,4 +517,11 @@ public interface Configuration {
      * @return {@code true} to output the results table (default: {@code true})
      */
     boolean outputQueryResults();
+
+    /**
+     * The {@link Comparator} to determine the order of repeatable migrations.
+     * <p>
+     * By default repeatable migrations are applied in the order of their description.
+     */
+    Comparator<ResolvedMigration> getRepeatableMigrationComparator();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -22,6 +22,7 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.Callback;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
+import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.configuration.ConfigUtils;
 import org.flywaydb.core.internal.util.ClassUtils;
 
@@ -29,7 +30,7 @@ import javax.sql.DataSource;
 import java.io.File;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Properties;
 
@@ -294,6 +295,21 @@ public class FluentConfiguration implements Configuration {
     @Override
     public boolean outputQueryResults() {
         return config.outputQueryResults();
+    }
+
+    @Override
+    public Comparator<ResolvedMigration> getRepeatableMigrationComparator() {
+        return config.getRepeatableMigrationComparator();
+    }
+
+    public FluentConfiguration repeatableMigrationComparator(String comparator) {
+        config.setRepeatableMigrationComparatorAsClassName(comparator);
+        return this;
+    }
+
+    public FluentConfiguration repeatableMigrationComparator(Comparator<ResolvedMigration> comparator) {
+        config.setRepeatableMigrationComparator(comparator);
+        return this;
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
  * Configuration-related utilities.
  */
 public class ConfigUtils {
+
     private static Log LOG = LogFactory.getLog(ConfigUtils.class);
 
     /**
@@ -71,6 +72,7 @@ public class ConfigUtils {
     public static final String PLACEHOLDERS_PROPERTY_PREFIX = "flyway.placeholders.";
     public static final String REPEATABLE_SQL_MIGRATION_PREFIX = "flyway.repeatableSqlMigrationPrefix";
     public static final String RESOLVERS = "flyway.resolvers";
+    public static final String REPEATABLE_MIGRATION_COMPARATOR = "flyway.repeatableMigrationComparator";
     public static final String SCHEMAS = "flyway.schemas";
     public static final String SKIP_DEFAULT_CALLBACKS = "flyway.skipDefaultCallbacks";
     public static final String SKIP_DEFAULT_RESOLVERS = "flyway.skipDefaultResolvers";

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMigrationResolver.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -107,7 +108,8 @@ public class CompositeMigrationResolver implements MigrationResolver {
      */
     private List<ResolvedMigration> doFindAvailableMigrations(Context context) throws FlywayException {
         List<ResolvedMigration> migrations = new ArrayList<>(collectMigrations(migrationResolvers, context));
-        Collections.sort(migrations, new ResolvedMigrationComparator());
+        Comparator<ResolvedMigration> repeatableMigrationComparator = context.getConfiguration().getRepeatableMigrationComparator();
+        Collections.sort(migrations, new ResolvedMigrationComparator(repeatableMigrationComparator));
 
         checkForIncompatibilities(migrations);
 
@@ -137,7 +139,7 @@ public class CompositeMigrationResolver implements MigrationResolver {
      */
     /* private -> for testing */
     static void checkForIncompatibilities(List<ResolvedMigration> migrations) {
-    	ResolvedMigrationComparator resolvedMigrationComparator = new ResolvedMigrationComparator();
+    	ResolvedMigrationComparator resolvedMigrationComparator = new ResolvedMigrationComparator(ResolvedMigrationComparator.DEFAULT_REPEATABLE_MIGRATION_COMPARATOR);
         // check for more than one migration with same version
         for (int i = 0; i < migrations.size() - 1; i++) {
             ResolvedMigration current = migrations.get(i);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/ResolvedMigrationComparator.java
@@ -23,23 +23,20 @@ import java.util.Comparator;
 * Comparator for ResolvedMigration.
 */
 public class ResolvedMigrationComparator implements Comparator<ResolvedMigration> {
+
+    public static final Comparator<ResolvedMigration> DEFAULT_REPEATABLE_MIGRATION_COMPARATOR =
+            Comparator.comparing(ResolvedMigration::getDescription);
+
+    private final Comparator<ResolvedMigration> repeatableMigrationComparator;
+
+    public ResolvedMigrationComparator(Comparator<ResolvedMigration> repeatableMigrationComparator) {
+        this.repeatableMigrationComparator = repeatableMigrationComparator;
+    }
+
     @Override
     public int compare(ResolvedMigration o1, ResolvedMigration o2) {
         if ((o1.getVersion() != null) && o2.getVersion() != null) {
             int v = o1.getVersion().compareTo(o2.getVersion());
-
-
-
-
-
-
-
-
-
-
-
-
-
             return v;
         }
         if (o1.getVersion() != null) {
@@ -48,6 +45,6 @@ public class ResolvedMigrationComparator implements Comparator<ResolvedMigration
         if (o2.getVersion() != null) {
             return 1;
         }
-        return o1.getDescription().compareTo(o2.getDescription());
+        return repeatableMigrationComparator.compare(o1, o2);
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/FixedJavaMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/FixedJavaMigrationResolver.java
@@ -51,7 +51,7 @@ public class FixedJavaMigrationResolver implements MigrationResolver {
             migrations.add(new ResolvedJavaMigration(javaMigration));
         }
 
-        Collections.sort(migrations, new ResolvedMigrationComparator());
+        Collections.sort(migrations, new ResolvedMigrationComparator(context.getConfiguration().getRepeatableMigrationComparator()));
         return migrations;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/ScanningJavaMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/ScanningJavaMigrationResolver.java
@@ -63,7 +63,7 @@ public class ScanningJavaMigrationResolver implements MigrationResolver {
             migrations.add(new ResolvedJavaMigration(javaMigration));
         }
 
-        Collections.sort(migrations, new ResolvedMigrationComparator());
+        Collections.sort(migrations, new ResolvedMigrationComparator(context.getConfiguration().getRepeatableMigrationComparator()));
         return migrations;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/sql/SqlMigrationResolver.java
@@ -102,7 +102,7 @@ public class SqlMigrationResolver implements MigrationResolver {
 
         );
 
-        Collections.sort(migrations, new ResolvedMigrationComparator());
+        Collections.sort(migrations, new ResolvedMigrationComparator(context.getConfiguration().getRepeatableMigrationComparator()));
         return migrations;
     }
 

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -138,6 +138,12 @@ public class FlywayExtension {
     public Boolean skipDefaultResolvers;
 
     /**
+     * Fully qualified class name of custom Comparator to determine the order of repeatable migrations.
+     * <p>(default: by description)</p>
+     */
+    public String repeatableMigrationComparator;
+
+    /**
      * The file name prefix for versioned SQL migrations. (default: V)
      * <p>Versioned SQL migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
      * which using the defaults translates to V1_1__My_description.sql</p>

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -183,6 +183,12 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     public Boolean skipDefaultResolvers;
 
     /**
+     * Fully qualified class name of custom Comparator to determine the order of repeatable migrations.
+     * <p>(default: by description)</p>
+     */
+    public String repeatableMigrationComparator;
+
+    /**
      * The file name prefix for versioned SQL migrations. (default: V)
      * <p>Versioned SQL migrations have the following file name structure: prefixVERSIONseparatorDESCRIPTIONsuffix ,
      * which using the defaults translates to V1_1__My_description.sql</p>
@@ -671,6 +677,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         putIfSet(conf, ConfigUtils.CALLBACKS, StringUtils.arrayToCommaDelimitedString(callbacks), StringUtils.arrayToCommaDelimitedString(extension.callbacks));
         putIfSet(conf, ConfigUtils.ERROR_OVERRIDES, StringUtils.arrayToCommaDelimitedString(errorOverrides), StringUtils.arrayToCommaDelimitedString(extension.errorOverrides));
 
+        putIfSet(conf, ConfigUtils.REPEATABLE_MIGRATION_COMPARATOR, repeatableMigrationComparator, extension.repeatableMigrationComparator);
         putIfSet(conf, ConfigUtils.DRYRUN_OUTPUT, dryRunOutput, extension.dryRunOutput);
         putIfSet(conf, ConfigUtils.STREAM, stream, extension.stream);
         putIfSet(conf, ConfigUtils.BATCH, batch, extension.batch);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -209,6 +209,13 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private Boolean skipDefaultResolvers;
 
     /**
+     * Fully qualified class name of custom Comparator to determine the order of repeatable migrations.
+     * <p>(default: by description)</p>
+     * <p>Also configurable with Maven or System Property: ${flyway.repeatableMigrationComparator} (Fully qualified class name)</p>
+     */
+    public String repeatableMigrationComparator;
+
+    /**
      * The encoding of Sql migrations. (default: UTF-8)<br> <p>Also configurable with Maven or System Property:
      * ${flyway.encoding}</p>
      */
@@ -719,6 +726,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
             putIfSet(conf, ConfigUtils.BASELINE_DESCRIPTION, baselineDescription);
             putArrayIfSet(conf, ConfigUtils.LOCATIONS, locations);
             putArrayIfSet(conf, ConfigUtils.RESOLVERS, resolvers);
+            putIfSet(conf, ConfigUtils.REPEATABLE_MIGRATION_COMPARATOR, repeatableMigrationComparator);
             putIfSet(conf, ConfigUtils.SKIP_DEFAULT_RESOLVERS, skipDefaultResolvers);
             putArrayIfSet(conf, ConfigUtils.CALLBACKS, callbacks);
             putIfSet(conf, ConfigUtils.SKIP_DEFAULT_CALLBACKS, skipDefaultCallbacks);


### PR DESCRIPTION
I would like to control the order of repeatable migrations. 
In order to do that I suggest a new configuration parameter `repeatableMigrationComparator`, fully qualified class name of custom Comparator to determine the order of repeatable migrations.

By default repeatable migrations are ordered by description. Which means as before if not set.

This doesn't brake the main idea that versioned migrations are always applied before repeatable. The custom Comparator implementation controls only repeatable migration order.

I have found that it might close #2698 .