### PR TITLE
update jackson-databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.1</version>
+                <version>2.13.2.1</version>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
Per https://github.com/advisories/GHSA-57j2-w4cx-62h2, 2.13.1 still
carries the vulnerability and 2.13.2.1 has the fix.

Signed-off-by: Srinivasan Muralidharan <srinivasan.muralidharan99@gmail.com>