### PR TITLE
Update the Flyway plugin for YugabyteDB

### DIFF
--- a/flyway-community-db-support/flyway-database-yugabytedb/pom.xml
+++ b/flyway-community-db-support/flyway-database-yugabytedb/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>flyway-database-postgresql</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -16,6 +16,7 @@
 package org.flywaydb.community.database.postgresql.yugabytedb;
 
 import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
 import org.flywaydb.database.postgresql.PostgreSQLDatabase;
@@ -42,6 +43,24 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
     @Override
     public boolean supportsDdlTransactions() {
         return false;
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return "CREATE TABLE IF NOT EXISTS " + table + " (\n" +
+                "    \"installed_rank\" INT NOT NULL PRIMARY KEY,\n" +
+                "    \"version\" VARCHAR(50),\n" +
+                "    \"description\" VARCHAR(200) NOT NULL,\n" +
+                "    \"type\" VARCHAR(20) NOT NULL,\n" +
+                "    \"script\" VARCHAR(1000) NOT NULL,\n" +
+                "    \"checksum\" INTEGER,\n" +
+                "    \"installed_by\" VARCHAR(100) NOT NULL,\n" +
+                "    \"installed_on\" TIMESTAMP NOT NULL DEFAULT now(),\n" +
+                "    \"execution_time\" INTEGER NOT NULL,\n" +
+                "    \"success\" BOOLEAN NOT NULL\n" +
+                ");\n" +
+                (baseline ? getBaselineStatement(table) + ";\n" : "") +
+                "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
     }
 
 }

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -22,6 +22,8 @@ import org.flywaydb.core.internal.jdbc.StatementInterceptor;
 import org.flywaydb.database.postgresql.PostgreSQLDatabase;
 
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
@@ -31,6 +33,13 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     @Override
     protected YugabyteDBConnection doGetConnection(Connection connection) {
+        Statement stmt = null;
+        try {
+            stmt = connection.createStatement();
+            stmt.execute("set yb_silence_advisory_locks_not_supported_error=on;");
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
         return new YugabyteDBConnection(this, connection);
     }
 

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -40,8 +40,8 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
         try {
             stmt = connection.createStatement();
             stmt.execute("set yb_silence_advisory_locks_not_supported_error=on;");
-        } catch (SQLException throwables) {
-            LOG.warn("Unable to set yb_silence_advisory_locks_not_supported_error ", throwables.printStackTrace(););
+        } catch (SQLException throwable) {
+            LOG.warn("Unable to set yb_silence_advisory_locks_not_supported_error ", throwable);
         }
         return new YugabyteDBConnection(this, connection);
     }

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -41,7 +41,7 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
             stmt = connection.createStatement();
             stmt.execute("set yb_silence_advisory_locks_not_supported_error=on;");
         } catch (SQLException throwables) {
-            LOG.warn("Unable to set yb_silence_advisory_locks_not_supported_error");
+            LOG.warn("Unable to set yb_silence_advisory_locks_not_supported_error ", throwables.printStackTrace(););
         }
         return new YugabyteDBConnection(this, connection);
     }

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -15,7 +15,9 @@
  */
 package org.flywaydb.community.database.postgresql.yugabytedb;
 
+import lombok.CustomLog;
 import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
@@ -25,6 +27,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+@CustomLog
 public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     public YugabyteDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
@@ -38,7 +41,7 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
             stmt = connection.createStatement();
             stmt.execute("set yb_silence_advisory_locks_not_supported_error=on;");
         } catch (SQLException throwables) {
-            throwables.printStackTrace();
+            LOG.warn("Unable to set yb_silence_advisory_locks_not_supported_error");
         }
         return new YugabyteDBConnection(this, connection);
     }

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -35,7 +35,7 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+        return url.startsWith("jdbc:yugabytedb:") ||url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
     }
 
     @Override

--- a/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-community-db-support/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -35,7 +35,7 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType {
 
     @Override
     public boolean handlesJDBCUrl(String url) {
-        return url.startsWith("jdbc:yugabytedb:") ||url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
+        return url.startsWith("jdbc:yugabytedb:") || url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:p6spy:postgresql:");
     }
 
     @Override


### PR DESCRIPTION
Problems:
* The current implementation does not use jdbc:yugabytedb:// for the connections.
* If user is using Flyway baseline, the baseline has default implementation of putting DDL and DML in a single transaction which YB will roll back the DML because of the catalog version changes.
* For YugabyteDB v2.20 all the commands fail with the error: ERROR: advisory locks are not yet implemented which has not been an issue for previous versions and not errored out.
Solutions:
* Added jdbc:yugabytedb: protocol in YugabyteDBDatabaseType.java
* Changed the implementation of getRawCreateScript() so that DDLs and DMLs are not in a single transaction
* For the pg_advisory_lock issue, setting yb_silence_advisory_locks_not_supported_error=on where connection is create and returning that connection

Tests:
The tests for these changes are in the repository: https://github.com/yugabyte/flyway-tests