### PR TITLE
Do not use MySQL named locks on Galera clusters

### DIFF
--- a/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
+++ b/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
@@ -155,6 +155,6 @@ public class MySQLConnection extends Connection<MySQLDatabase> {
     }
 
     protected boolean canUseNamedLockTemplate() {
-        return !database.isPxcStrict();
+        return !database.isPxcStrict() && !database.isWsrepOn();
     }
 }


### PR DESCRIPTION
Since MariaDB MDEV-30473 calling GET_LOCK on a (Galera) cluster is no longer allowed. Before this change the call was not replicated and only executed locally.

FlyWay now triggers the error "This version of MariaDB doesn't yet support 'GET_LOCK in cluster (WSREP_ON=ON)'" on Galera clusters.

This change checks for WSREP_ON=ON and disables the use of named locks and uses a table lock instead.

This functions in the same way as the check on Percona XtraDB Cluster with Strict Mode.