### PR TITLE
security updates multiple jdbc driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <version.logback>1.2.3</version.logback>
         <version.lombok>1.18.20</version.lombok>
         <version.lombok-maven-plugin>1.18.20.0</version.lombok-maven-plugin>
-        <version.mariadb>2.7.2</version.mariadb>
+        <version.mariadb>2.7.9</version.mariadb>
         <version.maven>3.8.5</version.maven>
         <version.mockito>4.2.0</version.mockito>
         <version.msal4j>1.13.7</version.msal4j>
@@ -181,10 +181,10 @@
         <version.sap>2.6.30</version.sap>
         <version.singlestore>1.1.4</version.singlestore>
         <version.slf4j>1.7.30</version.slf4j>
-        <version.snowflake>3.13.22</version.snowflake>
+        <version.snowflake>3.13.30</version.snowflake>
         <version.spanner>2.7.8</version.spanner>
         <version.springjdbc>5.3.19</version.springjdbc>
-        <version.sqlite>3.34.0</version.sqlite>
+        <version.sqlite>3.41.2.1</version.sqlite>
         <version.testcontainers>1.15.3</version.testcontainers>
     </properties>
 


### PR DESCRIPTION
some drivers provided with the current distribution have known security vulnerabilites reported by different scanner.
This PR updats the driver to the latest bugfix releases of the versions used.

* snowflake-jdbc
   - CVE-2023-30535 (GHSA-4g3j-c4wg-6j7x)
   - SNYK-JAVA-NETSNOWFLAKE-5425048 (https://security.snyk.io/vuln/SNYK-JAVA-NETSNOWFLAKE-5425048)
* sqlite-jdbc
  - CVE-2021-20227
  - CVE-2022-35737
  - CVE-2022-46908
* mariadb-connector
  - no CVE assigned here but race condition in connection pooling, problems fetching catalog meta data for some setups and multiople ArrayIndexOutOfBounceExcetions as well as ozen other bugfixes...

