### PR TITLE
Snowflake - show procedures - exclude built-in

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeSchema.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/snowflake/SnowflakeSchema.java
@@ -89,7 +89,7 @@ public class SnowflakeSchema extends Schema<SnowflakeDatabase, SnowflakeTable> {
             }
         }
 
-        for (Pair<String, String> snowflakeDropPair : generateDropStatementsWithArgs("PROCEDURES", "PROCEDURE")) {
+        for (Pair<String, String> snowflakeDropPair : generateDropStatementsWithArgs("USER PROCEDURES", "PROCEDURE")) {
             try {
                 jdbcTemplate.execute(snowflakeDropPair.getRight());
             } catch (SQLException sqlException) {


### PR DESCRIPTION
Snowflake recently introduced a change that shows also built-in procedures for `SHOW PROCEDURES`, which breaks the clean action.
https://community.snowflake.com/s/article/SHOW-PROCEDURES-Command-Output-Includes-Both-User-created-and-Built-in-Stored-Procedures

The proposed patch limits the output to only user procedures.