### PR TITLE
Fix #4186: Change failOnMissingLocations from primitive boolean to Bo…

### DIFF
--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -578,7 +578,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      *
      * @return @{code true} to fail (default: {@code false})
      */
-    public boolean failOnMissingLocations;
+    public Boolean failOnMissingLocations;
 
     /**
      * The configuration for plugins You will need to configure this with the key and value specific to your plugin


### PR DESCRIPTION
# Title:


Fix #4186: Change failOnMissingLocations from primitive boolean to Boolean wrapper in Gradle plugin
Body:


## Summary
- Fix `failOnMissingLocations` configuration being ignored in Gradle plugin
- Changed field type from primitive `boolean` to `Boolean` wrapper class

## Problem
The `failOnMissingLocations` field in `AbstractFlywayTask` was declared as primitive `boolean`, which:
1. Always defaults to `false` and can never be `null`
2. Causes `putIfSet()` to always use the default value instead of user-configured value
3. Makes Gradle configuration like `failOnMissingLocations = true` ineffective

## Solution
Changed `public boolean failOnMissingLocations` to `public Boolean failOnMissingLocations` to match the pattern used by all other 19 boolean configuration fields in this class.

## Related Issues
- Fixes #4186
- Same bug pattern as #3940 (connectRetries/connectRetriesInterval)

## Test plan
- [x] Build compiles successfully (`mvn compile`)
- [ ] Manual test: Set `failOnMissingLocations = true` in Gradle and verify it takes effect