### PR TITLE
Improve getDataBaseType failure message

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -1121,7 +1121,11 @@ public class ClassicConfiguration implements Configuration {
                     DatabaseType databaseType = DatabaseTypeRegister.getDatabaseTypeForConnection(connection, this);
                     model.setDatabaseType(databaseType);
                     return databaseType;
-                } catch (SQLException ignored) {
+                } catch (SQLException sqlException) {
+                    LOG.warn("Unable to get database type from connection caused by "
+                            + ClassUtils.formatThrowable(sqlException) + " at "
+                            + ExceptionUtils.getThrowLocation(sqlException)
+                    );
                 }
             }
         }


### PR DESCRIPTION
**_Which version and edition of Flyway are you using?_**
10.13.0

_**If this is not the latest version, can you reproduce the issue with the latest one as well? (Many bugs are fixed in newer releases and upgrading will often resolve the issue)**_
Stilll happening in 10.13.0

**_Which client are you using? (Command-line, Java API, Maven plugin, Gradle plugin)_**
Java API

**_Which database are you using? (Type & version)_**
PostgreSQL 16.2

**_Which operating system are you using?_**
Windows 11

**_What did you do? (Please include the content causing the issue, any relevant configuration settings, the SQL statement(s) that failed (if any), and the command you ran)_**
I upgraded a Springboot from 3.2.5 to 3.3.0. That release updated Flyway from  9.22.3 to 10.10.0.

When I run my app with incorrect db credentials, I see infinite loop without any information about problem.

When I was searching problem, I found that Flyway ignore any SqlException. 
I've created this PR to fix this ignoring and improve failure message.

_**What did you expect to see?**_
I expect to see some information about problem.

_**What did you see instead?**_
![image](https://github.com/flyway/flyway/assets/55619296/71d8ebe1-facd-4112-aff7-2a2605f841e1)

