### PR TITLE
update mariadb-java-client to 2.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <version.logback>1.2.3</version.logback>
         <version.lombok>1.18.20</version.lombok>
         <version.lombok-maven-plugin>1.18.20.0</version.lombok-maven-plugin>
-        <version.mariadb>2.7.9</version.mariadb>
+        <version.mariadb>2.7.10</version.mariadb>
         <version.maven>3.9.4</version.maven>
         <version.mockito>4.2.0</version.mockito>
         <version.msal4j>1.13.8</version.msal4j>


### PR DESCRIPTION
Hi,
the update includes the following fix:

[[CONJ-1091](https://jira.mariadb.org/browse/CONJ-1091)] Ensure setting connectTimeout as timeout for socket timeout until connection is done. This permit to set a connectTimeout, while socketTimeout can still be set to 0

(from https://mariadb.com/kb/en/mariadb-connector-j-2-7-10-release-notes/)