### PR TITLE
Fix Gradle dependency notation in Oracle DB docs

### DIFF
--- a/documentation/Reference/Database Driver Reference/Oracle Database.md
+++ b/documentation/Reference/Database Driver Reference/Oracle Database.md
@@ -58,16 +58,20 @@ Oracle support is a separate dependency for Flyway and will need to be added to 
 #### Redgate
 
 ```groovy
-dependencies {
-    implementation "com.redgate.flyway:flyway-database-oracle"
+buildscript {
+    dependencies {
+        classpath "com.redgate.flyway:flyway-database-oracle"
+    }
 }
 ```
 
 #### Open Source
 
 ```groovy
-dependencies {
-    implementation "org.flywaydb:flyway-database-oracle"
+buildscript {
+    dependencies {
+        classpath "org.flywaydb:flyway-database-oracle"
+    }
 }
 ```
 


### PR DESCRIPTION
Hi,

As is already correctly stated in [the docs for the Gradle task](https://documentation.red-gate.com/flyway/reference/usage/gradle-task), flyway database plugins should nowadays need to be declared as Gradle buildscript dependencies.

The documentation for Oracle DB still contains some old snippets that reference the old way of declaring it as a project dependency, which does not work anymore.

I fixed that because it can be quite confusing when you stumble upon the Oracle docs and find contradictory information.