### PR TITLE
fix: eliminate one usage of Task.getProject(). Inject ProjectLayout.

### DIFF
--- a/flyway-gradle-plugin/pom.xml
+++ b/flyway-gradle-plugin/pom.xml
@@ -85,6 +85,11 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
 
 
 

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -19,6 +19,7 @@
  */
 package org.flywaydb.gradle.task;
 
+import javax.inject.Inject;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.Location;
@@ -30,6 +31,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
@@ -65,6 +67,9 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      * The flyway {} block in the build script.
      */
     protected FlywayExtension extension;
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     /**
      * The fully qualified classname of the JDBC driver to use to connect to the database.
@@ -840,7 +845,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             return new File(workingDirectory);
         }
 
-        return new File(getProject().getProjectDir().getAbsolutePath());
+        return getProjectLayout().getProjectDirectory().getAsFile();
     }
 
     /**


### PR DESCRIPTION
Working towards resolution of https://github.com/flyway/flyway/issues/3550.

I work for the Cloud Platform team at Cashapp (Block, formerly Square). We are working towards making our builds fully compatible with the Gradle configuration cache. I previously ran such an [initiative](https://developer.squareup.com/blog/5-400-hours-a-year-saving-developers-time-and-sanity-with-gradles/) on the Square Android monorepo, which led to savings of about 5400 developer-hours per year (over $1m annually). Several of our repos at Cash use Flyway, making this plugin one of the primary hurdles to gaining all the potential advantages from using the configuration cache.

This small PR is a test to see if this repo accepts external contributions. If it works out, my team and I would like to continue contributing PRs until #3550 is resolved. The PR is based on [this documentation](https://docs.gradle.org/current/userguide/custom_gradle_types.html) from Gradle.