### PR TITLE
[community-db] Support OceanBase MySQL mode

### DIFF
--- a/flyway-community-db-support/flyway-database-oceanbase/pom.xml
+++ b/flyway-community-db-support/flyway-database-oceanbase/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Red Gate Software Ltd 2010-2024
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-community-db-support</artifactId>
+        <version>10.6.0</version>
+    </parent>
+
+    <artifactId>flyway-database-oceanbase</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/OceanBaseDatabaseExtension.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/OceanBaseDatabaseExtension.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class OceanBaseDatabaseExtension implements PluginMetadata {
+
+    public String getDescription() {
+        return "Community-contributed OceanBase database support extension " + readVersion() + " by Redgate";
+    }
+
+    private static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    OceanBaseDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/community/database/oceanbase/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseConnection.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseConnection.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.oceanbase;
+
+import org.flywaydb.database.mysql.MySQLConnection;
+import org.flywaydb.database.mysql.MySQLDatabase;
+
+import java.sql.Connection;
+
+public class OceanBaseConnection extends MySQLConnection {
+
+    public OceanBaseConnection(MySQLDatabase database, Connection connection) {
+        super(database, connection);
+    }
+
+    @Override
+    protected boolean canUseNamedLockTemplate() {
+        return false;
+    }
+}

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabase.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.oceanbase;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.database.mysql.MySQLConnection;
+import org.flywaydb.database.mysql.MySQLDatabase;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class OceanBaseDatabase extends MySQLDatabase {
+
+    public OceanBaseDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    protected MySQLConnection doGetConnection(Connection connection) {
+        return new OceanBaseConnection(this, connection);
+    }
+
+    @Override
+    protected boolean isCreateTableAsSelectAllowed() {
+        return true;
+    }
+
+    @Override
+    public void ensureSupported(Configuration configuration) {
+        ensureDatabaseIsRecentEnough("1.4");
+        recommendFlywayUpgradeIfNecessary("4.2");
+    }
+
+    @Override
+    protected MigrationVersion determineVersion() {
+        String versionNumber;
+        try {
+            versionNumber = OceanBaseJdbcUtils.getVersionNumber(rawMainJdbcConnection);
+        } catch (SQLException e) {
+            throw new FlywayException("Failed to get version number", e);
+        }
+        return MigrationVersion.fromVersion(versionNumber);
+    }
+}

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseDatabaseType.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.oceanbase;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.BaseDatabaseType;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.parser.Parser;
+import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.core.internal.util.ClassUtils;
+import org.flywaydb.database.mysql.MySQLParser;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class OceanBaseDatabaseType extends BaseDatabaseType {
+
+    private static final String MYSQL_JDBC_DRIVER = "com.mysql.cj.jdbc.Driver";
+    private static final String MYSQL_LEGACY_JDBC_DRIVER = "com.mysql.jdbc.Driver";
+    private static final String OB_JDBC_DRIVER = "com.oceanbase.jdbc.Driver";
+    private static final String OB_LEGACY_JDBC_DRIVER = "com.alipay.oceanbase.jdbc.Driver";
+
+    public String getName() {
+        return "OceanBase";
+    }
+
+    @Override
+    public int getPriority() {
+        // OceanBase needs to be checked in advance of MySql
+        return 1;
+    }
+
+    @Override
+    public int getNullType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public boolean handlesJDBCUrl(String url) {
+        return url.startsWith("jdbc:mysql:") || url.startsWith("jdbc:oceanbase:");
+    }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        if (url.startsWith("jdbc:mysql:")) {
+            return MYSQL_JDBC_DRIVER;
+        }
+        return OB_JDBC_DRIVER;
+    }
+
+    @Override
+    public String getBackupDriverClass(String url, ClassLoader classLoader) {
+        if (url.startsWith("jdbc:mysql:") && ClassUtils.isPresent(MYSQL_LEGACY_JDBC_DRIVER, classLoader)) {
+            return MYSQL_LEGACY_JDBC_DRIVER;
+        }
+        if (url.startsWith("jdbc:oceanbase:") && ClassUtils.isPresent(OB_LEGACY_JDBC_DRIVER, classLoader)) {
+            return OB_LEGACY_JDBC_DRIVER;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
+        String versionComment;
+        try {
+            versionComment = OceanBaseJdbcUtils.getVersionComment(connection);
+        } catch (SQLException e) {
+            return false;
+        }
+        return versionComment != null && versionComment.contains("OceanBase");
+    }
+
+    @Override
+    public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        return new OceanBaseDatabase(configuration, jdbcConnectionFactory, statementInterceptor);
+    }
+
+    @Override
+    public Parser createParser(Configuration configuration, ResourceProvider resourceProvider, ParsingContext parsingContext) {
+        return new MySQLParser(configuration, parsingContext);
+    }
+}

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseJdbcUtils.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/OceanBaseJdbcUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.community.database.oceanbase;
+
+import org.flywaydb.core.internal.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class OceanBaseJdbcUtils {
+
+    public static String getVersionComment(Connection connection) throws SQLException {
+        return queryVariable(connection, "version_comment");
+    }
+
+    public static String getVersionNumber(Connection connection) throws SQLException {
+        String versionComment = getVersionComment(connection);
+        if (StringUtils.hasText(versionComment)) {
+            String[] parts = versionComment.split(" ");
+            if (parts.length > 1) {
+                return parts[1];
+            }
+        }
+        return null;
+    }
+
+    private static String queryVariable(Connection connection, String variable) throws SQLException {
+        assert StringUtils.hasText(variable);
+        String sql = String.format("SHOW VARIABLES LIKE '%s'", variable);
+        try (Statement statement = connection.createStatement()) {
+            ResultSet rs = statement.executeQuery(sql);
+            if (rs.next()) {
+                return rs.getString("VALUE");
+            }
+        }
+        return null;
+    }
+}

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/package-info.java
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/java/org/flywaydb/community/database/oceanbase/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Community-supported package. No compatibility guarantees provided.
+ */
+package org.flywaydb.community.database.oceanbase;

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,2 @@
+org.flywaydb.community.database.OceanBaseDatabaseExtension
+org.flywaydb.community.database.oceanbase.OceanBaseDatabaseType

--- a/flyway-community-db-support/flyway-database-oceanbase/src/main/resources/org/flywaydb/community/database/oceanbase/version.txt
+++ b/flyway-community-db-support/flyway-database-oceanbase/src/main/resources/org/flywaydb/community/database/oceanbase/version.txt
@@ -1,0 +1,1 @@
+${pom.version}

--- a/flyway-community-db-support/pom.xml
+++ b/flyway-community-db-support/pom.xml
@@ -33,6 +33,7 @@
         <module>flyway-database-tidb</module>
         <module>flyway-database-ignite</module>
         <module>flyway-database-yugabytedb</module>
+        <module>flyway-database-oceanbase</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Close #3553. 

There are some modifications for database restrictions:
- Make `canUseNamedLockTemplate` to return false to skip calling `GET_LOCK`, as this function does not exist in OceanBase
- Add `OceanBaseDatabaseType` to handle [obconnector-j](https://github.com/oceanbase/obconnector-j) and mysql-connector-java
- Modity `ensureSupported` to support OceanBase versions