### PR TITLE
Move cleanOnValidationError into Maven&Gradle plugins

### DIFF
--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -382,15 +382,19 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     public Boolean validateOnMigrate;
 
     /**
-     * Deprecated, will be removed in a future release. <br> Whether to automatically call clean or not when a
+     * Whether to automatically call clean or not when a
      * validation error occurs. (default: {@code false}) This is exclusively intended as a convenience for development.
      * even though we strongly recommend not to change migration scripts once they have been checked into SCM and run,
      * this provides a way of dealing with this case in a smooth manner. The database will be wiped clean automatically,
      * ensuring that the next migration will bring you back to the state checked into SCM.
      * <b>Warning! Do not enable in production!</b>
-     * <p>Also configurable with Gradle or System Property: ${flyway.cleanOnValidationError}</p>
+     * <p>
+     * This feature has been moved from the Flyway core into the Gradle plugin.<br>
+     * Also configurable with Gradle or System Property: ${flyway.cleanOnValidationError}
+     * </p>
      */
     public Boolean cleanOnValidationError;
+    protected boolean cleanOnValidationErrorEnabled;
 
     /**
      * Ignore migrations that match this comma-separated list of patterns when validating migrations. Each pattern is of
@@ -607,6 +611,8 @@ public abstract class AbstractFlywayTask extends DefaultTask {
                 getProject().getBuildscript().getClassLoader());
 
             final Map<String, String> config = createFlywayConfig(envVars);
+            cleanOnValidationErrorEnabled = Boolean.TRUE.equals(
+                ConfigUtils.removeBoolean(config, ConfigUtils.CLEAN_ON_VALIDATION_ERROR));
             ConfigUtils.dumpConfigurationMap(config, "Using configuration:");
 
             final Flyway flyway = Flyway.configure(classLoader).configuration(config).load();

--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayMigrateTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayMigrateTask.java
@@ -20,6 +20,7 @@
 package org.flywaydb.gradle.task;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.exception.FlywayValidateException;
 
 public class FlywayMigrateTask extends AbstractFlywayTask {
     public FlywayMigrateTask() {
@@ -29,6 +30,15 @@ public class FlywayMigrateTask extends AbstractFlywayTask {
 
     @Override
     protected Object run(Flyway flyway) {
-        return flyway.migrate();
+        try {
+            return flyway.migrate();
+        } catch (final FlywayValidateException e) {
+            if (cleanOnValidationErrorEnabled) {
+                getLogger().info("Validation failed. Cleaning database because cleanOnValidationError is enabled.");
+                flyway.clean();
+                return flyway.migrate();
+            }
+            throw e;
+        }
     }
 }

--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayValidateTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayValidateTask.java
@@ -20,6 +20,7 @@
 package org.flywaydb.gradle.task;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.exception.FlywayValidateException;
 
 /**
  * <p>Validate applied migrations against resolved ones (on the filesystem or classpath)
@@ -45,7 +46,16 @@ public class FlywayValidateTask extends AbstractFlywayTask {
 
     @Override
     protected Object run(Flyway flyway) {
-        flyway.validate();
+        try {
+            flyway.validate();
+        } catch (final FlywayValidateException e) {
+            if (cleanOnValidationErrorEnabled) {
+                getLogger().info("Validation failed. Cleaning database because cleanOnValidationError is enabled.");
+                flyway.clean();
+            } else {
+                throw e;
+            }
+        }
         return null;
     }
 }

--- a/flyway-plugins/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
+++ b/flyway-plugins/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java
@@ -300,17 +300,21 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
     private String[] sqlMigrationSuffixes;
 
     /**
-     * Deprecated, will be removed in a future release. <br> Whether to automatically call clean or not when a
+     * Whether to automatically call clean or not when a
      * validation error occurs. (default: {@code false})
      * <p>This is exclusively intended as a convenience for development. even though we strongly recommend not to
      * change migration scripts once they have been checked into SCM and run, this provides a way of dealing with this
      * case in a smooth manner. The database will be wiped clean automatically, ensuring that the next migration will
      * bring you back to the state checked into SCM.</p>
      * <p><b>Warning! Do not enable in production!</b></p>
-     * <p>Also configurable with Maven or System Property: ${flyway.cleanOnValidationError}</p>
+     * <p>
+     * This feature has been moved from the Flyway core into the Maven plugin.<br>
+     * Also configurable with Maven or System Property: ${flyway.cleanOnValidationError}
+     * </p>
      */
     @Parameter(property = ConfigUtils.CLEAN_ON_VALIDATION_ERROR)
     private Boolean cleanOnValidationError;
+    protected boolean cleanOnValidationErrorEnabled;
 
     /**
      * Whether to disable clean. (default: {@code false}) This is especially useful for production environments where
@@ -837,6 +841,8 @@ abstract class AbstractFlywayMojo extends AbstractMojo {
             conf.putAll(envVars);
             conf.putAll(ConfigUtils.propertiesToMap(System.getProperties()));
             removeMavenPluginSpecificPropertiesToAvoidWarnings(conf);
+            cleanOnValidationErrorEnabled = Boolean.TRUE.equals(
+                ConfigUtils.removeBoolean(conf, ConfigUtils.CLEAN_ON_VALIDATION_ERROR));
 
             if ("auto".equalsIgnoreCase(conf.getOrDefault(ConfigUtils.LOGGERS, "auto"))) {
                 conf.put(ConfigUtils.LOGGERS, "maven");

--- a/flyway-plugins/flyway-maven-plugin/src/main/java/org/flywaydb/maven/ValidateMojo.java
+++ b/flyway-plugins/flyway-maven-plugin/src/main/java/org/flywaydb/maven/ValidateMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.exception.FlywayValidateException;
 
 /**
  * <p>Validate applied migrations against resolved ones (on the filesystem or classpath)
@@ -44,6 +45,15 @@ import org.flywaydb.core.Flyway;
 public class ValidateMojo extends AbstractFlywayMojo {
     @Override
     protected void doExecute(Flyway flyway) {
-        flyway.validate();
+        try {
+            flyway.validate();
+        } catch (final FlywayValidateException e) {
+            if (cleanOnValidationErrorEnabled) {
+                getLog().info("Validation failed. Cleaning database because cleanOnValidationError is enabled.");
+                flyway.clean();
+            } else {
+                throw e;
+            }
+        }
     }
 }


### PR DESCRIPTION
This feature has been removed from the Flyway core because of the issues with global configuration using TOML files.
https://documentation.red-gate.com/fd/deprecation-of-clean-on-validation-error-254154581.html

Closes #3957