### PR TITLE
Fix #4200: Resolve dependency conflict by upgrading oauth2-oidc-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -753,7 +753,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>oauth2-oidc-sdk</artifactId>
-        <version>10.7.1</version>
+        <version>11.32</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This PR resolves issue #4200 by upgrading the `oauth2-oidc-sdk` dependency.

### Changes
- Upgraded `com.nimbusds:oauth2-oidc-sdk` from `10.7.1` to `11.32` in `pom.xml`.

### Reason
- The previous version (10.7.1) caused a conflict with `json-smart:2.5.2` required by `msal4j`.
- Upgrading to version `11.32` aligns the dependencies and resolves the conflict.

### Verification
- Verified build and dependency tree locally using `./mvnw dependency:tree`.
- Confirmed that `flyway-commandline` builds successfully without conflict errors.