### PR TITLE
Make SLF4J detection also work with SLF4J 2.0

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/FeatureDetector.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/FeatureDetector.java
@@ -58,13 +58,11 @@ public final class FeatureDetector {
             // provide any implementation, causing SLF4J to drop what we want to be console output on the floor.
             // Versions up to 1.7 have a StaticLoggerBinder
             slf4jAvailable = ClassUtils.isPresent("org.slf4j.Logger", classLoader)
-                    && ClassUtils.isPresent("org.slf4j.impl.StaticLoggerBinder", classLoader);
+                    && ClassUtils.isPresent("org.slf4j.impl.StaticLoggerBinder", classLoader)
+                    && !StreamSupport.stream(ServiceLoader.load(org.slf4j.Logger.class, classLoader)
+                            .spliterator(), false).allMatch(logger -> logger instanceof org.slf4j.helpers.NOPLogger);
             // Versions 1.8 and later use a ServiceLocator to bind to the implementation
             slf4jAvailable |= ClassUtils.isImplementationPresent("org.slf4j.spi.SLF4JServiceProvider", classLoader);
-            if(slf4jAvailable) {
-                slf4jAvailable = !StreamSupport.stream(ServiceLoader.load(org.slf4j.Logger.class, classLoader).spliterator(),false)
-                                                             .allMatch(logger -> logger instanceof org.slf4j.helpers.NOPLogger);
-            }
         }
 
         return slf4jAvailable;


### PR DESCRIPTION
#### Fixes #3730 :

With SLF4J >=1.8, the ServiceLoader mechanism doesn't return any loggers. Therefore, the `allMatch` evaluates to true, disabling SLF4J.

This change therefore constrains the ServiceLoader check to the old version of SLF4J.

* It shouldn't change the behavior for users of old SLF4J (such as flyway-commandline), as the ServiceLoader is still only called when an SLF4J binding is present
* It does enable the auto-detection of SLF4J 1.8 and and higher again, which was broken since Flyway 9.16.2, when the ServiceLoader check was introduced.