### PR TITLE
Update Version for google-cloud-spanner-jdbc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <version.singlestore>1.1.4</version.singlestore>
         <version.slf4j>1.7.30</version.slf4j>
         <version.snowflake>3.13.30</version.snowflake>
-        <version.spanner>2.7.8</version.spanner>
+        <version.spanner>2.11.2</version.spanner>
         <version.springjdbc>5.3.19</version.springjdbc>
         <version.sqlite>3.41.2.2</version.sqlite>
         <version.testcontainers>1.15.3</version.testcontainers>


### PR DESCRIPTION
Updated Version of google-cloud-spanner-jdbc includes the lastest version of Google Guava. Necessary due to vulnerability issuses with version 31.