### PR TITLE
Fixing merge issue for placeholders in TOML files

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/models/FlywayModel.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/models/FlywayModel.java
@@ -203,7 +203,7 @@ public class FlywayModel {
         result.failOnMissingLocations = failOnMissingLocations.merge(otherPojo.failOnMissingLocations);
         result.loggers = loggers.merge(otherPojo.loggers);
         result.defaultSchema = defaultSchema.merge(otherPojo.defaultSchema);
-        result.placeholders = placeholders.merge(otherPojo.placeholders);
+        result.placeholders = MergeUtils.merge(placeholders, otherPojo.placeholders, (a,b) -> b != null ? b : a);
         result.reportEnabled = reportEnabled.merge(otherPojo.reportEnabled);
         result.propertyResolvers = MergeUtils.merge(propertyResolvers, otherPojo.propertyResolvers, (a,b) -> b != null ? b : a); // TODO: more granular merge
         result.pluginConfigurations = MergeUtils.merge(pluginConfigurations, otherPojo.pluginConfigurations, (a,b) -> b != null ? b : a);


### PR DESCRIPTION
Currently, if some placeholders are defined in a TOML file, and others are defined in the command line, only the ones defined in the command line are used. This is a regression from the CONF files, where the placeholders would have been merged, with a union between the placeholders in the TOML file and the command line being used (unless there was a common key, of course).

~NOTE: I've not been able to get the development environment working on my local machine yet for Flyway, so I've not been able to compile or test this. I may be able to do this in a few weeks, but if someone wants to test this for me and verify it, we could get this in sooner.~

I've got my development environment running and was able to compile flyway-core after these changes. I ran test and it passed, but I didn't see any tests run, so I'm not sure if you have any automated tests set up at all for this or not. Either way, I believe this change is ready for review and approval.