### PR TITLE
Feature: Configuration to suppress outOfOrder warning

### DIFF
--- a/documentation/Flyway CLI and API/Configuration/Parameters.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters.md
@@ -36,6 +36,7 @@ subtitle: placeholder page
 - [loggers](configuration/parameters/flyway/loggers)
 - [mixed](configuration/parameters/flyway/mixed)
 - [outOfOrder](configuration/parameters/flyway/Out Of Order)
+- [suppressOutOfOrderWarning](configuration/parameters/flyway/Suppress Out Of Order Warning)
 - [outputQueryResults](configuration/parameters/flyway/Output Query Results)
 - [reportFilename](configuration/parameters/flyway/Report Filename)
 - [skipDefaultCallbacks](configuration/parameters/flyway/Skip Default Callbacks)

--- a/documentation/Flyway CLI and API/Configuration/Parameters/Flyway/Suppress Out Of Order Warning.md
+++ b/documentation/Flyway CLI and API/Configuration/Parameters/Flyway/Suppress Out Of Order Warning.md
@@ -1,0 +1,65 @@
+---
+pill: outOfOrder
+subtitle: flyway.outOfOrder
+redirect_from: Configuration/suppressOutOfOrderWarning/
+---
+
+# Out Of Order
+
+## Description
+Disables the warning message that is shown during an execution with "outOfOrder" mode.
+
+This parameter has no effect if `outOfOrder` is not set to `true`.
+
+## Default
+false
+
+## Usage
+
+### Commandline
+```powershell
+./flyway -outOfOrder="true" -suppressOutOfOrderWarning="true" info
+```
+
+### TOML Configuration File
+```toml
+[flyway]
+outOfOrder = true
+suppressOutOfOrderWarning = true
+```
+
+### Configuration File
+```properties
+flyway.outOfOrder=true
+flyway.suppressOutOfOrderWarning=true
+```
+
+### Environment Variable
+```properties
+FLYWAY_OUT_OF_ORDER=true
+FLYWAY_SUPPRESS_OUT_OF_ORDER_WARNING=true
+```
+
+### API
+```java
+Flyway.configure()
+    .outOfOrder(true)
+    .suppressOutOfOrderWarning(true)
+    .load()
+```
+
+### Gradle
+```groovy
+flyway {
+    outOfOrder = true
+    suppressOutOfOrderWarning = true
+}
+```
+
+### Maven
+```xml
+<configuration>
+    <outOfOrder>true</outOfOrder>
+    <suppressOutOfOrderWarning>true</suppressOutOfOrderWarning>
+</configuration>
+```

--- a/documentation/Flyway CLI and API/Usage/Gradle Task/Gradle Task - flywayMigrate.md
+++ b/documentation/Flyway CLI and API/Usage/Gradle Task/Gradle Task - flywayMigrate.md
@@ -51,6 +51,7 @@ flyway {
     skipDefaultCallbacks = false
     target = '1.1'
     outOfOrder = false
+    suppressOutOfOrderWarning = false
     outputQueryResults = false
     validateOnMigrate = true
     cleanOnValidationError = false

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/Main.java
@@ -444,6 +444,7 @@ public class Main {
             LOG.info(indent + "cherryPick                     [" + "teams] Comma separated list of migrations that Flyway should consider when migrating");
             LOG.info(indent + "skipExecutingMigrations        Whether Flyway should skip actually executing the contents of the migrations");
             LOG.info(indent + "outOfOrder                     Allows migrations to be run \"out of order\"");
+            LOG.info(indent + "suppressOutOfOrderWarning      Don't show a warning if \"outOfOrder\" mode is enabled");
             LOG.info(indent + "callbacks                      Comma-separated list of FlywayCallback classes, or locations to scan for FlywayCallback classes");
             LOG.info(indent + "skipDefaultCallbacks           Skips default callbacks (sql)");
             LOG.info(indent + "validateOnMigrate              Validate when running migrate");

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/ClassicConfiguration.java
@@ -329,6 +329,11 @@ public class ClassicConfiguration implements Configuration {
     }
 
     @Override
+    public boolean isSuppressOutOfOrderWarning() {
+        return getModernFlyway().getSuppressOutOfOrderWarning();
+    }
+
+    @Override
     public ValidatePattern[] getIgnoreMigrationPatterns() {
         String[] ignoreMigrationPatterns = getModernFlyway().getIgnoreMigrationPatterns().toArray(new String[0]);
         if (Arrays.equals(ignoreMigrationPatterns, new String[]{""})) {
@@ -1639,6 +1644,10 @@ public class ClassicConfiguration implements Configuration {
         if (outOfOrderProp != null) {
             setOutOfOrder(outOfOrderProp);
         }
+        Boolean suppressOutOfOrderWarningProp = removeBoolean(props, ConfigUtils.SUPPRESS_OUT_OF_ORDER_WARNING);
+        if (suppressOutOfOrderWarningProp != null) {
+            setSuppressOutOfOrderWarning(suppressOutOfOrderWarningProp);
+        }
         Boolean skipExecutingMigrationsProp = removeBoolean(props, ConfigUtils.SKIP_EXECUTING_MIGRATIONS);
         if (skipExecutingMigrationsProp != null) {
             setSkipExecutingMigrations(skipExecutingMigrationsProp);
@@ -1839,6 +1848,10 @@ public class ClassicConfiguration implements Configuration {
 
     public void setOutOfOrder(Boolean outOfOrderProp) {
         getModernFlyway().setOutOfOrder(outOfOrderProp);
+    }
+
+    public void setSuppressOutOfOrderWarning(Boolean suppressOutOfOrderWarning) {
+        getModernFlyway().setSuppressOutOfOrderWarning(suppressOutOfOrderWarning);
     }
 
     public void setLockRetryCount(Integer lockRetryCount) {

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -410,7 +410,9 @@ public interface Configuration {
     boolean isOutOfOrder();
 
     /**
+     * Disables the warning message that is shown during an execution with "outOfOrder" mode.
      *
+     * @return {@code true} is warning message should be suppressed, otherwise {@code false}. (default: {@code false})
      */
     boolean isSuppressOutOfOrderWarning();
 

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/Configuration.java
@@ -410,6 +410,11 @@ public interface Configuration {
     boolean isOutOfOrder();
 
     /**
+     *
+     */
+    boolean isSuppressOutOfOrderWarning();
+
+    /**
      * Ignore migrations that match this comma-separated list of patterns when validating migrations.
      * Each pattern is of the form <migration_type>:<migration_state>
      * See https://documentation.red-gate.com/flyway/flyway-cli-and-api/configuration/parameters/flyway/ignore-migration-patterns for full details

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -723,6 +723,11 @@ public class FluentConfiguration implements Configuration {
         return this;
     }
 
+    public FluentConfiguration suppressOutOfOrderWarning(boolean suppressOutOfOrderWarning) {
+        config.setSuppressOutOfOrderWarning(suppressOutOfOrderWarning);
+        return this;
+    }
+
     /**
      * Whether Flyway should skip actually executing the contents of the migrations and only update the schema history table.
      * This should be used when you have applied a migration manually (via executing the sql yourself, or via an ide), and

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FluentConfiguration.java
@@ -723,6 +723,11 @@ public class FluentConfiguration implements Configuration {
         return this;
     }
 
+    /**
+     * Disables the warning message that is shown during an execution with "outOfOrder" mode.
+     *
+     * @param suppressOutOfOrderWarning {@code true} is warning message should be suppressed, otherwise {@code false}. (default: {@code false})
+     */
     public FluentConfiguration suppressOutOfOrderWarning(boolean suppressOutOfOrderWarning) {
         config.setSuppressOutOfOrderWarning(suppressOutOfOrderWarning);
         return this;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -183,7 +183,7 @@ public class DbMigrate {
             MigrationVersion schemaVersionToOutput = currentSchemaVersion == null ? MigrationVersion.EMPTY : currentSchemaVersion;
             migrateResult.initialSchemaVersion = schemaVersionToOutput.getVersion();
 
-            if (configuration.isOutOfOrder()) {
+            if (configuration.isOutOfOrder() && !configuration.isSuppressOutOfOrderWarning()) {
                 String outOfOrderWarning = "outOfOrder mode is active. Migration of schema " + schema + " may not be reproducible.";
                 LOG.warn(outOfOrderWarning);
                 migrateResult.addWarning(outOfOrderWarning);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -93,6 +93,7 @@ public class ConfigUtils {
     public static final String LOCATIONS = "flyway.locations";
     public static final String MIXED = "flyway.mixed";
     public static final String OUT_OF_ORDER = "flyway.outOfOrder";
+    public static final String SUPPRESS_OUT_OF_ORDER_WARNING = "flyway.suppressOutOfOrderWarning";
     public static final String SKIP_EXECUTING_MIGRATIONS = "flyway.skipExecutingMigrations";
     public static final String OUTPUT_QUERY_RESULTS = "flyway.outputQueryResults";
     public static final String PASSWORD = "flyway.password";
@@ -246,6 +247,9 @@ public class ConfigUtils {
         }
         if ("FLYWAY_OUT_OF_ORDER".equals(key)) {
             return OUT_OF_ORDER;
+        }
+        if ("FLYWAY_SUPPRESS_OUT_OF_ORDER_WARNING".equals(key)) {
+            return SUPPRESS_OUT_OF_ORDER_WARNING;
         }
         if ("FLYWAY_SKIP_EXECUTING_MIGRATIONS".equals(key)) {
             return SKIP_EXECUTING_MIGRATIONS;

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/models/FlywayModel.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/models/FlywayModel.java
@@ -77,6 +77,7 @@ public class FlywayModel {
     private String baselineDescription;
     private Boolean baselineOnMigrate;
     private Boolean outOfOrder;
+    private Boolean suppressOutOfOrderWarning;
     private Boolean skipExecutingMigrations;
     private List<String> callbacks;
     private Boolean skipDefaultCallbacks;
@@ -133,6 +134,7 @@ public class FlywayModel {
          model.baselineDescription = "<< Flyway Baseline >>";
          model.baselineOnMigrate = false;
          model.outOfOrder = false;
+         model.suppressOutOfOrderWarning = false;
          model.skipExecutingMigrations = false;
          model.callbacks = new ArrayList<>();
          model.skipDefaultCallbacks = false;
@@ -191,6 +193,7 @@ public class FlywayModel {
         result.baselineDescription = baselineDescription.merge(otherPojo.baselineDescription);
         result.baselineOnMigrate = baselineOnMigrate.merge(otherPojo.baselineOnMigrate);
         result.outOfOrder = outOfOrder.merge(otherPojo.outOfOrder);
+        result.suppressOutOfOrderWarning = suppressOutOfOrderWarning.merge(otherPojo.suppressOutOfOrderWarning);
         result.skipExecutingMigrations = skipExecutingMigrations.merge(otherPojo.skipExecutingMigrations);
         result.callbacks = callbacks.merge(otherPojo.callbacks);
         result.skipDefaultCallbacks = skipDefaultCallbacks.merge(otherPojo.skipDefaultCallbacks);

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -308,6 +308,8 @@ public class FlywayExtension {
      */
     public Boolean outOfOrder;
 
+    public Boolean suppressOutOfOrderWarning;
+
     /**
      * Whether Flyway should skip actually executing the contents of the migrations and only update the schema history table.
      * This should be used when you have applied a migration manually (via executing the sql yourself, or via an ide), and

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -308,6 +308,9 @@ public class FlywayExtension {
      */
     public Boolean outOfOrder;
 
+    /**
+     * Disables the warning message that is shown during an execution with "outOfOrder" mode.
+     */
     public Boolean suppressOutOfOrderWarning;
 
     /**

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -349,6 +349,9 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      */
     public Boolean outOfOrder;
 
+    /**
+     * Disables the warning message that is shown during an execution with "outOfOrder" mode.
+     */
     public Boolean suppressOutOfOrderWarning;
 
     /**

--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -349,6 +349,8 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      */
     public Boolean outOfOrder;
 
+    public Boolean suppressOutOfOrderWarning;
+
     /**
      * Whether Flyway should skip actually executing the contents of the migrations and only update the schema history table.
      * This should be used when you have applied a migration manually (via executing the sql yourself, or via an ide), and
@@ -723,6 +725,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         putIfSet(conf, ConfigUtils.TARGET, target, extension.target);
         putIfSet(conf, ConfigUtils.LOGGERS, StringUtils.arrayToCommaDelimitedString(loggers), StringUtils.arrayToCommaDelimitedString(extension.loggers));
         putIfSet(conf, ConfigUtils.OUT_OF_ORDER, outOfOrder, extension.outOfOrder);
+        putIfSet(conf, ConfigUtils.SUPPRESS_OUT_OF_ORDER_WARNING, suppressOutOfOrderWarning, extension.suppressOutOfOrderWarning);
         putIfSet(conf, ConfigUtils.SKIP_EXECUTING_MIGRATIONS, skipExecutingMigrations, extension.skipExecutingMigrations);
         putIfSet(conf, ConfigUtils.OUTPUT_QUERY_RESULTS, outputQueryResults, extension.outputQueryResults);
         putIfSet(conf, ConfigUtils.VALIDATE_ON_MIGRATE, validateOnMigrate, extension.validateOnMigrate);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -362,6 +362,9 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     @Parameter(property = ConfigUtils.OUT_OF_ORDER)
     private Boolean outOfOrder;
 
+    @Parameter(property = ConfigUtils.SUPPRESS_OUT_OF_ORDER_WARNING)
+    private Boolean suppressOutOfOrderWarning;
+
     /**
      * Whether Flyway should skip actually executing the contents of the migrations and only update the schema history table.
      * This should be used when you have applied a migration manually (via executing the sql yourself, or via an IDE), and
@@ -781,6 +784,7 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
             putIfSet(conf, ConfigUtils.CLEAN_ON_VALIDATION_ERROR, cleanOnValidationError);
             putIfSet(conf, ConfigUtils.CLEAN_DISABLED, cleanDisabled);
             putIfSet(conf, ConfigUtils.OUT_OF_ORDER, outOfOrder);
+            putIfSet(conf, ConfigUtils.SUPPRESS_OUT_OF_ORDER_WARNING, suppressOutOfOrderWarning);
             putIfSet(conf, ConfigUtils.SKIP_EXECUTING_MIGRATIONS, skipExecutingMigrations);
             putIfSet(conf, ConfigUtils.OUTPUT_QUERY_RESULTS, outputQueryResults);
             putIfSet(conf, ConfigUtils.TARGET, target);

--- a/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -362,6 +362,9 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     @Parameter(property = ConfigUtils.OUT_OF_ORDER)
     private Boolean outOfOrder;
 
+    /**
+     * Disables the warning message that is shown during an execution with "outOfOrder" mode.
+     */
     @Parameter(property = ConfigUtils.SUPPRESS_OUT_OF_ORDER_WARNING)
     private Boolean suppressOutOfOrderWarning;
 


### PR DESCRIPTION
This pull request is a solution for issue #3928 .

I added a new optional configuration flag `suppressOutOfOrderWarning` to suppress the warning message that is mentioned in the issue.

The default value of the flag is `false`, which ensures backward compatibility and doesn't change the current default behaviour.