### PR TITLE
Adding Logging to be explicit about unresolved (invalid?) migrations being ignored

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/resolver/MigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/resolver/MigrationResolver.java
@@ -15,7 +15,10 @@
  */
 package org.flywaydb.core.api.resolver;
 
+import org.flywaydb.core.internal.util.Pair;
+
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Resolves available migrations. This interface can be implemented to create custom resolvers. A custom resolver
@@ -28,5 +31,5 @@ public interface MigrationResolver {
      *
      * @return The available migrations.
      */
-    Collection<ResolvedMigration> resolveMigrations(Context context);
+    Pair<List<ResolvedMigration>, Collection<UnresolvedMigration>> attemptResolveMigrations(Context context);
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/api/resolver/UnresolvedMigration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/resolver/UnresolvedMigration.java
@@ -1,0 +1,10 @@
+package org.flywaydb.core.api.resolver;
+
+/**
+ * Migration that fails to resolve because it's invalid
+ */
+public interface UnresolvedMigration {
+
+    String getValidityMessage();
+
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -274,7 +274,7 @@ public class DbMigrate {
                 LOG.warn(unresolvedMigration.getValidityMessage());
             }
             LOG.warn("If these should have been resolved, perhaps try the -validateMigrationNaming=\"true\" " +
-                    "command-line option to fail this command instead of igoring unresolved migrations.");
+                    "command-line option to fail this command instead of ignoring unresolved migrations.");
         }
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbValidate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbValidate.java
@@ -115,12 +115,12 @@ public class DbValidate {
      */
     public ValidateResult validate() {
         if (!schema.exists()) {
-            if (!migrationResolver.resolveMigrations(new Context() {
+            if (!migrationResolver.attemptResolveMigrations(new Context() {
                 @Override
                 public Configuration getConfiguration() {
                     return configuration;
                 }
-            }).isEmpty() && !pending) {
+            }).getLeft().isEmpty() && !pending) {
                 String validationErrorMessage = "Schema " + schema + " doesn't exist yet";
                 ErrorDetails validationError = new ErrorDetails(ErrorCode.SCHEMA_DOES_NOT_EXIST, validationErrorMessage);
                 return CommandResultFactory.createValidateResult(database.getCatalog(), validationError, 0, null, new ArrayList<>());

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/UnresolvedMigrationImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/UnresolvedMigrationImpl.java
@@ -1,0 +1,18 @@
+package org.flywaydb.core.internal.resolver;
+
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.resolver.UnresolvedMigration;
+
+public class UnresolvedMigrationImpl implements UnresolvedMigration {
+
+    String validityMessage;
+
+    public UnresolvedMigrationImpl(String validityMessage) {
+        this.validityMessage = validityMessage;
+    }
+
+    @Override
+    public String getValidityMessage() {
+        return this.validityMessage;
+    }
+}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/FixedJavaMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/FixedJavaMigrationResolver.java
@@ -19,9 +19,12 @@ import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.Context;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
+import org.flywaydb.core.api.resolver.UnresolvedMigration;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
+import org.flywaydb.core.internal.util.Pair;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,7 +47,7 @@ public class FixedJavaMigrationResolver implements MigrationResolver {
     }
 
     @Override
-    public List<ResolvedMigration> resolveMigrations(Context context) {
+    public Pair<List<ResolvedMigration>, Collection<UnresolvedMigration>> attemptResolveMigrations(Context context) {
         List<ResolvedMigration> migrations = new ArrayList<>();
 
         for (JavaMigration javaMigration : javaMigrations) {
@@ -52,6 +55,6 @@ public class FixedJavaMigrationResolver implements MigrationResolver {
         }
 
         Collections.sort(migrations, new ResolvedMigrationComparator());
-        return migrations;
+        return Pair.of(migrations, new ArrayList<>());
     }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/ScanningJavaMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/java/ScanningJavaMigrationResolver.java
@@ -22,10 +22,13 @@ import org.flywaydb.core.api.resolver.Context;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.api.ClassProvider;
+import org.flywaydb.core.api.resolver.UnresolvedMigration;
 import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
 import org.flywaydb.core.internal.util.ClassUtils;
+import org.flywaydb.core.internal.util.Pair;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,7 +49,7 @@ public class ScanningJavaMigrationResolver implements MigrationResolver {
     private final Configuration configuration;
 
     @Override
-    public List<ResolvedMigration> resolveMigrations(Context context) {
+    public Pair<List<ResolvedMigration>, Collection<UnresolvedMigration>> attemptResolveMigrations(Context context) {
         List<ResolvedMigration> migrations = new ArrayList<>();
 
         for (Class<?> clazz : classProvider.getClasses()) {
@@ -55,6 +58,6 @@ public class ScanningJavaMigrationResolver implements MigrationResolver {
         }
 
         Collections.sort(migrations, new ResolvedMigrationComparator());
-        return migrations;
+        return Pair.of(migrations, new ArrayList<>());
     }
 }


### PR DESCRIPTION
Hey Flyway Team,

This is still very much a draft PR, but it's technically feature-complete and can at least demonstrate my desired changes. I'm happy to throw this in the garbage and redo it if the idea is sound, but the structure is just all wrong.

The behavior relevant to this PR is that when you run `flyway migrate`, by default, Flyway silently ignores migrations that don't follow the naming convention. There should at least be a warning log explaining to the user that there are some unresolved (skipped) migrations. If that behavior is undesirable, the user is informed and can discover the `validateMigrationNaming` flag from running Flyway.

I ran into this behavior yesterday while attempting to debug why specific DB migrations weren't running in our CI pipeline. Not being super familiar with Flyway, I was unaware of the migration naming conventions. Thankfully I have also discovered the `validateMigrationNaming` flag and turned it on for our CI setup, so that builds fail instead of just silently ignoring invalid migration files by default. I didn't even know this flag existed until I scoured google hunting for it, hoping that it actually existed.

Here's an example log of my proposed changes:
```
INFO: Flyway Community Edition 0-SNAPSHOT by Redgate
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.license.VersionPrinter info
INFO: See what's new here: https://flywaydb.org/documentation/learnmore/releaseNotes#0-SNAPSHOT
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.license.VersionPrinter info
INFO: 
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.database.base.BaseDatabaseType info
INFO: Database: jdbc:mysql://127.0.0.1:3306/test (MySQL 8.0)
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbValidate info
INFO: Successfully validated 1 migration (execution time 00:00.031s)
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory info
INFO: Creating Schema History table `test`.`flyway_schema_history` ...
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate info
INFO: Current version of schema `test`: << Empty Schema >>
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate info
INFO: Migrating schema `test` to version "0001 - migration 1"
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate info
INFO: Successfully applied org.flywaydb.core.internal.util.Pair@503f95a3 migration to schema `test`, now at version v0001 (execution time 00:00.049s)
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate warn
👉   WARNING: Found 1 unresolved migrations with the following output:
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate warn
👉   WARNING: Invalid versioned migration name format: V0002_migration_2.sql (could not recognise version number 0002_migration_2)
Feb 23, 2022 7:20:58 AM org.flywaydb.core.internal.command.DbMigrate warn
👉   WARNING: If these should have been resolved, perhaps try the -validateMigrationNaming="true" command-line option to fail this command instead of ignoring unresolved migrations.
```

I want to "be the change you wish to see" in the world and all that, so I decided to try and figure out how to implement this change myself as both a gesture of goodwill and show that it's at least possible. My apologies if the code is atrocious -- it's just a proof-of-concept to get this to the discussion phase.

I know this (related) issue has been brought up in the past: https://github.com/flyway/flyway/issues/2056

And at the time it was marked as `won't fix` because it would have been a behavioral change to Flyway. My proposed changes will not affect behavior in any way and will instead add a few more log lines to at least be explicit to the end-user so that issues related to this are discoverable instead of hidden and silent.