### PR TITLE
Update Jackson to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <version.ignite>2.13.0</version.ignite>
         <version.informix>4.50.3</version.informix>
         <version.jansi>1.18</version.jansi>
-        <version.jackson>2.14.0</version.jackson>
+        <version.jackson>2.15.2</version.jackson>
         <version.jaxb>2.3.1</version.jaxb>
         <version.jaybird>3.0.10</version.jaybird>
         <version.jboss>3.2.15.Final</version.jboss>


### PR DESCRIPTION
The jackson-dataformat-toml package has an associated CVE: https://www.cve.org/CVERecord?id=CVE-2023-3894

An Improper Input Validation vuln with a high CVSS score: https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATAFORMAT-5829116

Affects versions below 2.15.0