### PR TITLE
fix 404 link about how to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ So you've got an awesome idea to throw into Flyway. Great! Please keep the follo
 
 * **Use http://stackoverflow.com/questions/tagged/flyway for Flyway questions that are not bugs.**
 * **Contributions must include the necessary documentation updates.**
-* **Make sure to read https://documentation.red-gate.com/flyway/reference/contribute first**
+* **Make sure to read https://flyway.github.io/flyway/ first**

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
-    Detailed information how to contribute: https://documentation.red-gate.com/fd/code-184127557.html
+    Detailed information how to contribute: https://flyway.github.io/flyway/
 
     To build the OS-specific flyway-commandline assemblies you can run the build with one of the following commands:
     mvn clean install -Pbuild-assemblies-windows


### PR DESCRIPTION
The link to "how to contribute" was returning a 404, 
so I thought it should be updated to the correct one.

in:[CONTRIBUTING.md](https://github.com/flyway/flyway/blob/main/CONTRIBUTING.md)
https://documentation.red-gate.com/flyway/reference/contribute

in:[pom.xml](https://github.com/flyway/flyway/blob/main/pom.xml)
https://documentation.red-gate.com/fd/code-184127557.html