### PR TITLE
Placeholder names set by environment variables made case sensitive.

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -113,7 +113,7 @@ public class ConfigUtils {
             String convertedKey = convertKey(entry.getKey());
             if (convertedKey != null) {
                 // Known environment variable
-                result.put(convertKey(entry.getKey()), entry.getValue());
+                result.put(convertedKey, entry.getValue());
             }
         }
 
@@ -215,7 +215,7 @@ public class ConfigUtils {
             return PLACEHOLDER_SUFFIX;
         }
         if (key.matches("FLYWAY_PLACEHOLDERS_.+")) {
-            return PLACEHOLDERS_PROPERTY_PREFIX + key.substring("FLYWAY_PLACEHOLDERS_".length()).toLowerCase(Locale.ENGLISH);
+            return PLACEHOLDERS_PROPERTY_PREFIX + key.substring("FLYWAY_PLACEHOLDERS_".length());
         }
         if ("FLYWAY_REPEATABLE_SQL_MIGRATION_PREFIX".equals(key)) {
             return REPEATABLE_SQL_MIGRATION_PREFIX;


### PR DESCRIPTION
NOTE: this is a second try of pull request after problem with CLA

We use uppercase placeholders like ${TABLESPACE} set in flyway.conf as
flyway.placeholders.TABLESPACE=USERS

then I'v tried to set

export FLYWAY_PLACEHOLDERS_TABLESPACE=USERS

but it hasn't worked because substring after FLYWAY_PLACEHOLDERS_ was lowercased.

This pull request makes setting uppercased placeholders possible, but could potencially breake some projects that set it as uppercase but use as lovercase.

So I'm not sure if my fix is correct one.

Alternativ, case-insensitivity could be added while using placeholders, then it would be irrelevant how we set them.
