### PR TITLE
Expose flyway.schemas as default placeholder

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/parser/ParsingContext.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/parser/ParsingContext.java
@@ -32,6 +32,7 @@ import java.util.Map;
 @CustomLog
 public class ParsingContext {
     private static final String DEFAULT_SCHEMA_PLACEHOLDER = "defaultSchema";
+    private static final String SCHEMAS_PLACEHOLDER = "schemas";
     private static final String USER_PLACEHOLDER = "user";
     private static final String DATABASE_PLACEHOLDER = "database";
     private static final String TIMESTAMP_PLACEHOLDER = "timestamp";
@@ -71,6 +72,7 @@ public class ParsingContext {
         if (defaultSchemaName != null) {
             placeholders.put(generateName(DEFAULT_SCHEMA_PLACEHOLDER,configuration), defaultSchemaName);
         }
+        placeholders.put(generateName(SCHEMAS_PLACEHOLDER,configuration), String.join(",", schemaNames));
 
         if (catalog != null) {
             placeholders.put(generateName(DATABASE_PLACEHOLDER,configuration), catalog);


### PR DESCRIPTION
Background: 
I run on oracle with multiple complex schemas an heavy use of packages.
It can happen that packages have failures but anyhow get migrated succesfully as no ORA error is thrown.
In addition it can happen that packages are on failure, but after triggering re-compilation they work.

In order to solve that, I have a afterMigrate.sql script, which recompiles first invalid objects and then verifies if all are in valid state.

This script needs the schema names in order to look only to relevant schemas. I want to make this script re-usable and therefor use the information from flyway.schemas from configuration. I would use this info to split it and do the checks per schema accordingly. Currently I can only do it with the defaultSchema or hardcode all schema names in the script I want to avoid.

Please have a look and feedback if I have missed something or need to further do something.  