### PR TITLE
Support H2 2.0.201 (will break existing H2 1.4.200 support)

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Database.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Database.java
@@ -85,7 +85,7 @@ public class H2Database extends Database<H2Connection> {
     protected MigrationVersion determineVersion() {
         try {
             int buildId = getMainConnection().getJdbcTemplate().queryForInt(
-                    "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME = 'info.BUILD_ID'");
+                    "SELECT SETTING_VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE SETTING_NAME = 'info.BUILD_ID'");
             return MigrationVersion.fromVersion(super.determineVersion().getVersion() + "." + buildId);
         } catch (SQLException e) {
             throw new FlywaySqlException("Unable to determine H2 build ID", e);
@@ -95,7 +95,7 @@ public class H2Database extends Database<H2Connection> {
     private CompatibilityMode determineCompatibilityMode() {
         try {
             String mode = getMainConnection().getJdbcTemplate().queryForString(
-                    "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME = 'MODE'");
+                    "SELECT SETTING_VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE SETTING_NAME = 'MODE'");
             if (mode == null || "".equals(mode))
                 return CompatibilityMode.REGULAR;
             return CompatibilityMode.valueOf(mode);
@@ -117,7 +117,7 @@ public class H2Database extends Database<H2Connection> {
 
         ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("1.4", org.flywaydb.core.internal.license.Edition.ENTERPRISE);
 
-        recommendFlywayUpgradeIfNecessary("1.4.200");
+        recommendFlywayUpgradeIfNecessary("2.0.201");
         supportsDropSchemaCascade = getVersion().isAtLeast("1.4.200");
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
@@ -70,7 +70,7 @@ public class H2Schema extends Schema<H2Database, H2Table> {
             table.drop();
         }
 
-        List<String> sequenceNames = listObjectNames("SEQUENCE", "IS_GENERATED = false");
+        List<String> sequenceNames = listObjectNames("SEQUENCE", "");
         for (String statement : generateDropStatements("SEQUENCE", sequenceNames)) {
             jdbcTemplate.execute(statement);
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Schema.java
@@ -80,12 +80,6 @@ public class H2Schema extends Schema<H2Database, H2Table> {
             jdbcTemplate.execute(statement);
         }
 
-        List<String> aliasNames = jdbcTemplate.queryForStringList(
-                "SELECT ALIAS_NAME FROM INFORMATION_SCHEMA.FUNCTION_ALIASES WHERE ALIAS_SCHEMA = ?", name);
-        for (String statement : generateDropStatements("ALIAS", aliasNames)) {
-            jdbcTemplate.execute(statement);
-        }
-
         List<String> domainNames = listObjectNames("DOMAIN", "");
         if (!domainNames.isEmpty()) {
             if (name.equals(database.getMainConnection().getCurrentSchema().getName())) {


### PR DESCRIPTION
These changes allow flyway to work with the latest HEAD from H2. 

Merging these changes will break H2 1.4.200 support! However they may be useful as a starting point, or for others who are looking to migrate to the newer H2 releases. If there is a way to do this supporting both versions, please let me know.