### PR TITLE
feat: Add AWS RDS advanced JDBC wrapper for MySQL driver in Flyway

### DIFF
--- a/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLDatabaseType.java
+++ b/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLDatabaseType.java
@@ -92,6 +92,9 @@ public class MySQLDatabaseType extends BaseDatabaseType {
         }
         if (url.startsWith("jdbc:mysql:")) {
             return "com.mysql.cj.jdbc.Driver";
+        }
+        if (url.startsWith("jdbc:aws-wrapper:mysql")) {
+            return "software.amazon.jdbc.Driver";
         } else {
             return "com.mysql.jdbc.GoogleDriver";
         }


### PR DESCRIPTION
Added support for AWS Advanced JDBC Wrapper for MySQL in Flyway

This PR introduces support for the newly released [AWS Advanced JDBC Wrapper for MySQL](https://github.com/aws/aws-advanced-jdbc-wrapper), replacing the use of the legacy [AWS MySQL JDBC driver](https://github.com/awslabs/aws-mysql-jdbc). The previous driver has reached its [end of support](https://github.com/awslabs/aws-mysql-jdbc?tab=readme-ov-file#end-of-support), and this update ensures compatibility with AWS RDS and future enhancements provided by the new driver.
