### PR TITLE
Add basic support for YugabyteDB in Flyway

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
@@ -20,6 +20,7 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.database.base.BaseDatabaseType;
 
+import org.flywaydb.core.internal.database.yugabytedb.YugabyteDBDatabaseType;
 import org.flywaydb.core.internal.jdbc.JdbcUtils;
 import org.flywaydb.core.internal.util.StringUtils;
 
@@ -56,6 +57,7 @@ public class DatabaseTypeRegister {
             for (DatabaseType dt : loader) {
                 registeredDatabaseTypes.add(dt);
             }
+            registeredDatabaseTypes.add(new YugabyteDBDatabaseType());
 
             // Sort by preference order
             Collections.sort(registeredDatabaseTypes);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
@@ -20,7 +20,6 @@ import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.database.base.BaseDatabaseType;
 
-import org.flywaydb.core.internal.database.yugabytedb.YugabyteDBDatabaseType;
 import org.flywaydb.core.internal.jdbc.JdbcUtils;
 import org.flywaydb.core.internal.util.StringUtils;
 
@@ -57,7 +56,6 @@ public class DatabaseTypeRegister {
             for (DatabaseType dt : loader) {
                 registeredDatabaseTypes.add(dt);
             }
-            registeredDatabaseTypes.add(new YugabyteDBDatabaseType());
 
             // Sort by preference order
             Collections.sort(registeredDatabaseTypes);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBConnection.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLConnection;
+
+public class YugabyteDBConnection extends PostgreSQLConnection {
+
+    YugabyteDBConnection(YugabyteDBDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new YugabyteDBSchema(jdbcTemplate, (YugabyteDBDatabase) database, name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabase;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+import java.sql.Connection;
+
+public class YugabyteDBDatabase extends PostgreSQLDatabase {
+
+    public YugabyteDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected YugabyteDBConnection doGetConnection(Connection connection) {
+        return new YugabyteDBConnection(this, connection);
+    }
+
+    @Override
+    public void ensureSupported() {
+        // Checks the Postgres version
+        ensureDatabaseIsRecentEnough("11.2");
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
@@ -47,7 +47,7 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
         String selectVersionQueryOutput = getSelectVersionOutput(connection);
-        return Pattern.matches("PostgreSQL \\d{1,2}(\\.\\d{1,2})?-YB-\\d{1,2}(\\.\\d{1,2})?.*", selectVersionQueryOutput);
+        return Pattern.matches("PostgreSQL\\s\\d{1,2}(\\.\\d{1,2})?-YB-\\d{1,2}(\\.\\d{1,2})?.*", selectVersionQueryOutput);
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabaseType;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+import java.sql.Connection;
+
+
+public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
+    @Override
+    public String getName() {
+        return "YugabyteDB";
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        if (databaseProductName.startsWith("PostgreSQL")) {
+            String selectVersionQueryOutput = getSelectVersionOutput(connection);
+            return selectVersionQueryOutput.contains("YB");
+        }
+        return false;
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new YugabyteDBDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new YugabyteDBParser(configuration, parsingContext);
+    }
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBDatabaseType.java
@@ -25,6 +25,7 @@ import org.flywaydb.core.internal.parser.Parser;
 import org.flywaydb.core.internal.parser.ParsingContext;
 
 import java.sql.Connection;
+import java.util.regex.Pattern;
 
 
 public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
@@ -45,11 +46,8 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
 
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
-        if (databaseProductName.startsWith("PostgreSQL")) {
-            String selectVersionQueryOutput = getSelectVersionOutput(connection);
-            return selectVersionQueryOutput.contains("YB");
-        }
-        return false;
+        String selectVersionQueryOutput = getSelectVersionOutput(connection);
+        return Pattern.matches("PostgreSQL \\d{1,2}(\\.\\d{1,2})?-YB-\\d{1,2}(\\.\\d{1,2})?.*", selectVersionQueryOutput);
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBParser.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBParser.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLParser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+public class YugabyteDBParser extends PostgreSQLParser {
+    protected YugabyteDBParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBSchema.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLSchema;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+public class YugabyteDBSchema extends PostgreSQLSchema {
+    /**
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param name         The name of the schema.
+     */
+    public YugabyteDBSchema(JdbcTemplate jdbcTemplate, YugabyteDBDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new YugabyteDBTable(jdbcTemplate, (YugabyteDBDatabase) database, this, tableName);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/YugabyteDBTable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;
+
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLTable;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+public class YugabyteDBTable extends PostgreSQLTable {
+    /**
+     * @param jdbcTemplate The JDBC template for communicating with the DB.
+     * @param database     The database-specific support.
+     * @param schema       The schema this table lives in.
+     * @param name         The name of the table.
+     */
+    public YugabyteDBTable(JdbcTemplate jdbcTemplate, YugabyteDBDatabase database, YugabyteDBSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/package-info.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/yugabytedb/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © Red Gate Software Ltd 2010-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.core.internal.database.yugabytedb;

--- a/flyway-core/src/main/resources/META-INF/services/org.flywaydb.core.internal.database.DatabaseType
+++ b/flyway-core/src/main/resources/META-INF/services/org.flywaydb.core.internal.database.DatabaseType
@@ -18,3 +18,4 @@ org.flywaydb.core.internal.database.sqlserver.synapse.SynapseDatabaseType
 org.flywaydb.core.internal.database.sybasease.SybaseASEJConnectDatabaseType
 org.flywaydb.core.internal.database.sybasease.SybaseASEJTDSDatabaseType
 org.flywaydb.core.internal.database.base.TestContainersDatabaseType
+org.flywaydb.core.internal.database.yugabytedb.YugabyteDBDatabaseType


### PR DESCRIPTION
Adding support for YugabyteDB by extending the Flyway API implementation for PostgreSQL.

APIs overridden in YugabyteDB:

1. Database.ensureSupported()
2. Database.supportsDdlTransactions()
3. BaseDatabaseType.handlesJDBCUrl()
4. BaseDatabaseType.handlesDatabaseProductNameAndVersion()
5. BaseDatabaseType.getPriority()
6. BaseDatabaseType.getName()

Since YugabyteDB also works with PostgreSQL JDBC driver which is already shipped with the Flyway distribution, changes in pom.xml file to include maven coordinates of the driver are not needed.

Tested the changes with commands: info, migrate and clean - as outlined in [this section](https://flywaydb.org/documentation/contribute/contributingDatabaseSupport#getting-started).

Screenshot of the test run via IDE is available [here](https://docs.google.com/document/d/19eXgtK4O6_hWw_ApoPlBAAGww6rvnuiF-ny6rgkm1G4/edit?usp=sharing).

Relevant GitHub Issue: https://github.com/flyway/flyway/issues/3186