### PR TITLE
Reduce allocations from class loading through FeatureDetector

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/sqlite/SQLiteDatabaseType.java
@@ -23,7 +23,6 @@ import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
 import org.flywaydb.core.internal.parser.Parser;
 import org.flywaydb.core.internal.parser.ParsingContext;
-import org.flywaydb.core.internal.util.FeatureDetector;
 
 import java.sql.Connection;
 import java.sql.Types;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/Scanner.java
@@ -65,8 +65,6 @@ public class Scanner<I> implements ResourceProvider, ClassProvider<I> {
         FileSystemScanner fileSystemScanner = new FileSystemScanner(encoding, stream, detectEncoding, throwOnMissingLocations);
 
         FeatureDetector detector = new FeatureDetector(classLoader);
-        boolean aws = detector.isAwsAvailable();
-        boolean gcs = detector.isGCSAvailable();
         long cloudMigrationCount = 0;
 
         for (Location location : locations) {
@@ -86,7 +84,7 @@ public class Scanner<I> implements ResourceProvider, ClassProvider<I> {
 
 
             } else if (location.isAwsS3()) {
-                if (aws) {
+                if (detector.isAwsAvailable()) {
                     Collection<LoadableResource> awsResources = new AwsS3Scanner(encoding, throwOnMissingLocations).scanForResources(location);
                     resources.addAll(awsResources);
                     cloudMigrationCount += awsResources.stream().filter(r -> r.getFilename().endsWith(".sql")).count();

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/classpath/ClassPathScanner.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/scanner/classpath/ClassPathScanner.java
@@ -282,7 +282,7 @@ public class ClassPathScanner<I> implements ResourceAndClassScanner<I> {
      * @return The url resolver for this protocol.
      */
     private UrlResolver createUrlResolver(String protocol) {
-        if (new FeatureDetector(classLoader).isJBossVFSv2Available() && protocol.startsWith("vfs")) {
+        if (protocol.startsWith("vfs") && new FeatureDetector(classLoader).isJBossVFSv2Available()) {
             return new JBossVFSv2UrlResolver();
         }
 
@@ -316,13 +316,13 @@ public class ClassPathScanner<I> implements ResourceAndClassScanner<I> {
         }
 
         FeatureDetector featureDetector = new FeatureDetector(classLoader);
-        if (featureDetector.isJBossVFSv3Available() && "vfs".equals(protocol)) {
+        if ("vfs".equals(protocol) && featureDetector.isJBossVFSv3Available()) {
             JBossVFSv3ClassPathLocationScanner locationScanner = new JBossVFSv3ClassPathLocationScanner();
             locationScannerCache.put(protocol, locationScanner);
             resourceNameCache.put(locationScanner, new HashMap<>());
             return locationScanner;
         }
-        if (featureDetector.isOsgiFrameworkAvailable() && (isFelix(protocol) || isEquinox(protocol))) {
+        if ((isFelix(protocol) || isEquinox(protocol)) && featureDetector.isOsgiFrameworkAvailable()) {
             OsgiClassPathLocationScanner locationScanner = new OsgiClassPathLocationScanner();
             locationScannerCache.put(protocol, locationScanner);
             resourceNameCache.put(locationScanner, new HashMap<>());


### PR DESCRIPTION
Hi,

I've noticed a couple of avoidable allocations and class lookups caused by `FeatureDetector`.
<img width="527" alt="image" src="https://user-images.githubusercontent.com/6304496/228011612-b611bafc-b98d-41d1-9827-f0df5db681f6.png">

The idea of this PR is to check for the protocol first and only afterwards do the relatively "expensive" class loading.

Cheers,
Christoph