### PR TITLE
fix(spanner): use commit timestamp to populate installed_on

### DIFF
--- a/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerDatabase.java
+++ b/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerDatabase.java
@@ -134,11 +134,28 @@ public class SpannerDatabase extends Database<SpannerConnection> {
                 "    script STRING(1000) NOT NULL,\n" +
                 "    checksum INT64,\n" +
                 "    installed_by STRING(100) NOT NULL,\n" +
-                "    installed_on TIMESTAMP OPTIONS (allow_commit_timestamp=true),\n" +
+                "    installed_on TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),\n" +
                 "    execution_time INT64 NOT NULL,\n" +
                 "    success BOOL NOT NULL\n" +
                 ") PRIMARY KEY (installed_rank DESC);\n" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "") +
                 "CREATE INDEX " + table.getName() + "_s_idx ON " + table.getName() + " (success);";
+    }
+
+    @Override
+    public String getInsertStatement(Table table) {
+        return "INSERT INTO " + table
+                + " (" + quote("installed_rank")
+                + ", " + quote("version")
+                + ", " + quote("description")
+                + ", " + quote("type")
+                + ", " + quote("script")
+                + ", " + quote("checksum")
+                + ", " + quote("installed_by")
+                + ", " + quote("execution_time")
+                + ", " + quote("success")
+                + ", " + quote("installed_on")
+                + ")"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, PENDING_COMMIT_TIMESTAMP())";
     }
 }


### PR DESCRIPTION
Fixes https://github.com/flyway/flyway/issues/3329

As per the Spanner documentation about commit timestamps [here](https://cloud.google.com/spanner/docs/commit-timestamp), the column must be populated using the `PENDING_COMMIT_TIMESTAMP` function.
This also allows making that column `NOT NULL` like other database implementations do.