### PR TITLE
Redshift add support for `IDENTITY PROVIDER`

### DIFF
--- a/flyway-database/flyway-database-redshift/src/main/java/org/flywaydb/database/redshift/RedshiftParser.java
+++ b/flyway-database/flyway-database-redshift/src/main/java/org/flywaydb/database/redshift/RedshiftParser.java
@@ -28,6 +28,7 @@ public class RedshiftParser extends Parser {
     private static final Pattern VACUUM_REGEX = Pattern.compile("^VACUUM");
     private static final Pattern ALTER_TABLE_APPEND_FROM_REGEX = Pattern.compile("^ALTER TABLE( .*)? APPEND FROM");
     private static final Pattern ALTER_TABLE_ALTER_COLUMN_REGEX = Pattern.compile("^ALTER TABLE( .*)? ALTER COLUMN");
+    private static final Pattern IDENTITY_PROVIDER_REGEX = Pattern.compile("^(CREATE|ALTER|DROP) IDENTITY PROVIDER");
 
     public RedshiftParser(Configuration configuration, ParsingContext parsingContext) {
         super(configuration, parsingContext, 3);
@@ -44,7 +45,8 @@ public class RedshiftParser extends Parser {
                 || CREATE_EXTERNAL_TABLE_REGEX.matcher(simplifiedStatement).matches()
                 || VACUUM_REGEX.matcher(simplifiedStatement).matches()
                 || ALTER_TABLE_APPEND_FROM_REGEX.matcher(simplifiedStatement).matches()
-                || ALTER_TABLE_ALTER_COLUMN_REGEX.matcher(simplifiedStatement).matches()) {
+                || ALTER_TABLE_ALTER_COLUMN_REGEX.matcher(simplifiedStatement).matches()
+                || IDENTITY_PROVIDER_REGEX.matcher(simplifiedStatement).matches()) {
             return false;
         }
 


### PR DESCRIPTION
Redshift cannot execute [identity provider][0] statements from within a transaction block.

This is similar to the issue and fix in #2438.

[0]: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_IDENTITY_PROVIDER.html