### PR TITLE
Perform disk operation in right side of or statement

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
@@ -74,9 +74,8 @@ public class Scanner<I> implements ResourceProvider, ClassProvider<I> {
     @Override
     public LoadableResource getResource(String name) {
         for (LoadableResource resource : resources) {
-            String absolutePath = resource.getAbsolutePathOnDisk();
             String relativePath = resource.getRelativePath();
-            if (relativePath.equals(name) || absolutePath.equals(name)) {
+            if (relativePath.equals(name) || resource.getAbsolutePathOnDisk().equals(name)) {
                 return resource;
             }
         }


### PR DESCRIPTION
Hey, realize this isn't fully inline with the contributing guidelines, but the fix is pretty small so I opened a PR without an issue. If that's an issue (haha) I can re-open this.

I noticed with 6.5.3 that an application I have that has a few hundred migrations now takes ~30 seconds (used to be ~2 seconds on 6.5.2) to run in my CI environment (it's an old amazon linux ami, if it matters). Locally (on OSX), performance seems a little worse (~5 seconds -> ~8 seconds). It seems like it's because of commit https://github.com/flyway/flyway/commit/ecfebd2e99f9ac507c3af3627dad6d149dc89335. 

This PR inlines the `getAbsolutePathOnDisk` call to the right side of the `or` statement so it can be skipped when the cheap `getRelativePath` equality check is true.

