### PR TITLE
Update Spanner Database dependencies. 

### DIFF
--- a/flyway-database/flyway-gcp-spanner/pom.xml
+++ b/flyway-database/flyway-gcp-spanner/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax</artifactId>
-            <version>2.30.0</version>
+            <version>2.48.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <version.singlestore>1.1.4</version.singlestore>
         <version.slf4j>1.7.30</version.slf4j>
         <version.snowflake>3.14.1</version.snowflake>
-        <version.spanner>2.11.1</version.spanner>
+        <version.spanner>2.18.1</version.spanner>
         <version.springjdbc>5.3.19</version.springjdbc>
         <version.sqlite>3.41.2.2</version.sqlite>
         <version.testcontainers>1.15.3</version.testcontainers>


### PR DESCRIPTION
PR Fixes: https://github.com/flyway/flyway/issues/3900
For the spanner database:
Update com.google.cloud:google-cloud-spanner-jdbc to 2.18. 
Update com.google.api:gax to 2.48.1.