### PR TITLE
[snowflake] fix parser

### DIFF
--- a/flyway-database/flyway-database-snowflake/src/main/java/org/flywaydb/database/snowflake/SnowflakeParser.java
+++ b/flyway-database/flyway-database-snowflake/src/main/java/org/flywaydb/database/snowflake/SnowflakeParser.java
@@ -32,7 +32,7 @@ public class SnowflakeParser extends Parser {
     private static final String ALTERNATIVE_QUOTE_SCRIPT = "DECLARE";
     private static final List<String> CONDITIONALLY_CREATABLE_OBJECTS = Arrays.asList(
         "COLUMN", "CONNECTION", "CONSTRAINT", "DATABASE", "FORMAT", "FUNCTION", "GROUP", "INDEX", "INTEGRATION", "PIPE", "POLICY", "PROCEDURE", "ROLE",
-        "SCHEMA", "SEQUENCE", "STAGE", "STREAM", "TABLE", "TAG", "TASK", "USER", "VIEW", "WAREHOUSE", "MONITOR"
+        "SCHEMA", "SEQUENCE", "STAGE", "STREAM", "TABLE", "TAG", "TASK", "USER", "VIEW", "WAREHOUSE", "MONITOR", "COMMENT"
      );
 
     public SnowflakeParser(Configuration configuration, ParsingContext parsingContext) {


### PR DESCRIPTION
snowflake parser fails to parse the following command:
```
COMMENT IF EXISTS ON COLUMN sch.tbl.col IS 'text';
```