### PR TITLE
fix: only include user constraints

### DIFF
--- a/flyway-database/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerSchema.java
+++ b/flyway-database/flyway-gcp-spanner/src/main/java/org/flywaydb/database/spanner/SpannerSchema.java
@@ -154,7 +154,8 @@ public class SpannerSchema extends Schema<SpannerDatabase, SpannerTable> {
 
         Results foreignKeyRs = jdbcTemplate.executeStatement("SELECT CONSTRAINT_NAME, TABLE_NAME " +
                                                                      "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS " +
-                                                                     "WHERE CONSTRAINT_TYPE='FOREIGN KEY'");
+                                                                     "WHERE CONSTRAINT_TYPE='FOREIGN KEY' " +
+                                                                     "AND TABLE_SCHEMA=''");
 
         for (Result result : foreignKeyRs.getResults()) {
             for (List<String> row : result.getData()) {


### PR DESCRIPTION
Filter on the table schema name when selecting all foreign key constraints, to make sure that no system constraints are included in the results if they were to be added in the future. This also makes sure that if Cloud Spanner starts supporting named user schemas, the listed foreign keys are consistent with the tables that are used, which are all filtered based on an empty schema name.

Context: I'm one of the maintainers of the Cloud Spanner JDBC driver, and we are currently making sure that all our system queries will return correct and consistent results if multiple named schemas are present in a database. I noticed one system query in the Spanner Flyway integration that might return wrong results if the database would contain foreign key constraints for system tables and/or if Cloud Spanner would introduce support for named user schemas. All system queries in the Flyway Spanner integration that select tables or indexes already filter on `TABLE_SCHEMA = ''`, and this change adds that same filter when selecting all foreign keys.