### PR TITLE
Update version jackson-databind to address security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.10.5.1</version>
+                <version>2.12.6</version>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
Would it be okay to increase the version for jackson-databind to 2.12.6? This version addresses the security concern that is detailed in this issue: https://github.com/FasterXML/jackson-databind/issues/3328

Cheers