### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,10 +43,11 @@ jobs:
     - name: Checkout Flyway
       uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
+        cache: 'maven'
 
     - name: Build with Maven
       run: mvn -B install -e --file pom.xml

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,10 +42,11 @@ jobs:
     - name: Checkout Flyway
       uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
+        cache: 'maven'
 
     - name: Build with Maven
       run: mvn -B install -e --file pom.xml  "-Dgithub.os=${{ matrix.os }}"


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Java projects can run faster on GitHub Actions by enabling dependency caching on the [setup-java](https://github.com/actions/setup-java) action. `setup-java` supports caching for both Gradle and Maven projects.

**AS-IS**

```yaml
- name: Set up JDK ${{ matrix.java }}
  uses: actions/setup-java@v2
  with:
    java-version: ${{ matrix.java }}
    distribution: 'temurin'
```

**TO-BE**

```yaml
- name: Set up JDK ${{ matrix.java }}
  uses: actions/setup-java@v3
  with:
    java-version: ${{ matrix.java }}
    distribution: 'temurin'
    cache: 'maven'
```

> It’s literally a one line change to pass the `cache: 'maven'` input parameter.

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)
