### PR TITLE
Fix #4063 Repeatable scripts validation fails when updating flyway v1…

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/info/MigrationInfoImpl.java
@@ -458,6 +458,14 @@ public class MigrationInfoImpl implements MigrationInfo {
         return result;
     }
 
+    /**
+     * Overriden to handle repeatable script checksum mismatch on migrate - https://github.com/flyway/flyway/issues/4063
+     */
+    @Override
+    public boolean isChecksumMatching() {
+        return this.resolvedMigration.checksumMatches(this.appliedMigration.getChecksum());
+    }
+
     @Override
     public Integer getResolvedChecksum() {
         return resolvedMigration == null ? null : resolvedMigration.getChecksum();


### PR DESCRIPTION
An unmodified repeatable script (from flyway v7) fails to be applied when flyway in the project is updated from flyway v10.10 .0 to v10.18.2. 

Since, its a repeatable script, it has to be recognized as outdated and applied, instead of failing at validation.