### PR TITLE
issue 2932: CockroachDB: lock indicator is persisted in table and prevents application to start

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
@@ -164,6 +164,32 @@ public class JdbcTemplate {
      * @return The query result.
      * @throws SQLException when the query execution failed.
      */
+    public long queryForLong(String query, String... params) throws SQLException {
+        PreparedStatement statement = null;
+        ResultSet resultSet = null;
+
+        long result;
+        try {
+            statement = prepareStatement(query, params);
+            resultSet = statement.executeQuery();
+            resultSet.next();
+            result = resultSet.getLong(1);
+        } finally {
+            JdbcUtils.closeResultSet(resultSet);
+            JdbcUtils.closeStatement(statement);
+        }
+
+        return result;
+    }
+
+    /**
+     * Executes this query with these parameters against this connection.
+     *
+     * @param query  The query to execute.
+     * @param params The query parameters.
+     * @return The query result.
+     * @throws SQLException when the query execution failed.
+     */
     public boolean queryForBoolean(String query, String... params) throws SQLException {
         PreparedStatement statement = null;
         ResultSet resultSet = null;


### PR DESCRIPTION
Added 1 hour expiration timeout to clean table out if owner of lock was restarted when lock obtained. Getting an existing lock time and check if it's expired already. If table lock was obtained more than current timestamp + 1 hour, then remove the table lock.

Currently, it may lead to 2 situations:
1. Long run migration maybe interrupted by other one
2. Service will not be able to start before 1hour timeout is expired.