### PR TITLE
Test necessity of logger replacement before logging

### DIFF
--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/console/ColorizedConsoleLog.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/console/ColorizedConsoleLog.java
@@ -45,6 +45,26 @@ public class ColorizedConsoleLog implements Log {
     }
 
     @Override
+    public boolean isInfoEnabled() {
+        return this.log.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return this.log.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return this.log.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return this.log.isNoticeEnabled();
+    }
+
+    @Override
     public void debug(String message) {
         colorizeBright(System.out, Color.BLACK);
         this.log.debug(message);

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/console/ConsoleLog.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/console/ConsoleLog.java
@@ -35,6 +35,26 @@ public class ConsoleLog implements Log {
         return level == Level.DEBUG;
     }
 
+    @Override
+    public boolean isInfoEnabled() {
+        return level.compareTo(Level.INFO) <= 0;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return level.compareTo(Level.WARN) <= 0;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return level.compareTo(Level.INFO) <= 0;
+    }
+
     public void debug(String message) {
         if (isDebugEnabled()) {
             System.out.println("DEBUG: " + message);

--- a/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/file/FileLog.java
+++ b/flyway-commandline/src/main/java/org/flywaydb/commandline/logging/file/FileLog.java
@@ -43,6 +43,26 @@ public class FileLog implements Log {
     }
 
     @Override
+    public boolean isInfoEnabled() {
+        return level.compareTo(Level.INFO) <= 0;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return level.compareTo(Level.WARN) <= 0;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return false;
+    }
+
+    @Override
     public void debug(String message) {
         if (isDebugEnabled()) {
             writeLogMessage("DEBUG", message);

--- a/flyway-core/src/main/java/org/flywaydb/core/api/logging/Log.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/logging/Log.java
@@ -23,6 +23,14 @@ public interface Log {
 
     boolean isDebugEnabled();
 
+    boolean isInfoEnabled();
+
+    boolean isWarnEnabled();
+
+    boolean isErrorEnabled();
+
+    boolean isNoticeEnabled();
+
     void debug(String message);
 
     void info(String message);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/EvolvingLog.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/EvolvingLog.java
@@ -51,37 +51,75 @@ public class EvolvingLog implements Log {
     }
 
     @Override
+    public boolean isInfoEnabled() {
+        return log.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return log.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return log.isNoticeEnabled();
+    }
+
+    @Override
     public void debug(String message) {
+        if (!isDebugEnabled()) {
+            return;
+        }
         updateLog();
         log.debug(message);
     }
 
     @Override
     public void info(String message) {
+        if (!isInfoEnabled()) {
+            return;
+        }
         updateLog();
         log.info(message);
     }
 
     @Override
     public void warn(String message) {
+        if (!isWarnEnabled()) {
+            return;
+        }
         updateLog();
         log.warn(message);
     }
 
     @Override
     public void error(String message) {
+        if (!isErrorEnabled()) {
+            return;
+        }
         updateLog();
         log.error(message);
     }
 
     @Override
     public void error(String message, Exception e) {
+        if (!isErrorEnabled()) {
+            return;
+        }
         updateLog();
         log.error(message, e);
     }
 
     @Override
     public void notice(String message) {
+        if (!isNoticeEnabled()) {
+            return;
+        }
         updateLog();
         log.notice(message);
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/apachecommons/ApacheCommonsLog.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/apachecommons/ApacheCommonsLog.java
@@ -32,6 +32,26 @@ public class ApacheCommonsLog implements Log {
         return logger.isDebugEnabled();
     }
 
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return false;
+    }
+
     public void debug(String message) {
         logger.debug(message);
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/buffered/BufferedLog.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/buffered/BufferedLog.java
@@ -34,6 +34,26 @@ public class BufferedLog implements Log {
     }
 
     @Override
+    public boolean isInfoEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return true;
+    }
+
+    @Override
     public void debug(String message) {
         bufferedLogMessages.add(new BufferedLogMessage(message, Level.DEBUG));
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/javautil/JavaUtilLog.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/javautil/JavaUtilLog.java
@@ -36,6 +36,26 @@ public class JavaUtilLog implements Log {
         return logger.isLoggable(Level.FINE);
     }
 
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isLoggable(Level.INFO);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isLoggable(Level.WARNING);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isLoggable(Level.SEVERE);
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return false;
+    }
+
     public void debug(String message) {
         log(Level.FINE, message, null);
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/log4j2/Log4j2Log.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/log4j2/Log4j2Log.java
@@ -20,6 +20,7 @@
 package org.flywaydb.core.internal.logging.log4j2;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.flywaydb.core.api.logging.Log;
 
@@ -31,6 +32,26 @@ public class Log4j2Log implements Log {
     @Override
     public boolean isDebugEnabled() {
         return logger.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return false;
     }
 
     public void debug(String message) {logger.debug(message);}

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/multi/MultiLogger.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/multi/MultiLogger.java
@@ -44,6 +44,50 @@ public class MultiLogger implements Log {
     }
 
     @Override
+    public boolean isInfoEnabled() {
+        for (Log log : logs) {
+            if (!log.isInfoEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        for (Log log : logs) {
+            if (!log.isWarnEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        for (Log log : logs) {
+            if (!log.isErrorEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        for (Log log : logs) {
+            if (!log.isNoticeEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
     public void debug(String message) {
         for (Log log : logs) {
             log.debug(message);

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/logging/slf4j/Slf4jLog.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/logging/slf4j/Slf4jLog.java
@@ -33,6 +33,26 @@ public class Slf4jLog implements Log {
         return logger.isDebugEnabled();
     }
 
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isNoticeEnabled() {
+        return false;
+    }
+
     public void debug(String message) {
         logger.debug(message);
     }


### PR DESCRIPTION
This code optimizes thread performance by checking if the logging level is enabled before proceeding with expensive operations. The guard clause in EvolvingLog prevents unnecessary blocking when multiple threads call logging methods that won't actually output anything due to the current log level configuration. This reduces contention on the synchronized updateLog() method when logging is disabled for that level.