### PR TITLE
Fix PostgreSQL CopyManager class loading error when flyway API used from WildFly EJB

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLCopyParsedStatement.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLCopyParsedStatement.java
@@ -57,9 +57,22 @@ public class PostgreSQLCopyParsedStatement extends ParsedSqlStatement {
         );
         this.copyData = copyData;
     }
-
+    
     @Override
-    public Results execute(JdbcTemplate jdbcTemplate
+    public Results execute(JdbcTemplate jdbcTemplate) {
+    	Results results;
+    	
+    	try {
+    		results = execute(jdbcTemplate, jdbcTemplate.getConnection().getClass().getClassLoader());
+        } catch (Exception e) {
+        	// In case JBoss module class loader
+        	results = execute(jdbcTemplate, getClass().getClassLoader());
+        }
+    	
+    	return results;
+    }
+
+    public Results execute(JdbcTemplate jdbcTemplate, ClassLoader classLoader
 
 
 
@@ -71,7 +84,6 @@ public class PostgreSQLCopyParsedStatement extends ParsedSqlStatement {
         Method copyManagerCopyInMethod;
         try {
             Connection connection = jdbcTemplate.getConnection();
-            ClassLoader classLoader = connection.getClass().getClassLoader();
 
             Class<?> baseConnectionClass = classLoader.loadClass("org.postgresql.core.BaseConnection");
             baseConnection = connection.unwrap(baseConnectionClass);


### PR DESCRIPTION
Hello

When i try to use flyway migration API from WildFly Standalone session bean on application start i got Exception:
...
Caused by: org.flywaydb.core.api.FlywayException: Unable to find PostgreSQL CopyManager class
	at deployment.service-1.0.ear//org.flywaydb.core.internal.database.postgresql.PostgreSQLCopyParsedStatement.execute(PostgreSQLCopyParsedStatement.java:85)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.executeStatement(DefaultSqlScriptExecutor.java:212)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.execute(DefaultSqlScriptExecutor.java:128)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.executeOnce(SqlMigrationExecutor.java:78)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.lambda$execute$0(SqlMigrationExecutor.java:67)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.database.DefaultExecutionStrategy.execute(DefaultExecutionStrategy.java:27)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.execute(SqlMigrationExecutor.java:66)
	at deployment.service-1.0.ear//org.flywaydb.core.internal.command.DbMigrate.doMigrateGroup(DbMigrate.java:354)
...

WildFly jdbc connection configured using JBoss module - JBoss hand made modules solution with custom classloader.
Standard way to access this module for developer is to add something like this to EJB jar MANIFEST.MF:
Dependencies: org.postgresql

But this is not the case for postgres flyway migrations. While EJB bean can use any class from jdbc driver, migration executor still can't see CopyManager.

Issue was: PostgreSQLCopyParsedStatement.execute(...) method try to load CopyManager class from dataSource connection class loader.

It is good solution for most cases, but it does not work with JBoss modules classloader. To fix this i suggest to try connection class loader first (for most cases) and then try current class loader (to support JBoss/Wildfly EJB)

Tested with WildFly 22.0.1.Final and  JDK 11.0.8
Can be reproduced with docker container:  jboss/wildfly:22.0.1.Final

[FlywayStartup.java.zip](https://github.com/flyway/flyway/files/6639055/FlywayStartup.java.zip)


