### PR TITLE
Added connection attributes to SingleStore

### DIFF
--- a/flyway-database/flyway-singlestore/src/main/java/org/flywaydb/database/SingleStoreDatabaseExtension.java
+++ b/flyway-database/flyway-singlestore/src/main/java/org/flywaydb/database/SingleStoreDatabaseExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Red Gate Software Ltd 2010-2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.database;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.extensibility.PluginMetadata;
+import org.flywaydb.core.internal.util.FileUtils;
+
+public class SingleStoreDatabaseExtension implements PluginMetadata {
+    public String getDescription() {
+        return "SingleStoreDB database support " + readVersion() + " by Redgate";
+    }
+
+    public static String readVersion() {
+        try {
+            return FileUtils.copyToString(
+                    SingleStoreDatabaseExtension.class.getClassLoader().getResourceAsStream("org/flywaydb/database/version.txt"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FlywayException("Unable to read extension version: " + e.getMessage(), e);
+        }
+    }
+}

--- a/flyway-database/flyway-singlestore/src/main/java/org/flywaydb/database/singlestore/SingleStoreDatabaseType.java
+++ b/flyway-database/flyway-singlestore/src/main/java/org/flywaydb/database/singlestore/SingleStoreDatabaseType.java
@@ -23,9 +23,12 @@ import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
 import org.flywaydb.core.internal.parser.Parser;
 import org.flywaydb.core.internal.parser.ParsingContext;
+import org.flywaydb.database.SingleStoreDatabaseExtension;
 
 import java.sql.Connection;
 import java.sql.Types;
+import java.util.Arrays;
+import java.util.Properties;
 
 public class SingleStoreDatabaseType extends BaseDatabaseType {
     @Override
@@ -54,6 +57,19 @@ public class SingleStoreDatabaseType extends BaseDatabaseType {
     @Override
     public boolean handlesDatabaseProductNameAndVersion(String databaseProductName, String databaseProductVersion, Connection connection) {
         return databaseProductName.contains("SingleStore");
+    }
+
+    @Override
+    public void setDefaultConnectionProps(String url, Properties props, ClassLoader classLoader) {
+        props.put("connectionAttributes", 
+        String.format("_connector_name:%s,_connector_version:%s,_product_version:%s,program_name:%s,program_version:%s,program_vendor:%s",
+            "SingleStoreDB Flyway connector",
+            SingleStoreDatabaseExtension.readVersion(),
+            SingleStoreDatabaseExtension.readVersion(),
+            "Redgate_Flyway",
+            SingleStoreDatabaseExtension.readVersion(),
+            "Redgate"
+        ));
     }
 
     @Override


### PR DESCRIPTION
Setting connection attributes allows SingleStore to get more visibility on what connectors are used by customers and prioritize work on them.