### PR TITLE
Fix tablespace property not applied to schema history index in Oracle and DB2

### DIFF
--- a/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
+++ b/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
@@ -69,7 +69,7 @@ public class DB2Database extends Database<DB2Connection> {
                 ")" + (getVersion().isAtLeast("10.5") ? "" : " ORGANIZE BY ROW")
                 + tablespace + ";\n" +
                 "ALTER TABLE " + table + " ADD CONSTRAINT \"" + table.getName() + "_pk\" PRIMARY KEY (\"installed_rank\");\n" +
-                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");" +
+                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\")" + tablespace + ";" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "");
     }
 

--- a/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabase.java
+++ b/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabase.java
@@ -85,7 +85,7 @@ public class OracleDatabase extends Database<OracleConnection> {
                 "    CONSTRAINT \"" + table.getName() + "_pk\" PRIMARY KEY (\"installed_rank\")\n" +
                 ")" + tablespace + ";\n" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "") +
-                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");\n";
+                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\")" + tablespace + ";\n";
     }
 
     @Override


### PR DESCRIPTION
# Fix tablespace property not applied to schema history index in Oracle and DB2

## Description
Fixes #4155 - The `flyway_schema_history_s_idx` index now honors the `tablespace` configuration property in Oracle and DB2 databases. Previously, only the table and primary key index used the configured tablespace, while the success column index was created in the default tablespace.

## Changes
This PR adds the tablespace clause to the `CREATE INDEX` statement for the `_s_idx` index in both Oracle and DB2 database implementations.

### Modified Files
- `flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabase.java`
- `flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java`

### Oracle Fix
**File:** `OracleDatabase.java` (line 88)

**Before:**
```java
"CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");\n";
```

**After:**
```java
"CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\")" + tablespace + ";\n";
```

### DB2 Fix
**File:** `DB2Database.java` (line 72)

**Before:**
```java
"CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");" +
```

**After:**
```java
"CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\")" + tablespace + ";" +
```

## Testing
Tested with Oracle database by:
1. Configuring `spring.flyway.tablespace=SML_01`
2. Running Flyway migration
3. Querying `dba_indexes` to verify all three objects (table, pk index, s_idx index) are in the configured tablespace

**Before fix:**
```
INDEX_NAME                     TABLESPACE_NAME               
------------------------------ ------------------------------
flyway_schema_history_pk       SML_01                    
flyway_schema_history_s_idx    USERS_LOCAL     <-- Wrong!
```

**After fix:**
```
INDEX_NAME                     TABLESPACE_NAME               
------------------------------ ------------------------------
flyway_schema_history_pk       SML_01                    
flyway_schema_history_s_idx    SML_01      <-- Correct!
```

## Notes
- The `tablespace` variable is already properly formatted with the database-specific syntax:
  - Oracle: ` TABLESPACE "tablespace_name"`
  - DB2: ` IN "tablespace_name"`
- PostgreSQL already correctly applies the tablespace to the `_s_idx` index (verified in `PostgreSQLDatabase.java` line 75)
- No unit tests exist in the database modules (verified `pom.xml` files have no test dependencies)
- This is a minimal, single-line fix per database that follows the existing pattern used for the table creation

## Related Issues
Closes #4155

## Checklist
- [x] Code follows the existing style and patterns
- [x] Fix is minimal and focused
- [x] Changes are backward compatible (only affects new schema history table creation)
- [x] Both Oracle and DB2 implementations fixed consistently
- [x] Verified the fix resolves the reported issue
