### PR TITLE
Update hsqldb to version 2.7.1 to address CVE-2022-41853

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.gson>2.8.9</version.gson>
         <version.h2>2.1.214</version.h2>
         <version.hamcrest>2.2</version.hamcrest>
-        <version.hsqldb>2.6.1</version.hsqldb>
+        <version.hsqldb>2.7.1</version.hsqldb>
         <version.ignite>2.9.0</version.ignite>
         <version.informix>4.50.3</version.informix>
         <version.jansi>1.18</version.jansi>


### PR DESCRIPTION
Hi team, could this change please be included in an upcoming release to address this security vulnerability? https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41853

Cheers