### PR TITLE
Fix #2843 Multiple $$ string literals 

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLParser.java
@@ -114,6 +114,8 @@ public class PostgreSQLParser extends Parser {
     @SuppressWarnings("Duplicates")
     @Override
     protected Token handleAlternativeStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        // dollarQuote is required because in Postgres, literals encased in $$ can be given a label, as in:
+        // $label$This is a string literal$label$
         String dollarQuote = (char) reader.read() + reader.readUntilIncluding('$');
         reader.swallowUntilExcluding(dollarQuote);
         reader.swallow(dollarQuote.length());

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeParser.java
@@ -21,6 +21,8 @@ import org.flywaydb.core.internal.parser.*;
 import java.io.IOException;
 
 public class SnowflakeParser extends Parser {
+    private final String ALTERNATIVE_QUOTE = "$$";
+
     public SnowflakeParser(Configuration configuration, ParsingContext parsingContext) {
         super(configuration, parsingContext, 2);
     }
@@ -36,9 +38,9 @@ public class SnowflakeParser extends Parser {
 
     @Override
     protected Token handleAlternativeStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
-        String doubleDollarQuote = (char) reader.read() + reader.readUntilIncluding("$$");
-        reader.swallowUntilExcluding(doubleDollarQuote);
-        reader.swallow(doubleDollarQuote.length());
+        reader.swallow(ALTERNATIVE_QUOTE.length());
+        reader.swallowUntilExcluding(ALTERNATIVE_QUOTE);
+        reader.swallow(ALTERNATIVE_QUOTE.length());
         return new Token(TokenType.STRING, pos, line, col, null, null, context.getParensDepth());
     }
 }


### PR DESCRIPTION
Multiple $$...$$ literals were causing the Snowflake parser not to identify statements correctly