### PR TITLE
Supports OpenTelemetry JDBC prefix.

### DIFF
--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/yugabytedb/YugabyteDBDatabaseType.java
@@ -35,7 +35,8 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:")
+                || url.startsWith("jdbc:otel:postgresql:");
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/TestContainersDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/TestContainersDatabaseType.java
@@ -44,13 +44,16 @@ public class TestContainersDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:tc:") || url.startsWith("jdbc:p6spy:tc:");
+        return url.startsWith("jdbc:tc:") || url.startsWith("jdbc:p6spy:tc:") || url.startsWith("jdbc:otel:tc:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:tc:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:tc:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.testcontainers.jdbc.ContainerDatabaseDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cockroachdb/CockroachDBDatabaseType.java
@@ -58,7 +58,8 @@ public class CockroachDBDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:")
+                || url.startsWith("jdbc:otel:postgresql:");
     }
 
     @Override
@@ -71,6 +72,9 @@ public class CockroachDBDatabaseType extends BaseDatabaseType {
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:postgresql:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:postgresql:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.postgresql.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/db2/DB2DatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/db2/DB2DatabaseType.java
@@ -41,13 +41,16 @@ public class DB2DatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:db2:") || url.startsWith("jdbc:p6spy:db2:");
+        return url.startsWith("jdbc:db2:") || url.startsWith("jdbc:p6spy:db2:") || url.startsWith("jdbc:otel:db2:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:db2:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:db2:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.ibm.db2.jcc.DB2Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/derby/DerbyDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/derby/DerbyDatabaseType.java
@@ -43,13 +43,17 @@ public class DerbyDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:derby:") || url.startsWith("jdbc:p6spy:derby:");
+        return url.startsWith("jdbc:derby:") || url.startsWith("jdbc:p6spy:derby:")
+                || url.startsWith("jdbc:otel:derby:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:derby:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:derby:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         if (url.startsWith("jdbc:derby://")) {
             return "org.apache.derby.jdbc.ClientDriver";

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/firebird/FirebirdDatabaseType.java
@@ -42,13 +42,17 @@ public class FirebirdDatabaseType extends BaseDatabaseType {
     @Override
     public boolean handlesJDBCUrl(String url) {
         return url.startsWith("jdbc:firebird:") || url.startsWith("jdbc:firebirdsql:") ||
-               url.startsWith("jdbc:p6spy:firebird:") || url.startsWith("jdbc:p6spy:firebirdsql:");
+               url.startsWith("jdbc:p6spy:firebird:") || url.startsWith("jdbc:p6spy:firebirdsql:") ||
+                url.startsWith("jdbc:otel:firebird:") || url.startsWith("jdbc:otel:firebirdsql:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:firebird:") || url.startsWith("jdbc:p6spy:firebirdsql:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:firebird:") || url.startsWith("jdbc:otel:firebirdsql:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.firebirdsql.jdbc.FBDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2DatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2DatabaseType.java
@@ -40,13 +40,16 @@ public class H2DatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:h2:") || url.startsWith("jdbc:p6spy:h2:");
+        return url.startsWith("jdbc:h2:") || url.startsWith("jdbc:p6spy:h2:") || url.startsWith("jdbc:otel:h2:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:h2:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:h2:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.h2.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/hsqldb/HSQLDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/hsqldb/HSQLDBDatabaseType.java
@@ -40,13 +40,17 @@ public class HSQLDBDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:hsqldb:") || url.startsWith("jdbc:p6spy:hsqldb:");
+        return url.startsWith("jdbc:hsqldb:") || url.startsWith("jdbc:p6spy:hsqldb:")
+                || url.startsWith("jdbc:otel:hsqldb:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:hsqldb:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:hsqldb:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.hsqldb.jdbcDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/informix/InformixDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/informix/InformixDatabaseType.java
@@ -40,13 +40,17 @@ public class InformixDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:informix-sqli:") || url.startsWith("jdbc:p6spy:informix-sqli:");
+        return url.startsWith("jdbc:informix-sqli:") || url.startsWith("jdbc:p6spy:informix-sqli:")
+                || url.startsWith("jdbc:otel:informix-sqli:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:informix-sqli:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:informix-sqli:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.informix.jdbc.IfxDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLDatabaseType.java
@@ -61,7 +61,8 @@ public class MySQLDatabaseType extends BaseDatabaseType {
 
         }
         return url.startsWith("jdbc:mysql:") || url.startsWith("jdbc:google:") ||
-               url.startsWith("jdbc:p6spy:mysql:") || url.startsWith("jdbc:p6spy:google:");
+               url.startsWith("jdbc:p6spy:mysql:") || url.startsWith("jdbc:p6spy:google:") ||
+                url.startsWith("jdbc:otel:mysql:") || url.startsWith("jdbc:otel:google:");
     }
 
     @Override
@@ -73,6 +74,9 @@ public class MySQLDatabaseType extends BaseDatabaseType {
 
         if (url.startsWith("jdbc:p6spy:mysql:") || url.startsWith("jdbc:p6spy:google:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:mysql:") || url.startsWith("jdbc:otel:google:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         if (url.startsWith("jdbc:mysql:")) {
             return "com.mysql.cj.jdbc.Driver";

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/mariadb/MariaDBDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/mariadb/MariaDBDatabaseType.java
@@ -56,7 +56,8 @@ public class MariaDBDatabaseType extends BaseDatabaseType {
             throw new org.flywaydb.core.internal.license.FlywayTeamsUpgradeRequiredException("jdbc-secretsmanager");
 
         }
-        return url.startsWith("jdbc:mariadb:") || url.startsWith("jdbc:p6spy:mariadb:");
+        return url.startsWith("jdbc:mariadb:") || url.startsWith("jdbc:p6spy:mariadb:")
+                || url.startsWith("jdbc:otel:mariadb:");
     }
 
     @Override
@@ -68,6 +69,9 @@ public class MariaDBDatabaseType extends BaseDatabaseType {
 
         if (url.startsWith("jdbc:p6spy:mariadb:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:mariadb:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.mariadb.jdbc.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/oracle/OracleDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/oracle/OracleDatabaseType.java
@@ -65,7 +65,8 @@ public class OracleDatabaseType extends BaseDatabaseType {
             throw new org.flywaydb.core.internal.license.FlywayTeamsUpgradeRequiredException("jdbc-secretsmanager");
 
         }
-        return url.startsWith("jdbc:oracle") || url.startsWith("jdbc:p6spy:oracle");
+        return url.startsWith("jdbc:oracle") || url.startsWith("jdbc:p6spy:oracle")
+                || url.startsWith("jdbc:otel:oracle");
     }
 
     @Override
@@ -82,6 +83,9 @@ public class OracleDatabaseType extends BaseDatabaseType {
 
         if (url.startsWith("jdbc:p6spy:oracle:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:oracle:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "oracle.jdbc.OracleDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLDatabaseType.java
@@ -56,7 +56,8 @@ public class PostgreSQLDatabaseType extends BaseDatabaseType {
             throw new org.flywaydb.core.internal.license.FlywayTeamsUpgradeRequiredException("jdbc-secretsmanager");
 
         }
-        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:")
+                || url.startsWith("jdbc:otel:postgresql:");
     }
 
     @Override
@@ -68,6 +69,9 @@ public class PostgreSQLDatabaseType extends BaseDatabaseType {
 
         if (url.startsWith("jdbc:p6spy:postgresql:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:postgresql:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "org.postgresql.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/redshift/RedshiftDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/redshift/RedshiftDatabaseType.java
@@ -51,13 +51,17 @@ public class RedshiftDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:redshift:") || url.startsWith("jdbc:p6spy:redshift:");
+        return url.startsWith("jdbc:redshift:") || url.startsWith("jdbc:p6spy:redshift:")
+                || url.startsWith("jdbc:otel:redshift:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:redshift:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:redshift:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.amazon.redshift.jdbc42.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/saphana/SAPHANADatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/saphana/SAPHANADatabaseType.java
@@ -41,13 +41,16 @@ public class SAPHANADatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:sap:") || url.startsWith("jdbc:p6spy:sap:");
+        return url.startsWith("jdbc:sap:") || url.startsWith("jdbc:p6spy:sap:") || url.startsWith("jdbc:otel:sap:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:sap:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:sap:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.sap.db.jdbc.Driver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeDatabaseType.java
@@ -47,13 +47,17 @@ public class SnowflakeDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:snowflake:") || url.startsWith("jdbc:p6spy:snowflake:");
+        return url.startsWith("jdbc:snowflake:") || url.startsWith("jdbc:p6spy:snowflake:")
+                || url.startsWith("jdbc:otel:snowflake:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:snowflake:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:snowflake:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "net.snowflake.client.jdbc.SnowflakeDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabaseType.java
@@ -49,13 +49,17 @@ public class SQLiteDatabaseType extends BaseDatabaseType {
     @Override
     public boolean handlesJDBCUrl(String url) {
         return url.startsWith("jdbc:sqlite:") || url.startsWith("jdbc:sqldroid:") ||
-               url.startsWith("jdbc:p6spy:sqlite:") || url.startsWith("jdbc:p6spy:sqldroid:");
+               url.startsWith("jdbc:p6spy:sqlite:") || url.startsWith("jdbc:p6spy:sqldroid:") ||
+                url.startsWith("jdbc:otel:sqlite:") || url.startsWith("jdbc:otel:sqldroid:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:sqlite:") || url.startsWith("jdbc:p6spy:sqldroid:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:sqlite:") || url.startsWith("jdbc:otel:sqldroid:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         if (url.startsWith("jdbc:sqldroid:")) {
             return "org.sqldroid.SQLDroidDriver";

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlserver/SQLServerDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlserver/SQLServerDatabaseType.java
@@ -54,7 +54,8 @@ public class SQLServerDatabaseType extends BaseDatabaseType {
 
         }
         return url.startsWith("jdbc:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:jtds:")) ||
-               url.startsWith("jdbc:p6spy:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:p6spy:jtds:"));
+               url.startsWith("jdbc:p6spy:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:p6spy:jtds:")) ||
+                url.startsWith("jdbc:otel:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:otel:jtds:"));
     }
 
     @Override
@@ -66,6 +67,9 @@ public class SQLServerDatabaseType extends BaseDatabaseType {
 
         if (url.startsWith("jdbc:p6spy:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:p6spy:jtds:"))) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:sqlserver:") || (supportsJTDS() && url.startsWith("jdbc:otel:jtds:"))) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
 
         if (url.startsWith("jdbc:jtds:")) {

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sybasease/SybaseASEJConnectDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sybasease/SybaseASEJConnectDatabaseType.java
@@ -41,13 +41,17 @@ public class SybaseASEJConnectDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:sybase:") || url.startsWith("jdbc:p6spy:sybase:");
+        return url.startsWith("jdbc:sybase:") || url.startsWith("jdbc:p6spy:sybase:")
+                || url.startsWith("jdbc:otel:sybase:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:sybase:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:sybase:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.sybase.jdbc4.jdbc.SybDriver";
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sybasease/SybaseASEJTDSDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sybasease/SybaseASEJTDSDatabaseType.java
@@ -41,13 +41,16 @@ public class SybaseASEJTDSDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:jtds:") || url.startsWith("jdbc:p6spy:jtds:");
+        return url.startsWith("jdbc:jtds:") || url.startsWith("jdbc:p6spy:jtds:") || url.startsWith("jdbc:otel:jtds:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:jtds:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:jtds:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "net.sourceforge.jtds.jdbc.Driver";
     }

--- a/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerDatabaseType.java
+++ b/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerDatabaseType.java
@@ -54,13 +54,17 @@ public class SpannerDatabaseType extends BaseDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return (url.startsWith("jdbc:cloudspanner:") || url.startsWith("jdbc:p6spy:cloudspanner:"));
+        return url.startsWith("jdbc:cloudspanner:") || url.startsWith("jdbc:p6spy:cloudspanner:")
+                || url.startsWith("jdbc:otel:cloudspanner:");
     }
 
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         if (url.startsWith("jdbc:p6spy:cloudspanner:")) {
             return "com.p6spy.engine.spy.P6SpyDriver";
+        }
+        if (url.startsWith("jdbc:otel:cloudspanner:")) {
+            return "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver";
         }
         return "com.google.cloud.spanner.jdbc.JdbcDriver";
     }


### PR DESCRIPTION
This PR adds support for `jdbc:otel:` prefix, which can be used by OpenTelemetry Manual Instrumentation: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jdbc/library.