### PR TITLE
Fix #3752 BigQuery parsing END CASE issue

### DIFF
--- a/flyway-gcp-bigquery/src/main/java/org/flywaydb/database/bigquery/BigQueryParser.java
+++ b/flyway-gcp-bigquery/src/main/java/org/flywaydb/database/bigquery/BigQueryParser.java
@@ -144,6 +144,7 @@ public class BigQueryParser extends Parser {
                 && !"IF".equalsIgnoreCase(keywordText)
                 && !"WHILE".equalsIgnoreCase(keywordText)
                 && !"LOOP".equalsIgnoreCase(keywordText)
+                && !"CASE".equalsIgnoreCase(keywordText)
                 && !"AS".equalsIgnoreCase(keywordText)
                 && context.getBlockDepth() > 0) {
             context.decreaseBlockDepth();


### PR DESCRIPTION
This change is to fix the parsing issue while `CASE` syntax is defined in BigQuery store procedure.

BigQuery doc for CASE syntax
https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#case

Issue details
https://github.com/flyway/flyway/issues/3752

Fixes #3752 
