### PR TITLE
Issue #4184 Add configuration logic to MySQL connection for skipping user_variables_by_thread check

### DIFF
--- a/documentation/Reference/Configuration/Flyway Namespace/Flyway MySQL Namespace.md
+++ b/documentation/Reference/Configuration/Flyway Namespace/Flyway MySQL Namespace.md
@@ -1,0 +1,11 @@
+---
+subtitle: flyway.mysql
+---
+
+This namespace contains the configurations specific to MySQL databases.
+
+## Settings
+
+| Setting                                                                                                                            | Tier       | Type    | Description                                                                                            |
+|------------------------------------------------------------------------------------------------------------------------------------|------------|---------|--------------------------------------------------------------------------------------------------------|
+| [`skipUserVariableReset`](<Configuration/Flyway Namespace/Flyway MySQL Namespace/Flyway MySQL Skip User Variable Reset Setting>) | Community  | Boolean | Skip the user variable reset capability check that requires access to `performance_schema` system tables. |

--- a/documentation/Reference/Configuration/Flyway Namespace/Flyway MySQL Namespace/Flyway MySQL Skip User Variable Reset Setting.md
+++ b/documentation/Reference/Configuration/Flyway Namespace/Flyway MySQL Namespace/Flyway MySQL Skip User Variable Reset Setting.md
@@ -1,0 +1,161 @@
+---
+subtitle: flyway.mysql.skipUserVariableReset
+redirect_from: Configuration/mysqlSkipUserVariableReset/
+---
+
+## Description
+
+Skip the user variable reset capability check during MySQL connection initialization. 
+
+When Flyway connects to a MySQL database, it attempts to determine if the database supports user variable reset by querying the `performance_schema.user_variables_by_thread` system table. This check requires `SELECT` permission on `performance_schema` tables.
+
+If your MySQL user account does not have permission to access `performance_schema`, you can enable this setting to skip the check. This will prevent `SQLSyntaxErrorException` errors during Flyway initialization.
+This exception can cause critical issues when using connection pools like Druid, which treat this error as fatal and disable the affected connection, potentially triggering cascading failures in dependent components.
+
+## Type
+
+Boolean
+
+## Default
+
+`false`
+
+## Usage
+
+### Flyway Desktop
+
+This can't be set in a config file via Flyway Desktop, although it will be honoured, and it can be configured as an advanced parameter in operations on the Migrations page.
+
+### Command-line
+
+```powershell
+./flyway -mysql.skipUserVariableReset="true" migrate
+```
+
+### TOML Configuration File
+
+```toml
+[flyway.mysql]
+skipUserVariableReset = true
+```
+
+### Configuration File
+
+```properties
+flyway.mysql.skipUserVariableReset=true
+```
+
+### Environment Variable
+
+```properties
+FLYWAY_MYSQL_SKIP_USER_VARIABLE_RESET=true
+```
+
+### API
+
+```java
+MysqlConfigurationExtension mysqlConfigurationExtension = configuration.getConfigurationExtension(MysqlConfigurationExtension.class);
+mysqlConfigurationExtension.setSkipUserVariableReset(true);
+```
+
+### Gradle
+
+```groovy
+flyway {
+    mysqlSkipUserVariableReset = true
+}
+```
+
+### Maven
+
+```xml
+<configuration>
+    <mysqlSkipUserVariableReset>true</mysqlSkipUserVariableReset>
+</configuration>
+```
+
+### Spring Boot
+
+When using Spring Boot with Flyway, you can configure this setting in your `application.yml` or `application.properties`:
+#### Configuration customizer
+```java
+
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.database.mysql.MysqlConfigurationExtension;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Component
+@ConditionalOnClass(name = "org.flywaydb.database.mysql.MysqlConfigurationExtension")
+@ConfigurationProperties("spring.flyway.mysql")
+@Order(1)
+@Data
+public class MysqlFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
+
+    private Boolean skipUserVariableReset;
+
+    @Override
+    public void customize(FluentConfiguration configuration) {
+        if (skipUserVariableReset != null) {
+            MysqlConfigurationExtension mysqlConfig = configuration.getPluginRegister().getExact(MysqlConfigurationExtension.class);
+            if(mysqlConfig != null){
+                mysqlConfig.setSkipUserVariableReset(skipUserVariableReset);
+            }
+        }
+    }
+}
+```
+#### application.yml
+
+```yaml
+spring:
+  flyway:
+    mysql:
+      skip-user-variable-reset: true
+```
+
+or using kebab-case:
+
+```yaml
+spring:
+  flyway:
+    mysql:
+      skipUserVariableReset: true
+```
+
+#### application.properties
+
+```properties
+spring.flyway.properties.flyway.mysql.skip-user-variable-reset=true
+```
+
+## Use Cases
+
+### Database user with restricted permissions
+
+When your MySQL database user is restricted and does not have `SELECT` permission on `performance_schema.user_variables_by_thread`, you will encounter the following error:
+
+```
+java.sql.SQLSyntaxErrorException: SELECT command denied to user 'your_user'@'your_host' for table 'user_variables_by_thread'
+```
+
+In this case, enable `skipUserVariableReset` to bypass the capability check:
+
+```properties
+flyway.mysql.skipUserVariableReset=true
+```
+
+This allows Flyway to initialize successfully without requiring additional database permissions.
+
+### Cloud-managed databases with restricted system table access
+
+Some cloud database providers (e.g., AWS RDS, Azure Database for MySQL) may restrict access to certain `performance_schema` tables for security reasons. Setting this option to `true` allows Flyway to work with these restricted database instances.
+
+## Related Configuration
+
+- [Flyway MySQL Namespace](<Configuration/Flyway Namespace/Flyway MySQL Namespace>) - Overview of all MySQL-specific configurations

--- a/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
+++ b/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MySQLConnection.java
@@ -21,6 +21,7 @@ package org.flywaydb.database.mysql;
 
 import lombok.CustomLog;
 import lombok.Getter;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Connection;
 import org.flywaydb.core.internal.database.base.Schema;
 import org.flywaydb.core.internal.database.base.Table;
@@ -78,6 +79,17 @@ public class MySQLConnection extends Connection<MySQLDatabase> {
         if (!database.isMariaDB() && !database.getVersion().isAtLeast("5.7")) {
             LOG.debug("Disabled user variable reset as it is only available from MySQL 5.7 onwards");
             return false;
+        }
+        Configuration config = database.getConfiguration();
+        if(config != null){
+            MysqlConfigurationExtension configurationExtension = config.getPluginRegister().getExact(MysqlConfigurationExtension.class);
+            if(configurationExtension != null){
+                Boolean skipUserVariableReset = configurationExtension.getSkipUserVariableReset();
+                if(skipUserVariableReset != null && skipUserVariableReset){
+                    LOG.debug("Disabled user variable reset as it is skipped in configuration");
+                    return false;
+                }
+            }
         }
 
         try {

--- a/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MysqlConfigurationExtension.java
+++ b/flyway-database/flyway-mysql/src/main/java/org/flywaydb/database/mysql/MysqlConfigurationExtension.java
@@ -1,0 +1,63 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-oracle
+ * ========================================================================
+ * Copyright (C) 2010 - 2025 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.database.mysql;
+
+import lombok.Data;
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+
+/**
+ * Configuration extension for MySQL database-specific settings.
+ * <p>
+ * This extension provides additional configuration options specific to MySQL databases,
+ * allowing users to customize Flyway's behavior when working with MySQL.
+ * </p>
+ */
+@Data
+public class MysqlConfigurationExtension implements ConfigurationExtension {
+
+    /**
+     * Configuration parameter name for skipping user variable reset.
+     */
+    private static final String FLYWAY_MYSQL_SKIP_USER_VARIABLE_RESET = "flyway.mysql.skipUserVariableReset";
+
+    /**
+     * Skip the user variable reset capability check during MySQL connection initialization. 
+     * If your MySQL user account does not have permission to access `performance_schema`, you can enable this setting to skip the check. This will prevent `SQLSyntaxErrorException` errors during Flyway initialization.
+     * when using connection pools like Druid, which treat this error as fatal and disable the affected connection, potentially triggering cascading failures in dependent components. 
+     * Default value is {@code false}.
+     * </p>
+     */
+    private Boolean skipUserVariableReset = false;
+
+    @Override
+    public String getNamespace() {
+        return "mysql";
+    }
+
+    @Override
+    public String getConfigurationParameterFromEnvironmentVariable(String environmentVariable) {
+        switch (environmentVariable) {
+            case "FLYWAY_MYSQL_SKIP_USER_VARIABLE_RESET":
+                return FLYWAY_MYSQL_SKIP_USER_VARIABLE_RESET;
+            default:
+                return null;
+        }
+    }
+}

--- a/flyway-database/flyway-mysql/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-database/flyway-mysql/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,2 +1,3 @@
 org.flywaydb.database.mysql.MySQLDatabaseType
 org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType
+org.flywaydb.database.mysql.MysqlConfigurationExtension


### PR DESCRIPTION
feat(mysql): add support for skipping user variable reset via configuration

- Add configuration logic to MySQL connection for skipping user variable reset
- Retrieve skipUserVariableReset configuration via MysqlConfigurationExtension plugin
- Disable user variable reset functionality and log debug message when skip is enabled
- Register MysqlConfigurationExtension in plugin registry to ensure extension is active