### PR TITLE
Bump: log4j 2.15.3 to 2.16.0

### DIFF
--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -140,8 +140,8 @@
                         <Import-Package>
                             javax.sql,
                             org.apache.commons.logging;version="[1.1,2)";resolution:=optional,
-                            org.apache.logging.log4j;version="[2.15,3)";resolution:=optional,
-                            org.apache.logging.log4j.util;version="[2.15,3)";resolution:=optional,
+                            org.apache.logging.log4j;version="[2.16,0)";resolution:=optional,
+                            org.apache.logging.log4j.util;version="[2.16,0)";resolution:=optional,
                             org.jboss.vfs;version="[3.1.0,4)";resolution:=optional,
                             org.postgresql.copy;version="[9.3.1102,100.0)";resolution:=optional,
                             org.postgresql.core;version="[9.3.1102,100.0)";resolution:=optional,

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <version.jre>11.0.2</version.jre>
         <version.jtds>1.3.1</version.jtds>
         <version.junit>4.13.2</version.junit>
-        <version.log4net2>2.15.0</version.log4net2>
+        <version.log4net2>2.16.0</version.log4net2>
         <version.logback>1.2.3</version.logback>
         <version.lombok>1.18.20</version.lombok>
         <version.lombok-maven-plugin>1.18.20.0</version.lombok-maven-plugin>


### PR DESCRIPTION


- Disable JNDI by default. Require log4j2.enableJndi to be set to true to allow JNDI. Fixes [LOG4J2-3208](https://issues.apache.org/jira/browse/LOG4J2-3208)
- Completely remove support for Message Lookups. Fixes [LOG4J2-3211](https://issues.apache.org/jira/browse/LOG4J2-3211)

Second Log4J Vuln found: https://www.zdnet.com/article/second-log4j-vulnerability-found-apache-log4j-2-16-0-released/

