### PR TITLE
Fixed "Flyway using incorrect metadata column names for latest h2 db (2.0.202)" (#3334)

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Database.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/h2/H2Database.java
@@ -59,6 +59,7 @@ public class H2Database extends Database<H2Connection> {
     public H2Database(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
         super(configuration, jdbcConnectionFactory, statementInterceptor);
 
+        requiresV2MetadataColumnNames = super.determineVersion().isAtLeast("2.0.0");
         compatibilityMode = determineCompatibilityMode();
     }
 
@@ -112,7 +113,6 @@ public class H2Database extends Database<H2Connection> {
 
         recommendFlywayUpgradeIfNecessary("2.0.201");
         supportsDropSchemaCascade = getVersion().isAtLeast("1.4.200");
-        requiresV2MetadataColumnNames = getVersion().isAtLeast("2.0.0");
     }
 
     @Override


### PR DESCRIPTION
This fixes #3334 

The current version is using the `requiresV2MetadataColumnNames` flag to determine which columns to use, but we were getting errors because Flyway tries to get the metadata from the database to determine whether `requiresV2MetadataColumnNames` was true or false.
In this fix, the determination of requiresV2MetadataColumnNames is done in the constructor. Also, the version information in the parent class is enough for this process, so we use that for the decision.
