### PR TITLE
Fix for #3266: do not attempt to instantiate abstract callbacks

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -1399,8 +1399,11 @@ public class ClassicConfiguration implements Configuration {
     public void loadCallbackLocation(String path, boolean errorOnNotFound) {
         List<String> callbackClasses = classScanner.scanForType(path, Callback.class, errorOnNotFound);
         for (String callback : callbackClasses) {
-            Callback callbackObj = ClassUtils.instantiate(callback, classLoader);
-            this.callbacks.add(callbackObj);
+            Class<? extends Callback> callbackClass = ClassUtils.loadClass(Callback.class, callback, classLoader);
+            if (callbackClass != null) {
+                Callback callbackObj = ClassUtils.instantiate(callback, classLoader);
+                this.callbacks.add(callbackObj);
+            }
         }
     }
 


### PR DESCRIPTION
Skip abstract classes when loading callbacks. Since `ClassUtils.loadClass` catches all throwables, this also "quietly" skips classes for which instantiation was attempted but failed (a warning is logged, but such cases would previously cause `FluentConfiguration::callbacks` to error out).

I have tested this with my application, and I can now have my abstract callback class in the same package as its concrete implementations. I did not see anywhere to add automated test coverage for this, but I would be happy to if there is such a place.