### PR TITLE
#3598 - Correct Linux command

### DIFF
--- a/documentation/Flyway CLI and API/Usage/Command-line.md
+++ b/documentation/Flyway CLI and API/Usage/Command-line.md
@@ -20,7 +20,7 @@ The Flyway command-line tool is a standalone Flyway distribution. It runs on Win
 #### Linux
 
   Download, extract and install by adding to `PATH` (requires `sudo` permissions):
-  <pre class="console" style="overflow-x: auto"><span>$</span> wget -qO- {{site.enterpriseUrl}}/flyway-commandline/{{site.flywayVersion}}/<strong>flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</strong> | tarxvz && sudo ln -s `pwd`/flyway-{{site.flywayVersion}}/flyway /usr/local/bin </pre>
+  <pre class="console" style="overflow-x: auto"><span>$</span> wget -qO- {{site.enterpriseUrl}}/flyway-commandline/{{site.flywayVersion}}/<strong>flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</strong> | tar - xvz && sudo ln -s `pwd`/flyway-{{site.flywayVersion}}/flyway /usr/local/bin </pre>
 
   Or simply download the archive:
 
@@ -53,7 +53,7 @@ Go to Docker Hub for <a href="https://hub.docker.com/r/redgate/flyway/">detailed
 #### Linux
 
  Download, extract and install by adding to `PATH` (requires `sudo` permissions):
- <pre class="console" style="overflow-x: auto"><span>$</span> wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/<strong>flyway-commandline-{{site.flywayVersion}}-linux-x64.targz</strong> | tar xvz && sudo ln -s `pwd`/flyway-{{site.flywayVersion}}/flyway /usr/local/bin </pre>
+ <pre class="console" style="overflow-x: auto"><span>$</span> wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/<strong>flyway-commandline-{{site.flywayVersion}}-linux-x64.targz</strong> | tar -xvz && sudo ln -s `pwd`/flyway-{{site.flywayVersion}}/flyway /usr/local/bin </pre>
 
  Or simply download the archive:
 


### PR DESCRIPTION
Addresses #3598 Corrects the syntax for the `tar` step