### PR TITLE
Class cannot be located on the disk when using instrumentation agents like jacoco

### DIFF
--- a/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabaseType.java
+++ b/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleDatabaseType.java
@@ -271,13 +271,15 @@ public class OracleDatabaseType extends BaseDatabaseType {
         
         // Using System.setProperty("java.util.logging.config.file", {filePath}) here has no effect.
         // Because the JVM initializes the logging configuration early during startup.
-        String loggingPropertiesFile = Paths.get(ClassUtils.getInstallDir(this.getClass()), "assets/logging.properties").toString();
-        if (new File(loggingPropertiesFile).exists()) {
-            try (FileInputStream fis = new FileInputStream(loggingPropertiesFile)) {
-                LOG.debug("Initializing Java logging with custom properties file");
-                LogManager.getLogManager().readConfiguration(fis);
-            } catch (Exception ignored) {
-            }
+        if (ClassUtils.getLocationOnDisk(this.getClass()) != null) {
+            String loggingPropertiesFile = Paths.get(ClassUtils.getInstallDir(this.getClass()), "assets/logging.properties").toString();
+                if (new File(loggingPropertiesFile).exists()) {
+                    try (FileInputStream fis = new FileInputStream(loggingPropertiesFile)) {
+                        LOG.debug("Initializing Java logging with custom properties file");
+                        LogManager.getLogManager().readConfiguration(fis);
+                    } catch (Exception ignored) {
+                }
+            }            
         }
 
         String oracleHome = System.getenv(ORACLE_HOME);


### PR DESCRIPTION
Hello community
We have found the issue in our test using oracle db together with jacoco. Since 11.7.1 is failing this with NullPointerException. The issue was already reported to quarkus community: https://github.com/quarkusio/quarkus/issues/49566

This fix should handle this case.
Thank you very much for merging to mainstream.
Regards
myroch