### PR TITLE
Configurable s3 client

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -545,7 +545,8 @@ public class Flyway {
                         configuration.getEncoding(),
                         stream,
                         resourceNameCache,
-                        locationScannerCache
+                        locationScannerCache,
+                        configuration.getS3Client()
                 );
                 // set the defaults
                 resourceProvider = scanner;

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -32,6 +32,7 @@ import org.flywaydb.core.internal.scanner.ClasspathClassScanner;
 import org.flywaydb.core.internal.util.ClassUtils;
 import org.flywaydb.core.internal.util.Locations;
 import org.flywaydb.core.internal.util.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import javax.sql.DataSource;
 import java.io.File;
@@ -433,6 +434,11 @@ public class ClassicConfiguration implements Configuration {
      */
     private boolean createSchemas = true;
 
+    /**
+     * If set, can be used to override the default S3Client used by the AwsS3Scanner
+     */
+    private S3Client s3Client;
+
 
 
 
@@ -822,6 +828,15 @@ public class ClassicConfiguration implements Configuration {
 
 
 
+    }
+
+    /**
+     * Returns custom S3 client, if configured
+     * @return
+     */
+    @Override
+    public S3Client getS3Client() {
+        return s3Client;
     }
 
     /**
@@ -1849,6 +1864,15 @@ public class ClassicConfiguration implements Configuration {
 
 
 
+    }
+
+    /**
+     * Sets a custom s3 client to be used
+     *
+     * @param client
+     */
+    public void setS3Client(S3Client client) {
+       this.s3Client = client;
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.ClassProvider;
 import org.flywaydb.core.api.ResourceProvider;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import javax.sql.DataSource;
 import java.io.OutputStream;
@@ -594,4 +595,9 @@ public interface Configuration {
      * @return Properties that will be passed to the JDBC driver object
      */
     Map<String, String> getJdbcProperties();
+
+    /**
+     * Returns custom S3 client, if configured
+     */
+    S3Client getS3Client();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -1093,7 +1093,7 @@ public class FluentConfiguration implements Configuration {
     }
 
     /**
-     * S3 Client to use for pulling files
+     * Set custom S3 Client
      *
      * @param client The client to use for storing
      */

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -27,6 +27,7 @@ import org.flywaydb.core.api.ClassProvider;
 import org.flywaydb.core.internal.configuration.ConfigUtils;
 import org.flywaydb.core.api.ResourceProvider;
 import org.flywaydb.core.internal.util.ClassUtils;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import javax.sql.DataSource;
 import java.io.File;
@@ -340,6 +341,11 @@ public class FluentConfiguration implements Configuration {
     @Override
     public Map<String, String> getJdbcProperties() {
         return config.getJdbcProperties();
+    }
+
+    @Override
+    public S3Client getS3Client() {
+        return config.getS3Client();
     }
 
     /**
@@ -1083,6 +1089,16 @@ public class FluentConfiguration implements Configuration {
      */
     public FluentConfiguration jdbcProperties(Map<String,String> jdbcProperties) {
         config.setJdbcProperties(jdbcProperties);
+        return this;
+    }
+
+    /**
+     * S3 Client to use for pulling files
+     *
+     * @param client The client to use for storing
+     */
+    public FluentConfiguration s3Client(S3Client client) {
+        config.setS3Client(client);
         return this;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
@@ -31,6 +31,7 @@ import org.flywaydb.core.internal.scanner.cloud.gcs.GCSScanner;
 import org.flywaydb.core.internal.scanner.cloud.s3.AwsS3Scanner;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
@@ -54,7 +55,7 @@ public class Scanner<I> implements ResourceProvider, ClassProvider<I> {
      */
     public Scanner(Class<I> implementedInterface, Collection<Location> locations, ClassLoader classLoader, Charset encoding,
                    boolean stream,
-                   ResourceNameCache resourceNameCache, LocationScannerCache locationScannerCache
+                   ResourceNameCache resourceNameCache, LocationScannerCache locationScannerCache, S3Client s3Client
     ) {
         FileSystemScanner fileSystemScanner = new FileSystemScanner(encoding, stream);
 
@@ -79,9 +80,9 @@ public class Scanner<I> implements ResourceProvider, ClassProvider<I> {
 
             } else if (location.isAwsS3()) {
                 if (aws) {
-                    Collection<LoadableResource> awsResources = new AwsS3Scanner(encoding).scanForResources(location);
+                    Collection<LoadableResource> awsResources = new AwsS3Scanner(encoding, s3Client).scanForResources(location);
                     resources.addAll(awsResources);
-                    cloudMigrationCount += awsResources.stream().filter(r -> r.getFilename().endsWith(".sql")).count();;
+                    cloudMigrationCount += awsResources.stream().filter(r -> r.getFilename().endsWith(".sql")).count();
                 } else {
                     LOG.error("Can't read location " + location + "; AWS SDK not found");
                 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/cloud/s3/AwsS3Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/cloud/s3/AwsS3Scanner.java
@@ -37,7 +37,7 @@ public class AwsS3Scanner extends CloudScanner {
 
     private static final Log LOG = LogFactory.getLog(AwsS3Scanner.class);
 
-    private S3Client client;
+    private final S3Client client;
 
     /**
      * Creates a new AWS S3 scanner.


### PR DESCRIPTION
Added ability to provide a custom configured S3 Client, and also removed the block explicitly requiring AWS creds provided via env, per https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html I don't believe that is strictly necessary.  Better to leave it up to the developer on how they handle authentication to S3.