### PR TITLE
Fix automatic module name

### DIFF
--- a/flyway-community-db-support/pom.xml
+++ b/flyway-community-db-support/pom.xml
@@ -98,8 +98,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>org.flywaydb.core</Automatic-Module-Name>
-                        <Bundle-SymbolicName>org.flywaydb.core</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.flywaydb.community</Automatic-Module-Name>
+                        <Bundle-SymbolicName>org.flywaydb.community</Bundle-SymbolicName>
                         <Export-Package>
                             org.flywaydb.community;version=${project.version}
                         </Export-Package>

--- a/flyway-firebird/pom.xml
+++ b/flyway-firebird/pom.xml
@@ -125,8 +125,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>org.flywaydb.core</Automatic-Module-Name>
-                        <Bundle-SymbolicName>org.flywaydb.core</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.flywaydb.database</Automatic-Module-Name>
+                        <Bundle-SymbolicName>org.flywaydb.database</Bundle-SymbolicName>
                         <Export-Package>
                             org.flywaydb.database;version=${project.version}
                         </Export-Package>

--- a/flyway-gcp-bigquery/pom.xml
+++ b/flyway-gcp-bigquery/pom.xml
@@ -99,8 +99,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>org.flywaydb.core</Automatic-Module-Name>
-                        <Bundle-SymbolicName>org.flywaydb.core</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.flywaydb.database</Automatic-Module-Name>
+                        <Bundle-SymbolicName>org.flywaydb.database</Bundle-SymbolicName>
                         <Export-Package>
                             org.flywaydb.database;version=${project.version}
                         </Export-Package>

--- a/flyway-gcp-spanner/pom.xml
+++ b/flyway-gcp-spanner/pom.xml
@@ -105,8 +105,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>org.flywaydb.core</Automatic-Module-Name>
-                        <Bundle-SymbolicName>org.flywaydb.core</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.flywaydb.database</Automatic-Module-Name>
+                        <Bundle-SymbolicName>org.flywaydb.database</Bundle-SymbolicName>
                         <Export-Package>
                             org.flywaydb.database;version=${project.version}
                         </Export-Package>

--- a/flyway-mysql/pom.xml
+++ b/flyway-mysql/pom.xml
@@ -148,8 +148,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>org.flywaydb.core</Automatic-Module-Name>
-                        <Bundle-SymbolicName>org.flywaydb.core</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.flywaydb.database</Automatic-Module-Name>
+                        <Bundle-SymbolicName>org.flywaydb.database</Bundle-SymbolicName>
                         <Export-Package>
                             org.flywaydb.database;version=${project.version}
                         </Export-Package>


### PR DESCRIPTION
Make sure database and communitiy modules have a differnt automatic module name then the core module
Fixes https://github.com/flyway/flyway/issues/3342