### PR TITLE
Prevent unnecessary statements in RedshiftDatabaseType

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/redshift/RedshiftDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/redshift/RedshiftDatabaseType.java
@@ -73,8 +73,7 @@ public class RedshiftDatabaseType extends BaseDatabaseType {
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
         if (databaseProductName.startsWith("PostgreSQL")) {
-            String selectVersionQueryOutput = getSelectVersionOutput(connection);
-            if (databaseProductName.startsWith("PostgreSQL 8") && selectVersionQueryOutput.contains("Redshift")) {
+            if (databaseProductName.startsWith("PostgreSQL 8") && getSelectVersionOutput(connection).contains("Redshift")) {
                 return true;
             }
         }


### PR DESCRIPTION
Hi,

I noticed that while running on a normal Postgres database, there are some unnecessary queries for the version when checking the `RedshiftDatabaseType`.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/6304496/222407210-a2823a6c-6c43-404e-b2cc-951324fc0a74.png">

This isn't a huge deal (it only takes 2% of the complete Flyway interaction for me). Overall only ~0.1% on startup, but nonetheless I think this is an avoidable interaction with the database when running on a classic Postgres instance.

Cheers,
Christoph