### PR TITLE
Avoid generating FlywaySqlScriptException message dynamically

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/sqlscript/FlywaySqlScriptException.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/sqlscript/FlywaySqlScriptException.java
@@ -39,6 +39,8 @@ public class FlywaySqlScriptException extends FlywaySqlException {
 
     private final SqlStatement statement;
 
+    private final String decoratedMessage;
+
     public static final String STATEMENT_MESSAGE = "Run Flyway with -X option to see the actual statement causing the problem";
 
     /**
@@ -52,6 +54,16 @@ public class FlywaySqlScriptException extends FlywaySqlException {
         super(resource == null ? "Script failed" : "Script " + resource.getFilename() + " failed", sqlException);
         this.resource = resource;
         this.statement = statement;
+
+        String decoratedMessage = super.getMessage();
+        if (resource != null) {
+            decoratedMessage += "Location   : " + resource.getAbsolutePath() + " (" + resource.getAbsolutePathOnDisk() + ")\n";
+        }
+        if (statement != null) {
+            decoratedMessage += "Line       : " + getLineNumber() + "\n";
+            decoratedMessage += "Statement  : " + (LOG.isDebugEnabled() ? getStatement() : STATEMENT_MESSAGE) + "\n";
+        }
+        this.decoratedMessage = decoratedMessage;
     }
 
     /**
@@ -74,14 +86,6 @@ public class FlywaySqlScriptException extends FlywaySqlException {
 
     @Override
     public String getMessage() {
-        String message = super.getMessage();
-        if (resource != null) {
-            message += "Location   : " + resource.getAbsolutePath() + " (" + resource.getAbsolutePathOnDisk() + ")\n";
-        }
-        if (statement != null) {
-            message += "Line       : " + getLineNumber() + "\n";
-            message += "Statement  : " + (LOG.isDebugEnabled() ? getStatement() : STATEMENT_MESSAGE) + "\n";
-        }
-        return message;
+        return decoratedMessage;
     }
 }


### PR DESCRIPTION
This is suboptimal as we end up generating the same string over and over again and this particular `getMessage()` requires class loader calls (via `resource.getAbsolutePathOnDisk()`).

In Quarkus, we actually call `getMessage()` after the class loader is closed in some cases which causes some issues.

I think this is good practice anyway as better avoid calling the class loader multiple times when an error occurs.

See https://github.com/quarkusio/quarkus/issues/43926 for the background of this change.