### PR TITLE
Fix #3940: Change connectRetries and connectRetriesInterval from prim…

### DIFF
--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/FlywayExtension.java
@@ -53,7 +53,7 @@ public class FlywayExtension {
      * (default: 0)
      * <p>Also configurable with Gradle or System Property: ${flyway.connectRetries}</p>
      */
-    public int connectRetries;
+    public Integer connectRetries;
 
     /**
      * The maximum time between retries when attempting to connect to the database in seconds. This will cap the interval
@@ -61,7 +61,7 @@ public class FlywayExtension {
      * (default: 120)
      * <p>Also configurable with Gradle or System Property: ${flyway.connectRetriesInterval}</p>
      */
-    public int connectRetriesInterval;
+    public Integer connectRetriesInterval;
 
     /**
      * The SQL statements to run to initialize a new database connection immediately after opening it. (default: {@code null})

--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -104,14 +104,14 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      * The interval between retries doubles with each subsequent attempt. (default: 0)
      * <p>Also configurable with Gradle or System Property: ${flyway.connectRetries}</p>
      */
-    public int connectRetries;
+    public Integer connectRetries;
 
     /**
      * The maximum time between retries when attempting to connect to the database in seconds. This will cap the
      * interval between connect retry to the value provided. (default: 120)
      * <p>Also configurable with Gradle or System Property: ${flyway.connectRetriesInterval}</p>
      */
-    public int connectRetriesInterval;
+    public Integer connectRetriesInterval;
 
     /**
      * The SQL statements to run to initialize a new database connection immediately after opening it. (default:


### PR DESCRIPTION
## Summary
- Fix `connectRetries` and `connectRetriesInterval` configuration being ignored in Gradle plugin
- Changed field types from primitive `int` to `Integer` wrapper class in both `AbstractFlywayTask` and `FlywayExtension`

## Problem
Primitive `int` always defaults to 0 and can never be null, causing `putIfSet()` to always use the default value instead of user-configured values.

## Solution
Changed to `Integer` wrapper to match:
- Maven plugin (already uses `Integer`)
- `lockRetryCount` field in the same class (uses `Integer`)

## Related Issues
- Fixes #3940