### PR TITLE
log4j upgrade to 2.17.0, fixes #3360

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <version.jre>11.0.2</version.jre>
         <version.jtds>1.3.1</version.jtds>
         <version.junit>4.13.2</version.junit>
-        <version.log4net2>2.16.0</version.log4net2>
+        <version.log4net2>2.17.0</version.log4net2>
         <version.logback>1.2.3</version.logback>
         <version.lombok>1.18.20</version.lombok>
         <version.lombok-maven-plugin>1.18.20.0</version.lombok-maven-plugin>


### PR DESCRIPTION
fixes CVE-2021-45105
more log4shell remediation