### PR TITLE
Redact empty and multiple password params

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/DatabaseTypeRegister.java
@@ -113,11 +113,17 @@ public class DatabaseTypeRegister {
 
     private static String redactJdbcUrl(final String url, final Pattern pattern) {
         final Matcher matcher = pattern.matcher(url);
-        if (matcher.find()) {
-            final String password = matcher.group(1);
-            return url.replace(password, "********");
+        final String replacement = "********";
+        final StringBuilder redactedJdbcUrlBuilder = new StringBuilder();
+        int lastEndIndex = 0;
+
+        while (matcher.find()) {
+            redactedJdbcUrlBuilder.append(url, lastEndIndex, matcher.start(1));
+            redactedJdbcUrlBuilder.append(replacement);
+            lastEndIndex = matcher.end(1);
         }
-        return url;
+        redactedJdbcUrlBuilder.append(url.substring(lastEndIndex));
+        return redactedJdbcUrlBuilder.toString();
     }
 
     public static DatabaseType getDatabaseTypeForConnection(final Connection connection,

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/BaseDatabaseType.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/BaseDatabaseType.java
@@ -49,7 +49,7 @@ import static org.flywaydb.core.internal.sqlscript.SqlScriptMetadata.getMetadata
 @CustomLog
 public abstract class BaseDatabaseType implements DatabaseType {
     // Don't grab semicolons and ampersands - they have special meaning in URLs
-    private static final Pattern defaultJdbcCredentialsPattern = Pattern.compile("password=([^;&]*).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern defaultJdbcCredentialsPattern = Pattern.compile("[;&?]password=([^;&]*)(?=[;&])?", Pattern.CASE_INSENSITIVE);
     private static final Pattern hostJdbcCredentialsPattern = Pattern.compile("(?:jdbc:)?[^:]+://[^:]+:([^@]+)@.*", Pattern.CASE_INSENSITIVE);
 
     /**


### PR DESCRIPTION
Improves the `redactJdbcUrl` method such that it
- properly handles an empty password param
  - The current implementation properly finds an empty password param, but by attempting to replace all instances of it in the url it ends up injecting `********` between every character. This code replaces the found password at its location, and replaces even an empty password in order not to leak the fact that a DB does not have a password.
- redacts multiple password params
  - The current implementation replaces all instances of the first found password, but would not handle `password=foo&password=bar&foooo=bar`, as it would convert it to `password=********&password=bar&********oo=bar`. Legitimacy of multiple passwords aside, this improves prevention leaking of passwords.

I wrote up some unit tests but I noticed there currently was not any set up otherwise, so I have not committed them for now. Is there appetite for having those included as well?