### PR TITLE
DEBUG message formatting

### DIFF
--- a/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
+++ b/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
@@ -79,7 +79,7 @@ public class MySQLConnection extends Connection<MySQLDatabase> {
         } catch (SQLException e) {
             LOG.debug("Disabled user variable reset as "
                               + (database.isMariaDB() ? USER_VARIABLES_TABLE_MARIADB : USER_VARIABLES_TABLE_MYSQL)
-                              + "cannot be queried (SQL State: " + e.getSQLState() + ", Error Code: " + e.getErrorCode() + ")");
+                              + " cannot be queried (SQL State: " + e.getSQLState() + ", Error Code: " + e.getErrorCode() + ")");
             return false;
         }
     }


### PR DESCRIPTION
The debug message was printing out:

```log
2023-03-24 13:46:46.401 DEBUG --- [main] o.f.database.mysql.MySQLConnection: Disabled user variable reset as performance_schema.user_variables_by_threadcannot be queried (SQL State: 42000, Error Code: 1142)
```

It's just missing a space ;)