### PR TITLE
Fix  https://github.com/flyway/flyway/issues/3084

### DIFF
--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -683,10 +683,14 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         if (extension.configurations != null) {
             return extension.configurations;
         }
-        if (getProject().getGradle().getGradleVersion().startsWith("3")) {
-            return DEFAULT_CONFIGURATIONS_GRADLE3;
+        if (isJavaProject()) {
+            if (getProject().getGradle().getGradleVersion().startsWith("3")) {
+                return DEFAULT_CONFIGURATIONS_GRADLE3;
+            }
+            return DEFAULT_CONFIGURATIONS_GRADLE45;
+        } else {
+            return new String[0];
         }
-        return DEFAULT_CONFIGURATIONS_GRADLE45;
     }
 
     /**

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -606,8 +606,9 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             Set<URL> extraURLs = new HashSet<>();
             if (isJavaProject()) {
                 addClassesAndResourcesDirs(extraURLs);
-                addConfigurationArtifacts(determineConfigurations(envVars), extraURLs);
             }
+
+            addConfigurationArtifacts(determineConfigurations(envVars), extraURLs);
 
             ClassLoader classLoader = new URLClassLoader(
                     extraURLs.toArray(new URL[0]),


### PR DESCRIPTION
Allow to load configuration artifacts even when it is not a java project (i.e. one might be running flyway as a submodule without any kind of java dependencies)

I'll upload tomorrow at https://github.com/TarodBOFH/flyway-without-java-bug a version that takes the plugin snapshot from maven local instead with the path applied.

