### PR TITLE
Correctly specify rethrow on error during lock template execution

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLAdvisoryLockTemplate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLAdvisoryLockTemplate.java
@@ -69,7 +69,8 @@ public class PostgreSQLAdvisoryLockTemplate {
             lock();
             return callable.call();
         } catch (SQLException e) {
-            throw new FlywaySqlException("Unable to acquire PostgreSQL advisory lock", e);
+            rethrow = new FlywaySqlException("Unable to acquire PostgreSQL advisory lock", e);
+            throw rethrow;
         } catch (Exception e) {
             if (e instanceof RuntimeException) {
                 rethrow = (RuntimeException) e;


### PR DESCRIPTION
We have encountered an error "Unable to release PostgreSQL advisory lock" during our application start.

Looking through logs it seems that everything worked fine until some point.
We have suspicion that Flyway "swallows" original problem that is "SQLException", by throwing new exception in `finally` block.

This PR specifies `rethrow` (in the same way as done in next `catch` block in same method), so in `unlock` it could be correctly picked up.