### PR TITLE
Update documentation to match code

### DIFF
--- a/documentation/Flyway CLI and API/Configuration/Configuration Files.md
+++ b/documentation/Flyway CLI and API/Configuration/Configuration Files.md
@@ -161,7 +161,7 @@ flyway.locations=filesystem:sql
 #
 # auto: Auto detect the logger (default behavior)
 # console: Use stdout/stderr (only available when using the CLI)
-# slf4j2: Use the slf4j2 logger
+# slf4j: Use the slf4j logger
 # log4j2: Use the log4j2 logger
 # apache-commons: Use the Apache Commons logger
 #

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Loggers.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Loggers.md
@@ -13,7 +13,7 @@ This can be useful when a dependency comes with a logger you do not wish to use.
 
 * `auto` - Auto detect the logger (default behavior)
 * `console` - Use stdout/stderr (_only available when using CLI_)
-* `slf4j2` - Use the slf4j2 logger
+* `slf4j` - Use the slf4j logger
 * `log4j2` - Use the log4j2 logger
 * `apache-commons` - Use the Apache Commons logger
 

--- a/flyway-commandline/src/main/assembly/flyway.conf
+++ b/flyway-commandline/src/main/assembly/flyway.conf
@@ -123,7 +123,7 @@ flyway.locations=filesystem:sql
 #
 # auto: Auto detect the logger (default behavior)
 # console: Use stdout/stderr (only available when using the CLI)
-# slf4j2: Use the slf4j2 logger
+# slf4j: Use the slf4j logger
 # log4j2: Use the log4j2 logger
 # apache-commons: Use the Apache Commons logger
 #

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -731,7 +731,7 @@ public class ClassicConfiguration implements Configuration {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -633,7 +633,7 @@ public interface Configuration {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -166,7 +166,7 @@ public class FluentConfiguration implements Configuration {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -279,7 +279,7 @@ public class FlywayExtension {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -319,7 +319,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -339,7 +339,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
      * <ul>
      *     <li>auto: Auto detect the logger (default behavior)</li>
      *     <li>console: Use stdout/stderr (only available when using the CLI)</li>
-     *     <li>slf4j2: Use the slf4j2 logger</li>
+     *     <li>slf4j: Use the slf4j logger</li>
      *     <li>log4j2: Use the log4j2 logger</li>
      *     <li>apache-commons: Use the Apache Commons logger</li>
      * </ul>


### PR DESCRIPTION
See `LogFactory.java` where it checks for `slf4j`, not `slf4j2`.