### PR TITLE
Upgrade jackson-databind to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.12.6</version>
+                <version>2.13.1</version>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
Updating version of jackson-databind to 2.13.1 to address CVE-2020-36518: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518