### PR TITLE
fix Gradle plugin configuration syntax in documentation

### DIFF
--- a/documentation/Flyway CLI and API/Configuration/Parameters/Baseline Migration Prefix.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Baseline Migration Prefix.md
@@ -42,7 +42,7 @@ baselineMigrationConfigurationExtension.setBaselineMigrationPrefix("IB");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       baselineMigrationPrefix: 'IB'
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Dapr Secrets.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Dapr Secrets.md
@@ -39,7 +39,7 @@ daprConfigurationExtension.setDaprSecrets("secret1", "secret2");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         daprSecrets: ['secret1', 'secret2']
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Dapr URL.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Dapr URL.md
@@ -37,7 +37,7 @@ daprConfigurationExtension.setDaprUrl("http://localhost:3500/v1.0/secrets/my-sec
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         daprUrl: 'http://localhost:3500/v1.0/secrets/my-secrets-store'
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Google Cloud Secret Manager Project.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Google Cloud Secret Manager Project.md
@@ -37,7 +37,7 @@ gcsmConfigurationExtension.setGcsmProject("quixotic-ferret-345678");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         gcsmProject: 'quixotic-ferret-345678'
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Google Cloud Secret Manager Secrets.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Google Cloud Secret Manager Secrets.md
@@ -37,7 +37,7 @@ gcsmConfigurationExtension.setGcsmSecrets("secret1", "secret2");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         gcsmSecrets: ['secret1', 'secret2']
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/PostgreSQL Transactional Lock.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/PostgreSQL Transactional Lock.md
@@ -39,8 +39,8 @@ configurationExtension.setTransactionalLock(false);
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
-      postgresqlTransactionalLock: false
+    pluginConfiguration = [
+      postgresqlTransactionalLock: 'false'
     ]
 }
 ```

--- a/documentation/Flyway CLI and API/Configuration/Parameters/SQL Server Kerberos Login File.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/SQL Server Kerberos Login File.md
@@ -35,7 +35,7 @@ sqlServerConfigurationExtension.setKerberosLoginFile("/path/to/SQLJDBCDriver.con
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         sqlserverKerberosLoginFile: '/path/to/SQLJDBCDriver.conf'
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Vault Secrets.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Vault Secrets.md
@@ -40,7 +40,7 @@ vaultConfigurationExtension.setVaultSecrets("kv/data/flyway/flywayConfig1", "kv/
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultSecrets: ['kv/data/flyway/flywayConfig1', 'kv/flyway/flywayConfig2']
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Vault Token.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Vault Token.md
@@ -35,7 +35,7 @@ vaultConfigurationExtension.setVaultToken("s.abcdefghijklmnopqrstuvwx");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultToken: 's.abcdefghijklmnopqrstuvwx'
     ]
 }

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Vault URL.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Vault URL.md
@@ -37,7 +37,7 @@ vaultConfigurationExtension.setVaultUrl("http://localhost:8200/v1/");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultUrl: 'http://localhost:8200/v1/'
     ]
 }


### PR DESCRIPTION
I encountered errors using the `postgresqlTransactionalLock` example using Gradle 6.8.3 and 7.4, so this corrects the syntax for all similar examples that I could find.

In "documentation/Flyway CLI and API/Configuration/Parameters/PostgreSQL Transactional Lock.md", without the change to line 42, Gradle is unable to compile the build script, reporting:

> You tried to use a map entry for an index operation, this is not allowed. Maybe something should be set in parentheses or a comma is missing?

Without the change to line 43, the `flywayMigrate` task fails with:

> class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')
