### PR TITLE
SingleStoreDB support

### DIFF
--- a/flyway-community-db-support/pom.xml
+++ b/flyway-community-db-support/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>ignite-core</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.singlestore</groupId>
+            <artifactId>singlestore-jdbc-client</artifactId>
+            <version>${version.singlestore-jdbc}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreConnection.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreConnection.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.flywaydb.core.internal.database.base.Connection;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+public class SingleStoreConnection extends Connection<SingleStoreDatabase> {
+    private static final Log LOG = LogFactory.getLog(SingleStoreConnection.class);
+
+    private static final String USER_VARIABLES_TABLE = "information_schema.user_variables";
+
+    private final String userVariablesQuery = "SELECT variable_name FROM "
+            + USER_VARIABLES_TABLE
+            + " WHERE variable_value IS NOT NULL";
+    private final boolean canResetUserVariables;
+
+    public SingleStoreConnection(SingleStoreDatabase database, java.sql.Connection connection) {
+        super(database, connection);
+
+        canResetUserVariables = hasUserVariableResetCapability();
+    }
+
+    // ensure the database is recent enough and the current user has the necessary SELECT grant
+    private boolean hasUserVariableResetCapability() {
+        try {
+            jdbcTemplate.queryForStringList(userVariablesQuery);
+            return true;
+        } catch (SQLException e) {
+            LOG.debug("Disabled user variable reset as "
+                    + USER_VARIABLES_TABLE
+                    + "cannot be queried (SQL State: " + e.getSQLState() + ", Error Code: " + e.getErrorCode() + ")");
+            return false;
+        }
+    }
+
+    @Override
+    protected void doRestoreOriginalState() throws SQLException {
+        // prevent user-defined variables from leaking beyond the scope of a migration
+        if (canResetUserVariables) {
+            List<String> userVariables = jdbcTemplate.queryForStringList(userVariablesQuery);
+            if (!userVariables.isEmpty()) {
+                boolean first = true;
+                StringBuilder nulls = new StringBuilder();
+                StringBuilder variables = new StringBuilder();
+
+                for (String variable : userVariables) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        nulls.append(",");
+                        variables.append(",");
+                    }
+                    nulls.append("NULL");
+                    variables.append(variable);
+                }
+
+                jdbcTemplate.executeStatement("SELECT " + nulls.toString() + " INTO " + variables.toString());
+            }
+        }
+    }
+
+    @Override
+    protected String getCurrentSchemaNameOrSearchPath() throws SQLException {
+        return jdbcTemplate.queryForString("SELECT DATABASE()");
+    }
+
+    @Override
+    public void doChangeCurrentSchemaOrSearchPathTo(String schema) throws SQLException {
+        if (StringUtils.hasLength(schema)) {
+            jdbcTemplate.getConnection().setCatalog(schema);
+        } else {
+            try {
+                // Weird hack to switch back to no database selected...
+                String newDb = database.quote(UUID.randomUUID().toString());
+                jdbcTemplate.execute("CREATE SCHEMA " + newDb);
+                jdbcTemplate.execute("USE " + newDb);
+                jdbcTemplate.execute("DROP SCHEMA " + newDb);
+            } catch (Exception e) {
+                LOG.warn("Unable to restore connection to having no default schema: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    protected Schema doGetCurrentSchema() throws SQLException {
+        String schemaName = getCurrentSchemaNameOrSearchPath();
+
+        // SingleStore can have URLs where no current schema is set, so we must handle this case explicitly.
+        return schemaName == null ? null : getSchema(schemaName);
+    }
+
+    @Override
+    public Schema getSchema(String name) {
+        return new SingleStoreSchema(jdbcTemplate, database, name);
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreDatabase.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreDatabase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class SingleStoreDatabase extends Database<SingleStoreConnection> {
+
+    public SingleStoreDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "CREATE " + (getVersion().isAtLeast("7.3") ? "ROWSTORE" : "") +
+                " TABLE " + table +
+                "(\n" +
+                "    `installed_rank` INT NOT NULL,\n" +
+                "    `version` VARCHAR(50),\n" +
+                "    `description` VARCHAR(200) NOT NULL,\n" +
+                "    `type` VARCHAR(20) NOT NULL,\n" +
+                "    `script` VARCHAR(1000) NOT NULL,\n" +
+                "    `checksum` INT,\n" +
+                "    `installed_by` VARCHAR(100) NOT NULL,\n" +
+                "    `installed_on` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n" +
+                "    `execution_time` INT NOT NULL,\n" +
+                "    `success` BOOL NOT NULL,\n" +
+                "    PRIMARY KEY (`installed_rank`),\n" +
+                "    INDEX (`success`)\n" +
+                ");" + (baseline ? getBaselineStatement(table) : "");
+    }
+
+    @Override
+    protected SingleStoreConnection doGetConnection(Connection connection) {
+        return new SingleStoreConnection(this, connection);
+    }
+
+    @Override
+    public final void ensureSupported() {
+        ensureDatabaseIsRecentEnough("7.1");
+    }
+
+    @Override
+    protected String doGetCurrentUser() throws SQLException {
+        return getMainConnection().getJdbcTemplate().queryForString("SELECT SUBSTRING_INDEX(USER(),'@',1)");
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsChangingCurrentSchema() {
+        return true;
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return "1";
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return "0";
+    }
+
+    @Override
+    public String getOpenQuote() {
+        return "`";
+    }
+
+    @Override
+    public String getCloseQuote() {
+        return "`";
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return true;
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreDatabaseType.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreDatabaseType.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.BaseDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+
+import java.sql.Connection;
+import java.sql.Types;
+
+public class SingleStoreDatabaseType extends BaseDatabaseType {
+
+    @Override
+    public String getName() {
+        return "SingleStore";
+    }
+
+    @Override
+    public int getNullType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:singlestore:");
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return "com.singlestore.jdbc.Driver";
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        return databaseProductName.contains("SingleStore");
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new SingleStoreDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new SingleStoreParser(configuration, parsingContext);
+    }
+
+    @Override
+    public String instantiateClassExtendedErrorMessage() {
+        return "Failure probably due to inability to load dependencies. Please ensure you have downloaded 'https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client' and extracted to 'flyway/drivers' folder";
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreParser.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreParser.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.parser.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.lang.Character.isDigit;
+
+public class SingleStoreParser extends Parser {
+    private static final char ALTERNATIVE_SINGLE_LINE_COMMENT = '#';
+
+    private static final Pattern STORED_PROGRAM_REGEX = Pattern.compile(
+            "^CREATE\\s(OR REPLACE\\s)?(FUNCTION|PROCEDURE|TEMPORARY PROCEDURE)", Pattern.CASE_INSENSITIVE);
+    private static final StatementType STORED_PROGRAM_STATEMENT = new StatementType();
+
+    public SingleStoreParser(Configuration configuration, ParsingContext parsingContext) {
+        super(configuration, parsingContext, 8);
+    }
+
+    @Override
+    protected void resetDelimiter(ParserContext context) {
+        // Do not reset delimiter as delimiter changes survive beyond a single statement
+    }
+
+    @Override
+    protected Token handleKeyword(PeekingReader reader, ParserContext context, int pos, int line, int col, String keyword) throws IOException {
+        if ("DELIMITER".equalsIgnoreCase(keyword)) {
+            String text = reader.readUntilExcluding('\n', '\r').trim();
+            return new Token(TokenType.NEW_DELIMITER, pos, line, col, text, text, context.getParensDepth());
+        }
+        return super.handleKeyword(reader, context, pos, line, col, keyword);
+    }
+
+    @Override
+    protected char getIdentifierQuote() {
+        return '`';
+    }
+
+    @Override
+    protected char getAlternativeStringLiteralQuote() {
+        return '"';
+    }
+
+    @Override
+    protected boolean isSingleLineComment(String peek, ParserContext context, int col) {
+        return (super.isSingleLineComment(peek, context, col)
+                // Normally SingleStore treats # as a comment, but this may have been overridden by DELIMITER # directive
+                || (peek.charAt(0) == ALTERNATIVE_SINGLE_LINE_COMMENT && !isDelimiter(peek, context, col, 0)));
+    }
+
+    @Override
+    protected Token handleStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        reader.swallow();
+        reader.swallowUntilIncludingWithEscape('\'', true, '\\');
+        return new Token(TokenType.STRING, pos, line, col, null, null, context.getParensDepth());
+    }
+
+    @Override
+    protected Token handleAlternativeStringLiteral(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        reader.swallow();
+        reader.swallowUntilIncludingWithEscape('"', true, '\\');
+        return new Token(TokenType.STRING, pos, line, col, null, null, context.getParensDepth());
+    }
+
+    @Override
+    protected Token handleCommentDirective(PeekingReader reader, ParserContext context, int pos, int line, int col) throws IOException {
+        reader.swallow(2);
+        String text = reader.readUntilExcluding("*/");
+        reader.swallow(2);
+        return new Token(TokenType.MULTI_LINE_COMMENT_DIRECTIVE, pos, line, col, text, text, context.getParensDepth());
+    }
+
+    @Override
+    protected boolean isCommentDirective(String text) {
+        return text.length() >= 8
+                && text.charAt(0) == '/'
+                && text.charAt(1) == '*'
+                && text.charAt(2) == '!'
+                && isDigit(text.charAt(3))
+                && isDigit(text.charAt(4))
+                && isDigit(text.charAt(5))
+                && isDigit(text.charAt(6))
+                && isDigit(text.charAt(7));
+    }
+
+    @Override
+    protected StatementType detectStatementType(String simplifiedStatement, ParserContext context, PeekingReader reader) {
+        if (STORED_PROGRAM_REGEX.matcher(simplifiedStatement).matches()) {
+            return STORED_PROGRAM_STATEMENT;
+        }
+
+        return super.detectStatementType(simplifiedStatement, context, reader);
+    }
+
+    @Override
+    protected boolean shouldAdjustBlockDepth(ParserContext context, List<Token> tokens, Token token) {
+        Token lastToken = getPreviousToken(tokens, context.getParensDepth());
+        if (lastToken != null && lastToken.getType() == TokenType.KEYWORD) {
+            return true;
+        }
+
+        return super.shouldAdjustBlockDepth(context, tokens, token);
+    }
+
+    @Override
+    protected void adjustBlockDepth(ParserContext context, List<Token> tokens, Token keyword, PeekingReader reader) {
+        String keywordText = keyword.getText();
+        int parensDepth = keyword.getParensDepth();
+
+        if ("BEGIN".equalsIgnoreCase(keywordText) && context.getStatementType() == STORED_PROGRAM_STATEMENT) {
+            context.increaseBlockDepth(Integer.toString(parensDepth));
+        }
+
+        if (context.getBlockDepth() > 0 && lastTokenIs(tokens, parensDepth, "END") &&
+                !"IF".equalsIgnoreCase(keywordText) && !"LOOP".equalsIgnoreCase(keywordText)) {
+            String initiator = context.getBlockInitiator();
+            if (initiator.equals(Integer.toString(parensDepth))) {
+                context.decreaseBlockDepth();
+            }
+        }
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreSchema.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreSchema.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SingleStoreSchema extends Schema<SingleStoreDatabase, SingleStoreTable> {
+
+    SingleStoreSchema(JdbcTemplate jdbcTemplate, SingleStoreDatabase database, String name) {
+        super(jdbcTemplate, database, name);
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return jdbcTemplate.queryForInt("SELECT COUNT(1) FROM information_schema.schemata WHERE schema_name=? LIMIT 1", name) > 0;
+    }
+
+    @Override
+    protected boolean doEmpty() throws SQLException {
+        List<String> params = new ArrayList<>(Arrays.asList(name, name, name, name, name));
+
+        return jdbcTemplate.queryForInt("SELECT SUM(found) FROM ("
+                        + "(SELECT 1 as found FROM information_schema.tables WHERE table_schema=? LIMIT 1) UNION ALL "
+                        + "(SELECT 1 as found FROM information_schema.views WHERE table_schema=? LIMIT 1) UNION ALL "
+                        + "(SELECT 1 as found FROM information_schema.routines WHERE routine_schema=? LIMIT 1)"
+                        + ") as all_found",
+                params.toArray(new String[0])
+        ) == 0;
+    }
+
+    @Override
+     protected void doCreate() throws SQLException {
+        jdbcTemplate.execute("CREATE SCHEMA " + database.quote(name));
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP SCHEMA " + database.quote(name));
+    }
+
+    @Override
+    protected void doClean() throws SQLException {
+        for (String statement : cleanRoutines()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (String statement : cleanViews()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        for (Table table : allTables()) {
+            table.drop();
+        }
+    }
+
+    private List<String> cleanRoutines() throws SQLException {
+        List<Map<String, String>> routineNames =
+                jdbcTemplate.queryForList(
+                        "SELECT routine_name as 'N', routine_type as 'T' FROM information_schema.routines WHERE routine_schema=?",
+                        name);
+
+        List<String> statements = new ArrayList<>();
+        for (Map<String, String> row : routineNames) {
+            String routineName = row.get("N");
+            String routineType = row.get("T");
+            statements.add("DROP " + routineType + " " + database.quote(name, routineName));
+        }
+        return statements;
+    }
+
+    private List<String> cleanViews() throws SQLException {
+        List<String> viewNames =
+                jdbcTemplate.queryForStringList(
+                        "SELECT table_name FROM information_schema.views WHERE table_schema=?", name);
+
+        List<String> statements = new ArrayList<>();
+        for (String viewName : viewNames) {
+            statements.add("DROP VIEW " + database.quote(name, viewName));
+        }
+        return statements;
+    }
+
+    @Override
+    protected SingleStoreTable[] doAllTables() throws SQLException {
+        List<String> tableNames = jdbcTemplate.queryForStringList(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema=?", name);
+
+        SingleStoreTable[] tables = new SingleStoreTable[tableNames.size()];
+        for (int i = 0; i < tableNames.size(); i++) {
+            tables[i] = new SingleStoreTable(jdbcTemplate, database, this, tableNames.get(i));
+        }
+        return tables;
+    }
+
+    @Override
+    public Table getTable(String tableName) {
+        return new SingleStoreTable(jdbcTemplate, database, this, tableName);
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreTable.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/SingleStoreTable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;
+
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+
+public class SingleStoreTable extends Table<SingleStoreDatabase, SingleStoreSchema> {
+    private static final Log LOG = LogFactory.getLog(SingleStoreTable.class);
+
+    /**
+     * Creates a new SingleStoreTable table.
+     *
+     * @param jdbcTemplate The Jdbc Template for communicating with the DB.
+     * @param database The database-specific support.
+     * @param schema The schema this table lives in.
+     * @param name The name of the table.
+     */
+    SingleStoreTable(JdbcTemplate jdbcTemplate, SingleStoreDatabase database, SingleStoreSchema schema, String name) {
+        super(jdbcTemplate, database, schema, name);
+    }
+
+    @Override
+    protected void doDrop() throws SQLException {
+        jdbcTemplate.execute("DROP TABLE " + database.quote(schema.getName(), name));
+    }
+
+    @Override
+    protected boolean doExists() throws SQLException {
+        return exists(schema, null, name);
+    }
+
+    @Override
+    protected void doLock() throws SQLException {
+        if (jdbcTemplate.queryForString("select storage_type from information_schema.tables where table_schema=? and table_name=?", schema.getName(), name).equals("COLUMNSTORE")) {
+            LOG.warn("Taking lock on columnstore table is not supported by SingleStore");
+        } else {
+            jdbcTemplate.execute("SELECT * FROM " + this + " FOR UPDATE");
+        }
+    }
+}

--- a/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/package-info.java
+++ b/flyway-community-db-support/src/main/java/org/flywaydb/community/database/singlestore/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.singlestore;

--- a/flyway-community-db-support/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-community-db-support/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,4 +1,5 @@
 org.flywaydb.community.database.ignite.thin.IgniteThinDatabaseType
 org.flywaydb.community.database.mysql.tidb.TiDBDatabaseType
 org.flywaydb.community.database.yugabytedb.YugabyteDBDatabaseType
+org.flywaydb.community.database.singlestore.SingleStoreDatabaseType
 org.flywaydb.community.database.CommunityDatabaseExtension

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <version.springjdbc>4.3.30.RELEASE</version.springjdbc>
         <version.sqlite>3.34.0</version.sqlite>
         <version.testcontainers>1.15.3</version.testcontainers>
+        <version.singlestore-jdbc>1.0.1</version.singlestore-jdbc>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Added a connector for [SingleStoreDB](https://www.singlestore.com/) 
The connector uses [SingleStore JDBC driver](https://docs.singlestore.com/db/v7.6/en/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver.html)

SingleStoreDB is compatible with MySQL but the syntax of some queries is different and it doesn't support some MySQL features, so it needs a separate implementation.
The steps done to test the connector can be found [here](https://docs.google.com/document/d/11Ly2FnxvFsnIe-ZLEtSNcr90rfWb_7YS5qXlyuD1jHU/edit?usp=sharing).
Some time ago @pradheeps already [implemented](https://github.com/flyway/flyway/pull/1386) MemSQL connector (the old name of the SinleStore) but looks like that stuff is outdated.
