### PR TITLE
[security]: Fix CVE-2024-49194

### DIFF
--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -423,7 +423,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc</artifactId>
-            <version>2.6.38</version>
+            <version>2.6.40</version>
             <scope>runtime</scope>
         </dependency>
         <!-- #2136: JNA is required for MariaDB with unix sockets -->


### PR DESCRIPTION
Updating [databricks-jdbc](https://mvnrepository.com/artifact/com.databricks/databricks-jdbc) to 2.6.40 seems to fix [CVE-2024-49194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-49194).