### PR TITLE
Add BigQuery support 

### DIFF
--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -40,6 +40,7 @@
 # SQLite            : jdbc:sqlite:<database>
 # Sybase ASE        : jdbc:jtds:sybase://<host>:<port>/<database>
 # Redshift*         : jdbc:redshift://<host>:<port>/<database>
+# BigQuery*         : jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=<project_id>;OAuthType=0;OAuthServiceAcctEmail=<service_account_name>;OAuthPvtKeyPath=<path_to_service_account>;
 # flyway.url=
 
 # Fully qualified classname of the JDBC driver (autodetected by default based on flyway.url)

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.database.base.DatabaseType;
 import org.flywaydb.core.internal.database.base.TestContainersDatabaseType;
+import org.flywaydb.core.internal.database.bigquery.BigQueryDatabaseType;
 import org.flywaydb.core.internal.database.cockroachdb.CockroachDBDatabaseType;
 import org.flywaydb.core.internal.database.db2.DB2DatabaseType;
 import org.flywaydb.core.internal.database.derby.DerbyDatabaseType;
@@ -76,6 +77,7 @@ public class DatabaseTypeRegister {
             registeredDatabaseTypes.add(new RedshiftDatabaseType());
             registeredDatabaseTypes.add(new MariaDBDatabaseType());
 
+            registeredDatabaseTypes.add(new BigQueryDatabaseType());
             registeredDatabaseTypes.add(new DB2DatabaseType());
             registeredDatabaseTypes.add(new DerbyDatabaseType());
             registeredDatabaseTypes.add(new FirebirdDatabaseType());

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/DatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/DatabaseType.java
@@ -56,15 +56,32 @@ public abstract class DatabaseType {
     public abstract String getName();
 
     /**
-     * @return The JDBC type used to represent {@code null} in prepared statements.
+     * @return The JDBC type used to represent generic {@code null} in prepared statements.
      */
     public abstract int getNullType();
 
 
+    /**
+     * @return The JDBC type used to represent String {@code null} in prepared statements.
+     */
+    public int getStringNullType() {
+        return this.getNullType();
+    }
 
 
+    /**
+     * @return The JDBC type used to represent Integer {@code null} in prepared statements.
+     */
+    public int getIntegerNullType() {
+        return this.getNullType();
+    }
 
-
+    /**
+     * @return The JDBC type used to represent Boolean {@code null} in prepared statements.
+     */
+    public int getBooleanNullType() {
+        return this.getNullType();
+    }
 
     /**
      * Whether this database type should handle the given JDBC url.

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
@@ -19,7 +19,6 @@ import org.flywaydb.core.internal.database.base.Connection;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.util.StringUtils;
 
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
 /**
@@ -51,16 +50,6 @@ public class BigQueryConnection extends Connection<BigQueryDatabase> {
 
     public String getJdbcClientOption(String option) throws SQLException {
         return getJdbcConnection().getClientInfo(option);
-    }
-
-    public String getProjectIdRegionQualifier() throws SQLException {
-        String projectId = getJdbcClientOption("ProjectId");
-        String projectQualifier = StringUtils.hasText(projectId) ? database.quote(projectId.trim()) + "." : "";
-
-        String location = getJdbcClientOption("Location");
-        String regionQualifier = StringUtils.hasText(location) ? database.quote("region-" + location.trim()) + "." : "";
-
-        return projectQualifier + regionQualifier;
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.database.base.Connection;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.SQLException;
+
+/**
+ * BigQuery connection.
+ */
+public class BigQueryConnection extends Connection<BigQueryDatabase> {
+    BigQueryConnection(BigQueryDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    // FIXME Remove useless code
+    private String getProjectID() throws SQLException {
+        return jdbcTemplate.queryForString("SELECT @@project_id");
+    }
+
+    private String getASchemaName() throws SQLException {
+        return jdbcTemplate.queryForString("SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA LIMIT 1");
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
+        // BigQuery doesn't have a concept of current schema. We return a dataset (schema) name.
+        return getASchemaName();
+    }
+
+    @Override
+    public void changeCurrentSchemaTo(Schema schema) {
+        try {
+            if (schema.getName().equals(originalSchemaNameOrSearchPath) || originalSchemaNameOrSearchPath.startsWith(schema.getName() + ",") || !schema.exists()) {
+                return;
+            }
+
+            doChangeCurrentSchemaOrSearchPathTo(schema.toString());
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Error setting current schema to " + schema, e);
+        }
+    }
+
+    @Override
+    public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
+        String sn = jdbcTemplate.queryForString(
+                "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name=? LIMIT 1",
+                schema
+        );
+
+        if (!StringUtils.hasText(sn)) {
+            throw new SQLException("schema " + schema + " does not exist");
+        }
+    }
+
+    @Override
+    public Schema doGetCurrentSchema() throws SQLException {
+        String schemaName = getCurrentSchemaNameOrSearchPath();
+
+        if (!StringUtils.hasText(schemaName)) {
+            throw new FlywayException("BigQuery does not have any dataset. Please create one.");
+        }
+
+        return getSchema(schemaName);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new BigQuerySchema(jdbcTemplate, database, name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryConnection.java
@@ -62,7 +62,7 @@ public class BigQueryConnection extends Connection<BigQueryDatabase> {
     @Override
     public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
         String sn = jdbcTemplate.queryForString(
-                "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name=? LIMIT 1",
+                "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name='?' LIMIT 1",
                 schema
         );
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
@@ -15,13 +15,11 @@
  */
 package org.flywaydb.core.internal.database.bigquery;
 
-import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Database;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
-import org.flywaydb.core.internal.util.AbbreviationUtils;
 import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.Connection;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * BigQuery database.
+ */
+public class BigQueryDatabase extends Database<BigQueryConnection> {
+    /**
+     * Creates a new instance.
+     *
+     * @param configuration The Flyway configuration.
+     */
+    public BigQueryDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected BigQueryConnection doGetConnection(Connection connection) {
+        return new BigQueryConnection(this, connection);
+    }
+
+    @Override
+    public final void ensureSupported() {
+        // Always latest BigQuery version.
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "CREATE TABLE " + table + " (\n" +
+                "    `installed_rank` INT64 NOT NULL,\n" +
+                "    `version` STRING,\n" +
+                "    `description` STRING NOT NULL,\n" +
+                "    `type` STRING NOT NULL,\n" +
+                "    `script` STRING NOT NULL,\n" +
+                "    `checksum` INT64,\n" +
+                "    `installed_by` STRING NOT NULL,\n" +
+                "    `installed_on` TIMESTAMP,\n" + // BigQuery does not support default value
+                "    `execution_time` INT64 NOT NULL,\n" +
+                "    `success` BOOL NOT NULL\n" +
+                ");\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "");
+    }
+
+    @Override
+    protected String doGetCurrentUser() throws SQLException {
+        return getMainConnection().getJdbcTemplate().queryForString("SELECT SESSION_USER() as user;");
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        // Cannot find any evidence, assume to be false. But each DML statement has an implicit transaction.
+        return false;
+    }
+
+    @Override
+    public boolean supportsChangingCurrentSchema() {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "TRUE";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "FALSE";
+    }
+
+    @Override
+    public String doQuote(String identifier) {
+        return bigQueryQuote(identifier);
+    }
+
+    static String bigQueryQuote(String identifier) {
+        return "`" + StringUtils.replaceAll(identifier, "`", "\\`") + "`";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return false;
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        return false;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
@@ -106,7 +106,12 @@ public class BigQueryDatabase extends Database<BigQueryConnection> {
     }
 
     @Override
-    public boolean useSingleConnection() {
+    public boolean supportsMultiStatementTransactions() {
         return false;
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        return true;
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabase.java
@@ -15,11 +15,13 @@
  */
 package org.flywaydb.core.internal.database.bigquery;
 
+import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Database;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.util.AbbreviationUtils;
 import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.Connection;
@@ -64,6 +66,25 @@ public class BigQueryDatabase extends Database<BigQueryConnection> {
                 ");\n" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "");
     }
+
+    @Override
+    public String getInsertStatement(Table table) {
+        // Explicitly set installed_on to CURRENT_TIMESTAMP().
+        return "INSERT INTO " + table
+                + " (" + quote("installed_rank")
+                + ", " + quote("version")
+                + ", " + quote("description")
+                + ", " + quote("type")
+                + ", " + quote("script")
+                + ", " + quote("checksum")
+                + ", " + quote("installed_by")
+                + ", " + quote("installed_on")
+                + ", " + quote("execution_time")
+                + ", " + quote("success")
+                + ")"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP(), ?, ?)";
+    }
+
 
     @Override
     protected String doGetCurrentUser() throws SQLException {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.DatabaseType;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.util.ClassUtils;
+
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.Map;
+
+public class BigQueryDatabaseType extends DatabaseType {
+    private static final String BIGQUERY_JDBC42_DRIVER = "com.simba.googlebigquery.jdbc42.Driver";
+    private static final String BIGQUERY_JDBC_DRIVER = "com.simba.googlebigquery.jdbc.Driver";
+
+    @Override
+    public String getName() {
+        return "BigQuery";
+    }
+
+    @Override
+    public int getNullType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:bigquery:");
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return BIGQUERY_JDBC42_DRIVER;
+    }
+
+    @Override
+    public String getBackupDriverClass(String url, ClassLoader classLoader) {
+        if (ClassUtils.isPresent(BIGQUERY_JDBC_DRIVER, classLoader)) {
+            return BIGQUERY_JDBC_DRIVER;
+        }
+        return BIGQUERY_JDBC_DRIVER;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        // https://cloud.google.com/bigquery/docs/reference/odbc-jdbc-drivers
+        System.out.println("DEBUGGY " + databaseProductName + " " + databaseProductVersion);
+        return databaseProductName.toLowerCase().startsWith("bigquery");
+    }
+
+    @Override
+    public void setOverridingConnectionProps(Map<String, String> props) {}
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new BigQueryDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new BigQueryParser(configuration, parsingContext);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
@@ -46,6 +46,21 @@ public class BigQueryDatabaseType extends DatabaseType {
     }
 
     @Override
+    public int getStringNullType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public int getIntegerNullType() {
+        return Types.INTEGER;
+    }
+
+    @Override
+    public int getBooleanNullType() {
+        return Types.BOOLEAN;
+    }
+
+    @Override
     public boolean handlesJDBCUrl(String url) {
         return url.startsWith("jdbc:bigquery:");
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
@@ -64,8 +64,8 @@ public class BigQueryDatabaseType extends DatabaseType {
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
         // https://cloud.google.com/bigquery/docs/reference/odbc-jdbc-drivers
-        System.out.println("DEBUGGY " + databaseProductName + " " + databaseProductVersion);
-        return databaseProductName.toLowerCase().startsWith("bigquery");
+        // databaseProductName: Google BigQuery 2.0, databaseProductVersion: 2.0
+        return databaseProductName.toLowerCase().contains("bigquery");
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
@@ -40,7 +40,7 @@ public class BigQueryDatabaseType extends DatabaseType {
 
     @Override
     public int getNullType() {
-        return Types.VARCHAR;
+        return Types.NULL;
     }
 
     @Override
@@ -55,7 +55,7 @@ public class BigQueryDatabaseType extends DatabaseType {
 
     @Override
     public String getBackupDriverClass(String url, ClassLoader classLoader) {
-        if (ClassUtils.isPresent(BIGQUERY_JDBC_DRIVER, classLoader)) {
+        if(ClassUtils.isPresent(BIGQUERY_JDBC_DRIVER, classLoader)) {
             return BIGQUERY_JDBC_DRIVER;
         }
         return BIGQUERY_JDBC_DRIVER;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryDatabaseType.java
@@ -28,10 +28,12 @@ import org.flywaydb.core.internal.util.ClassUtils;
 import java.sql.Connection;
 import java.sql.Types;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class BigQueryDatabaseType extends DatabaseType {
     private static final String BIGQUERY_JDBC42_DRIVER = "com.simba.googlebigquery.jdbc42.Driver";
     private static final String BIGQUERY_JDBC_DRIVER = "com.simba.googlebigquery.jdbc.Driver";
+    private static final Pattern oAuthPattern = Pattern.compile("OAuth\\w+=([^;]*)", Pattern.CASE_INSENSITIVE);
 
     @Override
     public String getName() {
@@ -49,6 +51,11 @@ public class BigQueryDatabaseType extends DatabaseType {
     }
 
     @Override
+    public Pattern getJDBCCredentialsPattern() {
+        return oAuthPattern;
+    }
+
+    @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         return BIGQUERY_JDBC42_DRIVER;
     }
@@ -58,7 +65,7 @@ public class BigQueryDatabaseType extends DatabaseType {
         if(ClassUtils.isPresent(BIGQUERY_JDBC_DRIVER, classLoader)) {
             return BIGQUERY_JDBC_DRIVER;
         }
-        return BIGQUERY_JDBC_DRIVER;
+        return null;
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class BigQueryParser extends Parser {
+    private static final Pattern ALTER_CREATE_DROP_REGEX = Pattern.compile("^(ALTER|CREATE|DROP)");
+
+    public BigQueryParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext, 3);
+    }
+
+    @Override
+    protected char getAlternativeStringLiteralQuote() {
+        return '\'';
+    }
+
+    @Override
+    protected Boolean detectCanExecuteInTransaction(String simplifiedStatement, List<Token> keywords) {
+        // DDL cannot be executed in transaction
+        if (ALTER_CREATE_DROP_REGEX.matcher(simplifiedStatement).matches()) {
+            return false;
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    protected Token handleAlternativeStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        String dollarQuote = (char) reader.read() + reader.readUntilIncluding('\'');
+        reader.swallowUntilExcluding(dollarQuote);
+        reader.swallow(dollarQuote.length());
+        return new Token(TokenType.STRING, pos, line, col, null, null, context.getParensDepth());
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
@@ -18,7 +18,6 @@ package org.flywaydb.core.internal.database.bigquery;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
-import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -60,12 +59,12 @@ public class BigQuerySchema extends Schema<BigQueryDatabase, BigQueryTable> {
 
     @Override
     protected void doCreate() throws SQLException {
-        jdbcTemplate.execute("CREATE SCHEMA " + database.quote(name));
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS " + database.quote(name));
     }
 
     @Override
     protected void doDrop() throws SQLException {
-        jdbcTemplate.execute("DROP SCHEMA " + database.quote(name) + " CASCADE");
+        jdbcTemplate.execute("DROP SCHEMA IF EXISTS " + database.quote(name) + " CASCADE");
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.database.bigquery;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.util.StringUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -40,8 +41,11 @@ public class BigQuerySchema extends Schema<BigQueryDatabase, BigQueryTable> {
 
     @Override
     protected boolean doExists() throws SQLException {
+        // Restrict to the specified GCP project and BigQuery region. The region is by default US.
+        String qualifier = database.getMainConnection().getProjectIdRegionQualifier();
+
         return jdbcTemplate.queryForInt(
-                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name='" + name + "'"
+                "SELECT COUNT(*) FROM " + qualifier + "INFORMATION_SCHEMA.SCHEMATA WHERE schema_name='" + name + "'"
         ) > 0;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQuerySchema.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PostgreSQL implementation of Schema.
+ */
+public class BigQuerySchema extends Schema<BigQueryDatabase, BigQueryTable> {
+    /**
+     * Creates a new PostgreSQL schema.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    BigQuerySchema(JdbcTemplate jdbcTemplate, BigQueryDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name=?", name) > 0;
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        // The TABLES table contains one record for each table, view, materialized view, and external table.
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM ?.INFORMATION_SCHEMA.TABLES", name)
+                + jdbcTemplate.queryForInt("SELECT COUNT(*) FROM ?.INFORMATION_SCHEMA.ROUTINES", name)
+                == 0;
+    }
+
+    @Override
+    protected void doCreate() throws SQLException {
+        jdbcTemplate.execute("CREATE SCHEMA " + database.quote(name));
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP SCHEMA " + database.quote(name) + " CASCADE");
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        for (String statement : generateDropStatements("BASE TABLE", "TABLE")) {
+            jdbcTemplate.execute(statement);
+        }
+        for (String statement : generateDropStatements("EXTERNAL", "EXTERNAL TABLE")) {
+            jdbcTemplate.execute(statement);
+        }
+        for (String statement : generateDropStatements("VIEW", "VIEW")) {
+            jdbcTemplate.execute(statement);
+        }
+        for (String statement : generateDropStatements("MATERIALIZED VIEW", "MATERIALIZED VIEW")) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : generateDropStatementsForRoutines("FUNCTION")) {
+            jdbcTemplate.execute(statement);
+        }
+        for (String statement : generateDropStatementsForRoutines("PROCEDURE")) {
+            jdbcTemplate.execute(statement);
+        }
+    }
+
+    /**
+     * Generates the statements for dropping the routines in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     * @param objType The type of object for the DROP statement; FUNCTION or PROCEDURE
+     */
+    private List<String> generateDropStatementsForRoutines(String objType) throws SQLException {
+        List<String> objNames =
+                jdbcTemplate.queryForStringList(
+                        // Search for all functions
+                        "SELECT routine_name FROM `?`.INFORMATION_SCHEMA.ROUTINES WHERE routine_type='?'",
+                        name, objType
+                );
+
+        List<String> statements = new ArrayList<>();
+        for (String objName : objNames) {
+            statements.add("DROP " + objType + " IF EXISTS " + database.quote(name, objName));
+        }
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the TABLE, EXTERNAL TABLE, VIEW, MATERIALIZED VIEW, in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     * @param type The object type, BASE TABLE, EXTERNAL, VIEW, or MATERIALIZED VIEW.
+     * @param objType The type of object for the DROP statement; TABLE, EXTERNAL TABLE, VIEW or MATERIALIZED VIEW.
+     */
+    private List<String> generateDropStatements(String type, String objType) throws SQLException {
+        List<String> names =
+                jdbcTemplate.queryForStringList(
+                        // Search for all views
+                        "SELECT table_name FROM `?`.INFORMATION_SCHEMA.TABLES WHERE table_type='?'",
+                        name, type
+                );
+        List<String> statements = new ArrayList<>();
+        for (String domainName : names) {
+            statements.add("DROP " + objType + " IF EXISTS " + database.quote(name, domainName));
+        }
+
+        return statements;
+    }
+
+    @Override
+    protected BigQueryTable[] doAllTables() throws SQLException {
+        List<String> tableNames =
+                jdbcTemplate.queryForStringList(
+                        //Search for all the table names
+                        "SELECT table_name FROM `?`.INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE'",
+                        name
+                );
+        BigQueryTable[] tables = new BigQueryTable[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new BigQueryTable(jdbcTemplate, database, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new BigQueryTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
@@ -43,9 +43,11 @@ public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
 
     @Override
     protected boolean doExists() throws SQLException {
+        if (!schema.exists()) {
+            return false;
+        }
         return jdbcTemplate.queryForInt(
-                "SELECT COUNT(*) FROM `?`.INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE' AND table_name=?",
-                schema.getName(), name
+                "SELECT COUNT(*) FROM " + database.quote(schema.getName()) + ".INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE' AND table_name='" + name + "'"
         ) > 0;
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.bigquery;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+
+/**
+ * BigQuery-specific table.
+ */
+public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
+    /**
+     * Creates a new Redshift table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    BigQueryTable(JdbcTemplate jdbcTemplate, BigQueryDatabase database, BigQuerySchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + database.quote(schema.getName(), name));
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt(
+                "SELECT COUNT(*) FROM `?`.INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE' AND table_name=?",
+                schema.getName(), name
+        ) > 0;
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        jdbcTemplate.execute("DELETE FROM " + this + " WHERE FALSE");
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
@@ -25,7 +25,7 @@ import java.sql.SQLException;
  */
 public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
     /**
-     * Creates a new Redshift table.
+     * Creates a new BigQuery table.
      *
      * @param jdbcTemplate The Jdbc Template for communicating with the DB.
      * @param database     The database-specific support.
@@ -43,9 +43,13 @@ public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
 
     @Override
     protected boolean doExists() throws SQLException {
+        /*
+        The simba driver does not respect Location (BigQuery location) configuration.
+        It always checks US multi-region :(.
         if (!schema.exists()) {
             return false;
         }
+        */
         return jdbcTemplate.queryForInt(
                 "SELECT COUNT(*) FROM " + database.quote(schema.getName()) + ".INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE' AND table_name='" + name + "'"
         ) > 0;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
@@ -53,6 +53,6 @@ public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
 
     @Override
     protected void doLock() throws SQLException {
-        jdbcTemplate.execute("DELETE FROM " + this + " WHERE FALSE");
+        // Do nothing as BigQuery does not support table-level lock.
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/BigQueryTable.java
@@ -43,13 +43,9 @@ public class BigQueryTable extends Table<BigQueryDatabase, BigQuerySchema> {
 
     @Override
     protected boolean doExists() throws SQLException {
-        /*
-        The simba driver does not respect Location (BigQuery location) configuration.
-        It always checks US multi-region :(.
         if (!schema.exists()) {
             return false;
         }
-        */
         return jdbcTemplate.queryForInt(
                 "SELECT COUNT(*) FROM " + database.quote(schema.getName()) + ".INFORMATION_SCHEMA.TABLES WHERE table_type='BASE TABLE' AND table_name='" + name + "'"
         ) > 0;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/bigquery/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Private API. No compatibility guarantees provided.
+ */
+package org.flywaydb.core.internal.database.bigquery;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/jdbc/JdbcTemplate.java
@@ -35,9 +35,25 @@ public class JdbcTemplate {
     protected final Connection connection;
 
     /**
-     * The type to assign to a null value.
+     * The type to assign to a generic null value.
      */
     protected final int nullType;
+
+    /**
+     * The type to assign to a String null value.
+     */
+    protected final int stringNullType;
+
+    /**
+     * The type to assign to a Integer null value.
+     */
+    protected final int integerNullType;
+
+    /**
+     * The type to assign to a Boolean null value.
+     */
+    protected final int booleanNullType;
+
 
     /**
      * Creates a new JdbcTemplate.
@@ -56,6 +72,9 @@ public class JdbcTemplate {
     public JdbcTemplate(Connection connection, DatabaseType databaseType) {
         this.connection = connection;
         this.nullType = databaseType.getNullType();
+        this.stringNullType = databaseType.getStringNullType();
+        this.integerNullType = databaseType.getIntegerNullType();
+        this.booleanNullType = databaseType.getBooleanNullType();
     }
 
     /**
@@ -354,11 +373,11 @@ public class JdbcTemplate {
             } else if (params[i] instanceof String){
                 statement.setString(i + 1, params[i].toString());
             } else if (params[i] == JdbcNullTypes.StringNull) {
-                statement.setNull(i + 1, nullType);
+                statement.setNull(i + 1, stringNullType);
             } else if (params[i] == JdbcNullTypes.IntegerNull) {
-                statement.setNull(i + 1, nullType);
+                statement.setNull(i + 1, integerNullType);
             } else if (params[i] == JdbcNullTypes.BooleanNull) {
-                statement.setNull(i + 1, nullType);
+                statement.setNull(i + 1, booleanNullType);
             } else {
                 throw new FlywayException("Unhandled object of type '" + params[i].getClass().getName() + "'. " +
                         "Please contact support or leave an issue on GitHub.");


### PR DESCRIPTION
This PR adds BigQuery support to flyway. A sample configuration file is
```
# Long properties can be split over multiple lines by ending each line with a backslash
flyway.locations=filesystem:<path_to_sql_folder>

flyway.url=jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=<gcp_project_id>;Location=EU;OAuthType=0;OAuthServiceAcctEmail=<sa_name>@<gcp_project_id>.iam.gserviceaccount.com;OAuthPvtKeyPath=<path_to_service_account_key_file.json>;
flyway.user='hello'
flyway.password='world'

flyway.driver=com.simba.googlebigquery.jdbc42.Driver
flyway.jarDirs=<path_enclosing_simba_driver>/SimbaJDBCDriverforGoogleBigQuery42_1.2.16.1020

flyway.schemas=flyway
# The simba JDBC driver always creates schema in the US multi-region (doesn't respect the BigQuery Location configuration).
# So we have to manually create the schema and tell flyway to not create schema.
# Please ignore the warning flyway outputs if you have created the schema in the Location.
flyway.createSchemas=false
```

It supports both versioned and repeatable migrations. The driver can be obtained via [Google Cloud](https://cloud.google.com/bigquery/docs/reference/odbc-jdbc-drivers#current_jdbc_driver_release_12161020). Note BigQuery's limitations in [transactional support](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language#limitations).