### PR TITLE
Add Trino support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Windows, macOS, Linux, Docker and Java
 Maven and Gradle
 
 #### Supported databases
-Aurora MySQL, Aurora PostgreSQL, Azure Synapse, CockroachDB, DB2, Derby, Firebird, Google BigQuery, Google Cloud Spanner, H2, HSQLDB, Informix, MariaDB, MongoDB, MySQL, Oracle, Percona XtraDB Cluster, PostgreSQL, Redshift, SAP HANA (Including SAP HANA Cloud), SingleStoreDB, Snowflake, SQLite, SQL Server, Sybase ASE, TiDB, TimescaleDB, YugabyteDB
+Aurora MySQL, Aurora PostgreSQL, Azure Synapse, CockroachDB, DB2, Derby, Firebird, Google BigQuery, Google Cloud Spanner, H2, HSQLDB, Informix, MariaDB, MongoDB, MySQL, Oracle, Percona XtraDB Cluster, PostgreSQL, Redshift, SAP HANA (Including SAP HANA Cloud), SingleStoreDB, Snowflake, SQLite, SQL Server, Sybase ASE, TiDB, TimescaleDB, YugabyteDB, Trino
 
 #### Third party plugins
 SBT, Ant, Spring Boot, Grails, Play!, DropWizard, Grunt, Griffon, Ninja, ...

--- a/documentation/Flyway CLI and API/Supported Databases/Trino.md
+++ b/documentation/Flyway CLI and API/Supported Databases/Trino.md
@@ -1,0 +1,48 @@
+---
+subtitle: Trino
+---
+# Trino
+- **Verified Versions:** N/A
+- **Maintainer:** Community
+
+## Supported Versions and Support Levels
+
+{% include database-boilerplate.html %}
+
+## Driver
+
+| Item                               | Details                                                           |
+|------------------------------------|-------------------------------------------------------------------|
+| **URL format**                     | <code>jdbc:trino://<i>host</i>:<i>port</i>/<i>database</i></code> |
+| **SSL support**                    | Not tested                                                        |
+| **Ships with Flyway Command-line** | No                                                                |
+| **Maven Central coordinates**      | `io.trino:trino-jdbc`                                             |
+| **Supported versions**             | `N/A`                                                             |
+| **Default Java class**             | `io.trino.jdbc.TrinoDriver`                                       |
+
+
+## Java Usage
+
+Trino support is a separate dependency for Flyway and must be added to your Java project to access these features.
+
+### Maven
+
+#### Open Source
+
+```xml
+
+<dependency>
+    <groupId>org.flywaydb</groupId>
+    <artifactId>flyway-database-trino</artifactId>
+</dependency>
+```
+
+### Gradle
+
+#### Open Source
+
+```groovy
+dependencies {
+    compile "org.flywaydb:flyway-database-trino"
+}
+```

--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -153,6 +153,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-database-trino</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
 
 
 

--- a/flyway-commandline/src/main/assembly/component.xml
+++ b/flyway-commandline/src/main/assembly/component.xml
@@ -209,6 +209,7 @@
                 <include>org.flywaydb:flyway-database-ignite</include>
                 <include>org.flywaydb:flyway-database-tidb</include>
                 <include>org.flywaydb:flyway-database-yugabytedb</include>
+                <include>org.flywaydb:flyway-database-trino</include>
                 <include>org.flywaydb:flyway-sqlserver</include>
                 <include>org.flywaydb:flyway-singlestore</include>
                 <include>org.flywaydb:flyway-mysql</include>

--- a/flyway-community-db-support/flyway-database-trino/pom.xml
+++ b/flyway-community-db-support/flyway-database-trino/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Red Gate Software Ltd 2010-2024
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.6.0</version>
+    </parent>
+
+    <artifactId>flyway-database-trino</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-jdbc</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoConnection.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoConnection.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.internal.database.base.Connection;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.SQLException;
+
+import static org.flywaydb.community.database.trino.TrinoDatabase.quote;
+
+public class TrinoConnection
+        extends Connection<TrinoDatabase>
+{
+    protected TrinoConnection(TrinoDatabase database, java.sql.Connection connection)
+    {
+        super(database, connection);
+    }
+
+    @Override
+    protected void doRestoreOriginalState()
+    {
+    }
+
+    @Override
+    public Schema doGetCurrentSchema()
+            throws SQLException
+    {
+        String currentSchema = getCurrentSchemaNameOrSearchPath();
+
+        if (!StringUtils.hasText(currentSchema)) {
+            throw new FlywayException("Unable to determine current schema. " +
+                    "Set the current schema with schema parameter of the JDBC URL or with Flyway's schemas property.");
+        }
+
+        return getSchema(currentSchema);
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath()
+            throws SQLException
+    {
+        return jdbcTemplate.queryForString("SELECT CURRENT_SCHEMA");
+    }
+
+    @Override
+    public void changeCurrentSchemaTo(Schema schema)
+    {
+        try {
+            if (schema.getName().equals(originalSchemaNameOrSearchPath) || !schema.exists()) {
+                return;
+            }
+
+            doChangeCurrentSchemaOrSearchPathTo(schema.toString());
+        }
+        catch (SQLException e) {
+            throw new FlywaySqlException("Error setting current schema to " + schema, e);
+        }
+    }
+
+    @Override
+    public void doChangeCurrentSchemaOrSearchPathTo(String schema)
+            throws SQLException
+    {
+        jdbcTemplate.executeStatement("USE " + quote(schema));
+    }
+
+    @Override
+    public Schema getSchema(String name)
+    {
+        return new TrinoSchema(jdbcTemplate, database, name);
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoDatabase.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoDatabase.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class TrinoDatabase
+        extends Database<TrinoConnection>
+{
+    public TrinoDatabase(
+            Configuration configuration,
+            JdbcConnectionFactory jdbcConnectionFactory,
+            StatementInterceptor statementInterceptor)
+    {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected TrinoConnection doGetConnection(Connection connection)
+    {
+        return new TrinoConnection(this, connection);
+    }
+
+    @Override
+    public void ensureSupported(Configuration configuration) {}
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline)
+    {
+        return "CREATE TABLE " + table + " (\n" +
+                "    \"installed_rank\" INT NOT NULL,\n" +
+                "    \"version\" VARCHAR(50),\n" +
+                "    \"description\" VARCHAR(200) NOT NULL,\n" +
+                "    \"type\" VARCHAR(20) NOT NULL,\n" +
+                "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+                "    \"checksum\" INTEGER,\n" +
+                "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+                "    \"installed_on\" TIMESTAMP NOT NULL,\n" +
+                "    \"execution_time\" INTEGER NOT NULL,\n" +
+                "    \"success\" BOOLEAN NOT NULL\n" +
+                ");\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "");
+    }
+
+    @Override
+    public String getInsertStatement(Table table)
+    {
+        return "INSERT INTO " + table
+                + " (" + quote("installed_rank")
+                + ", " + quote("version")
+                + ", " + quote("description")
+                + ", " + quote("type")
+                + ", " + quote("script")
+                + ", " + quote("checksum")
+                + ", " + quote("installed_by")
+                + ", " + quote("installed_on")
+                + ", " + quote("execution_time")
+                + ", " + quote("success")
+                + ")"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, now(), ?, ?)";
+    }
+
+    @Override
+    protected String doGetCurrentUser()
+            throws SQLException
+    {
+        return getMainConnection().getJdbcTemplate().queryForString("SELECT CURRENT_USER");
+    }
+
+    @Override
+    public boolean supportsDdlTransactions()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMultiStatementTransactions()
+    {
+        return false;
+    }
+
+    @Override
+    public String getBooleanTrue()
+    {
+        return "TRUE";
+    }
+
+    @Override
+    public String getBooleanFalse()
+    {
+        return "FALSE";
+    }
+
+    @Override
+    public String doQuote(String identifier)
+    {
+        return quote(identifier);
+    }
+
+    static String quote(String identifier)
+    {
+        return "\"" + StringUtils.replaceAll(identifier, "\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public boolean catalogIsSchema()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean useSingleConnection()
+    {
+        return true;
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoDatabaseType.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoDatabaseType.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.BaseDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.Properties;
+
+public class TrinoDatabaseType
+        extends BaseDatabaseType
+{
+    @Override
+    public String getName()
+    {
+        return "Trino";
+    }
+
+    @Override
+    public int getNullType()
+    {
+        return Types.NULL;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url)
+    {
+        return url.startsWith("jdbc:trino:");
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader)
+    {
+        return "io.trino.jdbc.TrinoDriver";
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(
+            String databaseProductName,
+            String databaseProductVersion,
+            Connection connection)
+    {
+        return databaseProductName.startsWith("Trino");
+    }
+
+    @Override
+    public Database createDatabase(
+            Configuration configuration,
+            JdbcConnectionFactory jdbcConnectionFactory,
+            StatementInterceptor statementInterceptor)
+    {
+        return new TrinoDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(
+            Configuration configuration,
+            ResourceProvider resourceProvider,
+            ParsingContext parsingContext)
+    {
+        return new TrinoParser(configuration, parsingContext);
+    }
+
+    @Override
+    public void setDefaultConnectionProps(String url, Properties props, ClassLoader classLoader)
+    {
+        props.put("source", APPLICATION_NAME);
+    }
+
+    @Override
+    public boolean detectUserRequiredByUrl(String url)
+    {
+        return !url.contains("user=");
+    }
+
+    @Override
+    public boolean detectPasswordRequiredByUrl(String url)
+    {
+        return !url.contains("password=");
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoParser.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+public class TrinoParser
+        extends Parser
+{
+    public TrinoParser(Configuration configuration, ParsingContext parsingContext)
+    {
+        super(configuration, parsingContext, 3);
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoSchema.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoSchema.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrinoSchema
+        extends Schema<TrinoDatabase, TrinoTable>
+{
+    protected TrinoSchema(JdbcTemplate jdbcTemplate, TrinoDatabase database, String name)
+    {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists()
+            throws SQLException
+    {
+        return jdbcTemplate.queryForInt("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name=?", name) > 0;
+    }
+
+    @Override
+    protected boolean doEmpty()
+            throws SQLException
+    {
+        return !jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
+                "    SELECT table_name FROM information_schema.tables t\n" +
+                "    WHERE  t.table_schema = ?\n" +
+                ")", name);
+    }
+
+    @Override
+    protected void doCreate()
+            throws SQLException
+    {
+        jdbcTemplate.executeStatement("CREATE SCHEMA " + TrinoDatabase.quote(name));
+    }
+
+    @Override
+    protected void doDrop()
+            throws SQLException
+    {
+        jdbcTemplate.executeStatement("DROP SCHEMA " + TrinoDatabase.quote(name));
+    }
+
+    @Override
+    protected void doClean()
+            throws SQLException
+    {
+        for (String statement : generateDropStatementsForMaterializedViews()) {
+            jdbcTemplate.executeStatement(statement);
+        }
+
+        for (String statement : generateDropStatementsForViews()) {
+            jdbcTemplate.executeStatement(statement);
+        }
+
+        for (TrinoTable table : allTables()) {
+            table.drop();
+        }
+    }
+
+    /**
+     * Generates the statements for dropping the materialized views in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForMaterializedViews()
+            throws SQLException
+    {
+        List<String> viewNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT table_name FROM information_schema.tables" +
+                                " WHERE table_type = 'BASE TABLE' AND table_schema = ?",
+                        name);
+
+        List<String> statements = new ArrayList<>();
+        for (String domainName : viewNames) {
+            statements.add("DROP MATERIALIZED VIEW IF EXISTS " + database.quote(name, domainName));
+        }
+
+        return statements;
+    }
+
+    /**
+     * Generates the statements for dropping the views in this schema.
+     *
+     * @return The drop statements.
+     * @throws SQLException when the clean statements could not be generated.
+     */
+    private List<String> generateDropStatementsForViews()
+            throws SQLException
+    {
+        List<String> viewNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT table_name FROM information_schema.tables" +
+                                " WHERE table_type = 'VIEW' AND table_schema = ?",
+                        name);
+        List<String> statements = new ArrayList<>();
+        for (String domainName : viewNames) {
+            statements.add("DROP VIEW IF EXISTS " + database.quote(name, domainName));
+        }
+
+        return statements;
+    }
+
+    @Override
+    protected TrinoTable[] doAllTables()
+            throws SQLException
+    {
+        List<String> tableNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT table_name FROM information_schema.tables" +
+                                " WHERE table_type = 'BASE TABLE' AND table_schema = ?",
+                        name);
+        TrinoTable[] tables = new TrinoTable[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new TrinoTable(jdbcTemplate, database, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    @Override
+    public TrinoTable getTable(String tableName)
+    {
+        return new TrinoTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoTable.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/TrinoTable.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.trino;
+
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+
+public class TrinoTable
+        extends Table<TrinoDatabase, TrinoSchema>
+{
+    /**
+     * Creates a new Trino table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database The database-specific support.
+     * @param schema The schema this table lives in.
+     * @param name The name of the table.
+     */
+    protected TrinoTable(
+            JdbcTemplate jdbcTemplate,
+            TrinoDatabase database,
+            TrinoSchema schema,
+            String name)
+    {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doDrop()
+            throws SQLException
+    {
+        jdbcTemplate.executeStatement("DROP TABLE " + database.quote(schema.getName(), name));
+    }
+
+    @Override
+    protected boolean doExists()
+            throws SQLException
+    {
+        return jdbcTemplate.queryForBoolean("SELECT EXISTS (\n" +
+                "  SELECT table_name\n" +
+                "  FROM   information_schema.tables\n" +
+                "  WHERE  table_schema = ?\n" +
+                "  AND    table_name = ?\n" +
+                "  AND    table_type = 'BASE TABLE'\n" +
+                ")", schema.getName(), name);
+    }
+
+    @Override
+    protected void doLock()
+    {
+    }
+}

--- a/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/package-info.java
+++ b/flyway-community-db-support/flyway-database-trino/src/main/java/org/flywaydb/community/database/trino/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Community-supported package. No compatibility guarantees provided.
+ */
+package org.flywaydb.community.database.trino;

--- a/flyway-community-db-support/flyway-database-trino/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-community-db-support/flyway-database-trino/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,1 @@
+org.flywaydb.community.database.trino.TrinoDatabaseType

--- a/flyway-community-db-support/pom.xml
+++ b/flyway-community-db-support/pom.xml
@@ -33,6 +33,7 @@
         <module>flyway-database-tidb</module>
         <module>flyway-database-ignite</module>
         <module>flyway-database-yugabytedb</module>
+        <module>flyway-database-trino</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <version.spanner>2.11.1</version.spanner>
         <version.springjdbc>5.3.19</version.springjdbc>
         <version.sqlite>3.41.2.2</version.sqlite>
+        <version.trino>437</version.trino>
         <version.testcontainers>1.15.3</version.testcontainers>
     </properties>
 
@@ -458,6 +459,12 @@
                 <groupId>com.ibm.informix</groupId>
                 <artifactId>jdbc</artifactId>
                 <version>${version.informix}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-jdbc</artifactId>
+                <version>${version.trino}</version>
                 <optional>true</optional>
             </dependency>
 


### PR DESCRIPTION
Trino (formerly known as Presto) is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources.

It's an open-source project, using [the Apache 2.0 license](https://github.com/trinodb/trino/blob/master/LICENSE), and the JDBC driver is freely redistributable.

Trino is ANSI SQL compliant.

Tested using this script: https://gist.github.com/nineinchnick/d3496c05939856c1b0858af99457d85a