### PR TITLE
Gradle Plugin: Use task configuration avoidance API

### DIFF
--- a/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayPlugin.java
+++ b/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayPlugin.java
@@ -29,12 +29,12 @@ import org.gradle.api.Project;
 public class FlywayPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getExtensions().create("flyway", FlywayExtension.class);
-        project.getTasks().create("flywayClean", FlywayCleanTask.class);
-        project.getTasks().create("flywayBaseline", FlywayBaselineTask.class);
-        project.getTasks().create("flywayMigrate", FlywayMigrateTask.class);
-        project.getTasks().create("flywayUndo", FlywayUndoTask.class);
-        project.getTasks().create("flywayValidate", FlywayValidateTask.class);
-        project.getTasks().create("flywayInfo", FlywayInfoTask.class);
-        project.getTasks().create("flywayRepair", FlywayRepairTask.class);
+        project.getTasks().register("flywayClean", FlywayCleanTask.class);
+        project.getTasks().register("flywayBaseline", FlywayBaselineTask.class);
+        project.getTasks().register("flywayMigrate", FlywayMigrateTask.class);
+        project.getTasks().register("flywayUndo", FlywayUndoTask.class);
+        project.getTasks().register("flywayValidate", FlywayValidateTask.class);
+        project.getTasks().register("flywayInfo", FlywayInfoTask.class);
+        project.getTasks().register("flywayRepair", FlywayRepairTask.class);
     }
 }


### PR DESCRIPTION
This PR updates the Flyway Gradle plugin to use Gradle's [Task configuration avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html).

This update is part of https://github.com/flyway/flyway/pull/3879, but I've created a separate PR for it as this change is useful on its own.