### PR TITLE
Fix #2957: make software.amazon.awssdk:s3 optional in POM

### DIFF
--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
see #2957

@MikielAgutu