### PR TITLE
Mention Spanner size limit

### DIFF
--- a/documentation/Flyway CLI and API/Supported Databases/Google Cloud Spanner.md
+++ b/documentation/Flyway CLI and API/Supported Databases/Google Cloud Spanner.md
@@ -32,6 +32,10 @@ In the Flyway Command-Line this would look like the following:
 
 <pre class="console"><span>&gt;</span> flyway migrate -batch=true</pre>
 
+### Data limit
+
+Flyway Community Edition has a 10GB limit on database size, and this is unlimited in Flyway Teams.
+
 You can find out more about Flyway Teams Edition [here](https://www.red-gate.com/products/flyway/teams).
 
 ## Using Flyway with Google Cloud Spanner


### PR DESCRIPTION
The Open Source & Community editions of Flyway enforce a [10GB data limit](https://github.com/flyway/flyway/blob/main/flyway-database/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerDatabase.java#L56-L59) for Spanner. This can be a surprise when moving from a small development database to a large production database.

I've adapted the clause from the BigQuery page and added it to the Spanner page.