### PR TITLE
Make specific PostgreSQL methods visible outside the package.

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLConnection.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Callable;
 public class PostgreSQLConnection extends Connection<PostgreSQLDatabase> {
     private final String originalRole;
 
-    PostgreSQLConnection(PostgreSQLDatabase database, java.sql.Connection connection) {
+    protected PostgreSQLConnection(PostgreSQLDatabase database, java.sql.Connection connection) {
         super(database, connection);
 
         try {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabase.java
@@ -53,7 +53,7 @@ public class PostgreSQLDatabase extends Database<PostgreSQLConnection> {
 
 
     @Override
-    public final void ensureSupported() {
+    public void ensureSupported() {
         ensureDatabaseIsRecentEnough("9.0");
 
         ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("9.5", org.flywaydb.core.internal.license.Edition.ENTERPRISE);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
@@ -38,7 +38,7 @@ public class PostgreSQLSchema extends Schema<PostgreSQLDatabase, PostgreSQLTable
      * @param database     The database-specific support.
      * @param name         The name of the schema.
      */
-    PostgreSQLSchema(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, String name) {
+    protected PostgreSQLSchema(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, String name) {
         super(jdbcTemplate, database, name);
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLTable.java
@@ -32,7 +32,7 @@ public class PostgreSQLTable extends Table<PostgreSQLDatabase, PostgreSQLSchema>
      * @param schema       The schema this table lives in.
      * @param name         The name of the table.
      */
-    PostgreSQLTable(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, PostgreSQLSchema schema, String name) {
+    protected PostgreSQLTable(JdbcTemplate jdbcTemplate, PostgreSQLDatabase database, PostgreSQLSchema schema, String name) {
         super(jdbcTemplate, database, schema, name);
     }
 


### PR DESCRIPTION
This is in relation to the GitHub issue #3214.

**Changes proposed:**

PostgreSQLConnection constructor (not visible outside the package) - is now made _protected_.
PostgreSQLSchema constructor (not visible outside the package) - is now made _protected_.
PostgreSQLTable constructor (not visible outside the package) - is now made _protected_.
PostgreSQLDatabase.ensureSupported() (_final_ method) is now made non-final.

This would help in adding support to new databases which are compatible with PostgreSQL to leverage the already existing implementation of Flyway classes and build upon them.

**Build succeeds with _mvn package_.**