### PR TITLE
Add Support for CockroachDB 20.2

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBConnection.java
@@ -15,6 +15,7 @@
  */
 package org.flywaydb.core.internal.database.cockroachdb;
 
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.internal.database.base.Connection;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
@@ -30,6 +31,23 @@ public class CockroachDBConnection extends Connection<CockroachDBDatabase> {
         super(database, connection);
     }
 
+
+    @Override
+    public Schema doGetCurrentSchema() throws SQLException {
+        if ( database.getVersion().isAtLeast("20.2") ) {
+            String currentSchema = jdbcTemplate.queryForString("SELECT current_schema");
+            if (StringUtils.hasText(currentSchema)) {
+                return getSchema(currentSchema);
+            }
+        }
+        String searchPath = getCurrentSchemaNameOrSearchPath();
+        if (!StringUtils.hasText(searchPath)) {
+            throw new FlywayException("Unable to determine current schema as search_path is empty. " +
+                    "Set the current schema in currentSchema parameter of the JDBC URL or in Flyway's schemas property.");
+        }
+        return getSchema(searchPath);
+    }
+
     @Override
     public Schema getSchema(String name) {
         return new CockroachDBSchema(jdbcTemplate, database, name);
@@ -37,7 +55,11 @@ public class CockroachDBConnection extends Connection<CockroachDBDatabase> {
 
     @Override
     protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
-        return jdbcTemplate.queryForString("SHOW database");
+        if ( database.getVersion().isAtLeast("20.2") ) {
+            return jdbcTemplate.queryForString("SHOW search_path");
+        } else {
+            return jdbcTemplate.queryForString("SHOW database");
+        }
     }
 
     @Override
@@ -49,15 +71,15 @@ public class CockroachDBConnection extends Connection<CockroachDBDatabase> {
             }
             doChangeCurrentSchemaOrSearchPathTo(schema.getName());
         } catch (SQLException e) {
-            throw new FlywaySqlException("Error setting current database to " + schema, e);
+            throw new FlywaySqlException("Error setting current schema to " + schema, e);
         }
     }
 
     @Override
     public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
         if (!StringUtils.hasLength(schema)) {
-            schema = "DEFAULT";
+            schema = "public";
         }
-        jdbcTemplate.execute("SET database = " + schema);
+        jdbcTemplate.execute("SET search_path = " + schema);
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBSchema.java
@@ -38,6 +38,11 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     final boolean cockroachDB1;
 
     /**
+     * Is this CockroachDB >= 20.2
+     */
+    final boolean hasSchemaSupport;
+
+    /**
      * Creates a new CockroachDB schema.
      *
      * @param jdbcTemplate The Jdbc Template for communicating with the DB.
@@ -47,6 +52,7 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     CockroachDBSchema(JdbcTemplate jdbcTemplate, CockroachDBDatabase database, String name) {
         super(jdbcTemplate, database, name);
         cockroachDB1 = !database.getVersion().isAtLeast("2");
+        hasSchemaSupport = database.getVersion().isAtLeast("20.2");
     }
 
     @Override
@@ -60,6 +66,9 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     }
 
     private boolean doExistsOnce() throws SQLException {
+        if ( hasSchemaSupport ) {
+            return jdbcTemplate.queryForBoolean("SELECT EXISTS ( SELECT 1 FROM information_schema.schemata WHERE schema_name=? )", name);
+        }
         return jdbcTemplate.queryForBoolean("SELECT EXISTS ( SELECT 1 FROM pg_database WHERE datname=? )", name);
     }
 
@@ -81,19 +90,32 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
                     "  WHERE table_schema=?" +
                     "  AND table_type='BASE TABLE'" +
                     ")", name);
+        } else if ( ! hasSchemaSupport ) {
+            return !jdbcTemplate.queryForBoolean("SELECT EXISTS (" +
+                    "  SELECT 1" +
+                    "  FROM information_schema.tables " +
+                    "  WHERE table_catalog=?" +
+                    "  AND table_schema='public'" +
+                    "  AND table_type='BASE TABLE'" +
+                    " UNION ALL" +
+                    "  SELECT 1" +
+                    "  FROM information_schema.sequences " +
+                    "  WHERE sequence_catalog=?" +
+                    "  AND sequence_schema='public'" +
+                    ")", name, name);
+        } else {
+            return !jdbcTemplate.queryForBoolean("SELECT EXISTS (" +
+                    "  SELECT 1" +
+                    "  FROM information_schema.tables " +
+                    "  WHERE table_schema=?" +
+                    "  AND table_type='BASE TABLE'" +
+                    " UNION ALL" +
+                    "  SELECT 1" +
+                    "  FROM information_schema.sequences " +
+                    "  WHERE sequence_schema=?" +
+                    ")", name, name);
         }
-        return !jdbcTemplate.queryForBoolean("SELECT EXISTS (" +
-                "  SELECT 1" +
-                "  FROM information_schema.tables " +
-                "  WHERE table_catalog=?" +
-                "  AND table_schema='public'" +
-                "  AND table_type='BASE TABLE'" +
-                " UNION ALL" +
-                "  SELECT 1" +
-                "  FROM information_schema.sequences " +
-                "  WHERE sequence_catalog=?" +
-                "  AND sequence_schema='public'" +
-                ")", name, name);
+
     }
 
     @Override
@@ -108,7 +130,11 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     }
 
     protected void doCreateOnce() throws SQLException {
-        jdbcTemplate.execute("CREATE DATABASE " + database.quote(name));
+        if ( hasSchemaSupport ) {
+            jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS " + database.quote(name));
+        } else {
+            jdbcTemplate.execute("CREATE DATABASE IF NOT EXISTS " + database.quote(name));
+        }
     }
 
     @Override
@@ -123,7 +149,12 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     }
 
     protected void doDropOnce() throws SQLException {
-        jdbcTemplate.execute("DROP DATABASE " + database.quote(name));
+        if ( hasSchemaSupport ) {
+            jdbcTemplate.execute("DROP SCHEMA IF EXISTS " + database.quote(name));
+        } else {
+            jdbcTemplate.execute("DROP DATABASE IF EXISTS " + database.quote(name));
+        }
+
     }
 
     @Override
@@ -158,7 +189,11 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
      * @throws SQLException when the clean statements could not be generated.
      */
     private List<String> generateDropStatementsForViews() throws SQLException {
-        List<String> names =
+        List<String> names = hasSchemaSupport ?
+                jdbcTemplate.queryForStringList(
+                        "SELECT table_name FROM information_schema.views" +
+                                " WHERE table_schema=?", name)
+                :
                 jdbcTemplate.queryForStringList(
                         "SELECT table_name FROM information_schema.views" +
                                 " WHERE table_catalog=? AND table_schema='public'", name);
@@ -177,7 +212,11 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
      * @throws SQLException when the clean statements could not be generated.
      */
     private List<String> generateDropStatementsForSequences() throws SQLException {
-        List<String> names =
+        List<String> names = hasSchemaSupport ?
+                jdbcTemplate.queryForStringList(
+                        "SELECT sequence_name FROM information_schema.sequences" +
+                                " WHERE sequence_schema=?", name)
+                :
                 jdbcTemplate.queryForStringList(
                         "SELECT sequence_name FROM information_schema.sequences" +
                                 " WHERE sequence_catalog=? AND sequence_schema='public'", name);
@@ -192,7 +231,7 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
     @Override
     protected CockroachDBTable[] doAllTables() throws SQLException {
         String query;
-        if (cockroachDB1) {
+        if (cockroachDB1 || hasSchemaSupport) {
             query =
                     //Search for all the table names
                     "SELECT table_name FROM information_schema.tables" +

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBSchema.java
@@ -150,7 +150,7 @@ public class CockroachDBSchema extends Schema<CockroachDBDatabase, CockroachDBTa
 
     protected void doDropOnce() throws SQLException {
         if ( hasSchemaSupport ) {
-            jdbcTemplate.execute("DROP SCHEMA IF EXISTS " + database.quote(name));
+            jdbcTemplate.execute("DROP SCHEMA IF EXISTS " + database.quote(name) + " CASCADE");
         } else {
             jdbcTemplate.execute("DROP DATABASE IF EXISTS " + database.quote(name));
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBTable.java
@@ -103,23 +103,15 @@ public class CockroachDBTable extends Table<CockroachDBDatabase, CockroachDBSche
 
     @Override
     protected void doLock() throws SQLException {
-        if ( database.getVersion().isAtLeast("20.1") ) {
-            jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
-        } else {
-            if (lockDepth == 0) {
-                insertRowLock.doLock(jdbcTemplate, database.getInsertStatement(this), database.getBooleanTrue());
-            }
+        if (lockDepth == 0) {
+            insertRowLock.doLock(jdbcTemplate, database.getInsertStatement(this), database.getBooleanTrue());
         }
     }
 
     @Override
     protected void doUnlock() throws SQLException {
-        if ( database.getVersion().isAtLeast("20.1") ) {
-            super.doUnlock();
-        } else {
-            if (lockDepth == 1) {
-                insertRowLock.doUnlock(jdbcTemplate, getDeleteLockTemplate());
-            }
+        if (lockDepth == 1) {
+            insertRowLock.doUnlock(jdbcTemplate, getDeleteLockTemplate());
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBTable.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
  * carrying out a migration.
  */
 public class CockroachDBTable extends Table<CockroachDBDatabase, CockroachDBSchema> {
+
     private final InsertRowLock insertRowLock = new InsertRowLock();
 
     /**
@@ -56,7 +57,7 @@ public class CockroachDBTable extends Table<CockroachDBDatabase, CockroachDBSche
     }
 
     protected void doDropOnce() throws SQLException {
-        jdbcTemplate.execute("DROP TABLE " + database.quote(schema.getName(), name) + " CASCADE");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS " + database.quote(schema.getName(), name) + " CASCADE");
     }
 
     @Override
@@ -70,39 +71,60 @@ public class CockroachDBTable extends Table<CockroachDBDatabase, CockroachDBSche
     }
 
     protected boolean doExistsOnce() throws SQLException {
-        if (schema.cockroachDB1) {
+        if (schema.cockroachDB1 ) {
             return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
                     "   SELECT 1\n" +
                     "   FROM   information_schema.tables \n" +
                     "   WHERE  table_schema = ?\n" +
                     "   AND    table_name = ?\n" +
                     ")", schema.getName(), name);
+        } else if ( !schema.hasSchemaSupport ) {
+            return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
+                    "   SELECT 1\n" +
+                    "   FROM   information_schema.tables \n" +
+                    "   WHERE  table_catalog = ?\n" +
+                    "   AND    table_schema = 'public'\n" +
+                    "   AND    table_name = ?\n" +
+                    ")", schema.getName(), name);
+        } else {
+            // There is a bug in CockroachDB v20.2.0-beta.* which causes the string equality operator to not work as
+            // expected, therefore we apply a workaround using the like operator.
+            // https://github.com/cockroachdb/cockroach/issues/55437
+            String sql = "SELECT EXISTS (\n" +
+                    "   SELECT 1\n" +
+                    "   FROM   information_schema.tables \n" +
+                    "   WHERE  table_schema = ?\n" +
+                    "   AND    table_name like '%"+name+"%' and length(table_name) = length(?)\n" +
+                    ")";
+            return jdbcTemplate.queryForBoolean(sql, schema.getName(), name);
         }
 
-        return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
-                "   SELECT 1\n" +
-                "   FROM   information_schema.tables \n" +
-                "   WHERE  table_catalog = ?\n" +
-                "   AND    table_schema = 'public'\n" +
-                "   AND    table_name = ?\n" +
-                ")", schema.getName(), name);
     }
 
     @Override
     protected void doLock() throws SQLException {
-        if (lockDepth == 0) {
-            insertRowLock.doLock(jdbcTemplate, database.getInsertStatement(this), database.getBooleanTrue());
+        if ( database.getVersion().isAtLeast("20.1") ) {
+            jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
+        } else {
+            if (lockDepth == 0) {
+                insertRowLock.doLock(jdbcTemplate, database.getInsertStatement(this), database.getBooleanTrue());
+            }
         }
     }
 
     @Override
     protected void doUnlock() throws SQLException {
-        if (lockDepth == 1) {
-            insertRowLock.doUnlock(jdbcTemplate, getDeleteLockTemplate());
+        if ( database.getVersion().isAtLeast("20.1") ) {
+            super.doUnlock();
+        } else {
+            if (lockDepth == 1) {
+                insertRowLock.doUnlock(jdbcTemplate, getDeleteLockTemplate());
+            }
         }
     }
 
     private String getDeleteLockTemplate() {
         return "DELETE FROM " + this + " WHERE version = '?' AND DESCRIPTION = 'flyway-lock'";
     }
+    
 }


### PR DESCRIPTION
This PR adds support for the upcoming CockroachDB version 20.2, which will support custom schemas (beside the default `public` schema). 