### PR TITLE
Fixed broken support for CockroachDB versions >= 20.* caused by broken table already exists detection

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBDatabase.java
@@ -71,7 +71,7 @@ public class CockroachDBDatabase extends Database<CockroachDBConnection> {
 
     @Override
     public String getRawCreateScript(Table table, boolean baseline) {
-        return "CREATE TABLE " + table + " (\n" +
+        return "CREATE TABLE IF NOT EXISTS " + table + " (\n" +
                 "    \"installed_rank\" INT NOT NULL PRIMARY KEY,\n" +
                 "    \"version\" VARCHAR(50),\n" +
                 "    \"description\" VARCHAR(200) NOT NULL,\n" +
@@ -84,7 +84,7 @@ public class CockroachDBDatabase extends Database<CockroachDBConnection> {
                 "    \"success\" BOOLEAN NOT NULL\n" +
                 ");\n" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "") +
-                "CREATE INDEX \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
+                "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
     }
 
     @Override


### PR DESCRIPTION
CockroachDB has a unique approach to the conception of schemas and databases which is well documented at [1]. Unfortunately, the existing implementation of [`CockroachDBTable.doExistsOnce()`](https://github.com/flyway/flyway/blob/flyway-6.5.6/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBTable.java#L82) is broken and will always return `false` for tables which are not part of the connection's default database (e.g. `defaultdb`).

With this PR this bug is fixed (at least for CockroachDB >= 2) by explicitly prefixing the `information_schema` schema with the table's database (schema).

[1] https://www.cockroachlabs.com/docs/stable/sql-name-resolution.htm 