### PR TITLE
Drop jre7 classifier from postgresql JDBC driver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.oracle>19.6.0.0</version.oracle>
         <version.osgi>4.3.1</version.osgi>
         <version.p6spy>3.9.1</version.p6spy>
-        <version.postgresql>42.2.19.jre7</version.postgresql>
+        <version.postgresql>42.2.19</version.postgresql>
         <version.redshift>1.2.10.1009</version.redshift>
         <version.sap>2.6.30</version.sap>
         <version.slf4j>1.7.30</version.slf4j>


### PR DESCRIPTION
As mentioned in https://github.com/flyway/flyway/commit/a912d87eb5dacb2a4b83bbed5f42e03b71519419#r48670327 - I'd rather have this driver version...