### PR TITLE
Allow creation of schema history table on non-empty schemas

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -180,9 +180,11 @@ public class Flyway {
 
                 if (!schemaHistory.exists()) {
                     List<Schema> nonEmptySchemas = new ArrayList<>();
-                    for (Schema schema : schemas) {
-                        if (schema.exists() && !schema.empty()) {
-                            nonEmptySchemas.add(schema);
+                    if (!configuration.allowCreateHistoryOnNonEmptySchemas()) {
+                        for (Schema schema : schemas) {
+                            if (schema.exists() && !schema.empty()) {
+                                nonEmptySchemas.add(schema);
+                            }
                         }
                     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -121,6 +121,7 @@ public class ClassicConfiguration implements Configuration {
     private String[] vaultSecrets;
     private boolean failOnMissingLocations = false;
     private final ClasspathClassScanner classScanner;
+    private boolean allowCreateHistoryOnNonEmptySchemas = false;
 
     public ClassicConfiguration() {
         classScanner = new ClasspathClassScanner(this.classLoader);
@@ -477,6 +478,17 @@ public class ClassicConfiguration implements Configuration {
     @Override
     public String getOracleKerberosCacheFile(){
         return oracleKerberosCacheFile;
+    }
+
+    @Override
+    public boolean allowCreateHistoryOnNonEmptySchemas()
+    {
+        return allowCreateHistoryOnNonEmptySchemas;
+    }
+
+    public void setAllowCreateHistoryOnNonEmptySchemas(boolean allowCreateHistoryOnNonEmptySchemas)
+    {
+        this.allowCreateHistoryOnNonEmptySchemas = allowCreateHistoryOnNonEmptySchemas;
     }
 
     /**
@@ -1609,6 +1621,7 @@ public class ClassicConfiguration implements Configuration {
         setShouldCreateSchemas(configuration.getCreateSchemas());
         setLockRetryCount(configuration.getLockRetryCount());
         setFailOnMissingLocations(configuration.getFailOnMissingLocations());
+        setAllowCreateHistoryOnNonEmptySchemas(configuration.allowCreateHistoryOnNonEmptySchemas());
 
         url = configuration.getUrl();
         user = configuration.getUser();

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -649,4 +649,13 @@ public interface Configuration {
      * @return @{code true} to fail (default: {@code false})
      */
     boolean getFailOnMissingLocations();
+
+    /**
+     * Whether to allow creating the missing schema history table for non-empty schemas.
+     *
+     * Be careful when enabling this as it removes the safety net that ensures Flyway does not migrate the wrong database in case of a configuration mistake!
+     *
+     * @return @{code true} to allow (default: {@code false})
+     */
+    boolean allowCreateHistoryOnNonEmptySchemas();
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -372,6 +372,25 @@ public class FluentConfiguration implements Configuration {
         return config.getFailOnMissingLocations();
     }
 
+    @Override
+    public boolean allowCreateHistoryOnNonEmptySchemas()
+    {
+        return config.allowCreateHistoryOnNonEmptySchemas();
+    }
+
+    /**
+     * Whether to allow creating the missing schema history table for non-empty schemas.
+     *
+     * Be careful when enabling this as it removes the safety net that ensures Flyway does not migrate the wrong database in case of a configuration mistake!
+     *
+     * @param allowCreateHistoryOnNonEmptySchemas true to allow (default: false)
+     */
+    public FluentConfiguration allowCreateHistoryOnNonEmptySchemas(boolean allowCreateHistoryOnNonEmptySchemas)
+    {
+        config.setAllowCreateHistoryOnNonEmptySchemas(allowCreateHistoryOnNonEmptySchemas);
+        return this;
+    }
+
     /**
      * Sets the stream where to output the SQL statements of a migration dry run. {@code null} to execute the SQL statements
      * directly against the database. The stream when be closing when Flyway finishes writing the output.


### PR DESCRIPTION
Allow history table creation on non-empty schemas via a new
configuration. This allows library writers to use Flyway in
an neutral/independent manner without disrupting the main
applications Flyway usage.

A library can set a different history table name, set the
new configuration and run a separate, internal Flyway
instance to do the library's separate migrations.

This is a very safe change as it's opt-in. The default behavior 
remains the same. Users must enable this new behavior.

Note: I don't see any tests in the project but I did test locally 

Closes #3184