### PR TITLE
Adjust launch script to properly ref local JRE

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -31,8 +31,8 @@ THIS="$0"
 # Detect the installation directory
 INSTALLDIR=`dirname "$THIS"`
 
-if [ -x "${INSTALLDIR}/jre/bin/java" ]; then
- JAVA_CMD=${INSTALLDIR}/jre/bin/java
+if [ -x "${INSTALLDIR}jre/bin/java" ]; then
+ JAVA_CMD=${INSTALLDIR}jre/bin/java
 else
  # Use JAVA_HOME if it is set
  if [ -z "$JAVA_HOME" ]; then JAVA_CMD=java; else JAVA_CMD=$JAVA_HOME/bin/java; fi

--- a/flyway-commandline/src/main/assembly/flyway
+++ b/flyway-commandline/src/main/assembly/flyway
@@ -31,8 +31,8 @@ THIS="$0"
 # Detect the installation directory
 INSTALLDIR=`dirname "$THIS"`
 
-if [ -x "$INSTALLDIR/jre/bin/java" ]; then
- JAVA_CMD=$INSTALLDIR/jre/bin/java
+if [ -x "${INSTALLDIR}/jre/bin/java" ]; then
+ JAVA_CMD=${INSTALLDIR}/jre/bin/java
 else
  # Use JAVA_HOME if it is set
  if [ -z "$JAVA_HOME" ]; then JAVA_CMD=java; else JAVA_CMD=$JAVA_HOME/bin/java; fi


### PR DESCRIPTION
Bash script to start doesn't properly reference the bundled JRE. Change should be cross-distro safe, if my bashfu isn't so obsolete.

Error was:
```/usr/local/bin/flyway: line 83: //flyway-7.2.0/jre/bin/java: No such file or directory```

These tweaks make it go away :) 