### PR TITLE
Update library license url reference to a stable license url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>https://flywaydb.org/licenses/flyway-oss</url>
+            <url>https://github.com/flyway/flyway/blob/main/README.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
Fixes #3925

Currently the license URL refers to an external link which is currently redirecting to Red Gate product page and not referencing any meaningful and enforceable URL

This change adds a reference to a license that's expected to be associated with the OSS repository at all times.