### PR TITLE
Fix OracleParser block-depth underflow (#3871)

### DIFF
--- a/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
+++ b/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 public class OracleParser extends Parser {
 
@@ -114,6 +115,9 @@ public class OracleParser extends Parser {
 
     private static final StatementType PLSQL_WRAPPED_STATEMENT = new StatementType();
     private int initialWrappedBlockDepth = -1;
+
+    // for PACKAGE BODY tracking
+    private String currentPackageName;
 
     private static Pattern toRegex(String... commands) {
         return Pattern.compile(toRegexPattern(commands));
@@ -351,6 +355,15 @@ public class OracleParser extends Parser {
         }
 
         if (PLSQL_PACKAGE_BODY_REGEX.matcher(simplifiedStatement).matches()) {
+            // Store package name (strip optional schema prefix) for END <name> detection
+            Matcher m = PLSQL_PACKAGE_BODY_REGEX.matcher(simplifiedStatement);
+            if (m.find()) {
+                currentPackageName = m.group(4).trim();
+                int dot = currentPackageName.indexOf('.');
+                if (dot >= 0) {
+                    currentPackageName = currentPackageName.substring(dot + 1);
+                }
+            }
             return PLSQL_PACKAGE_BODY_STATEMENT;
         }
 
@@ -491,6 +504,21 @@ public class OracleParser extends Parser {
         int parensDepth = keyword.getParensDepth();
 
         if (lastTokenIs(tokens, parensDepth, "GOTO")) {
+            // Handle END <packageName> inside PACKAGE BODY safely
+            if (context.getStatementType() == PLSQL_PACKAGE_BODY_STATEMENT && "END".equals(keywordText) && currentPackageName != null) {
+                try {
+                    String peek = reader.peek(currentPackageName.length() + 1);
+                    if (peek != null && peek.matches("\\s+" + Pattern.quote(currentPackageName) + "(\\s*;|\\s+/)?")) {
+                        if (context.getBlockDepth() > 0) {
+                            context.decreaseBlockDepth();
+                        }
+                        currentPackageName = null;
+                        return;
+                    }
+                } catch (IOException ignore) {
+                    // Continue with generic logic on peek failure
+                }
+            }
             return;
         }
 
@@ -534,7 +562,9 @@ public class OracleParser extends Parser {
         ) {
             context.increaseBlockDepth(keywordText);
         } else if ("END".equals(keywordText)) {
-            context.decreaseBlockDepth();
+            if (context.getBlockDepth() > 0) {
+                context.decreaseBlockDepth();
+            }
         }
 
         // Package bodies can have an unbalanced BEGIN without END in the initialisation section. This allows us


### PR DESCRIPTION
Fix OracleParser underflow in PACKAGE BODY parsing

Handle END <pkg> specially and guard generic END with blockDepth>0 to prevent the “unable to decrease block depth below 0” error.
