### PR TITLE
fix(sec): upgrade org.apache.commons:commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.aws-java-sdk>2.17.189</version.aws-java-sdk>
         <version.aws-secretsmanager>1.0.8</version.aws-secretsmanager>
         <version.commonslogging>1.2</version.commonslogging>
-        <version.commonstext>1.9</version.commonstext>
+        <version.commonstext>1.10.0</version.commonstext>
         <version.db2>11.5.0.0</version.db2>
         <version.derby>10.15.2.0</version.derby>
         <version.equinox>3.15.200</version.equinox>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-text 1.9
- [CVE-2022-42889](https://www.oscs1024.com/hd/CVE-2022-42889)


### What did I do？
Upgrade org.apache.commons:commons-text from 1.9 to 1.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS