### PR TITLE
Update aws-secretsmanager version to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <version.antlr>4.13.2</version.antlr>
     <version.appinsights>3.4.7</version.appinsights>
     <version.aws-java-sdk>2.32.22</version.aws-java-sdk> <!-- TODO: revert back to range once nexus is better -->
-    <version.aws-secretsmanager>2.0.2</version.aws-secretsmanager>
+    <version.aws-secretsmanager>2.0.4</version.aws-secretsmanager>
     <version.azure-identity>1.15.4</version.azure-identity>
     <version.bcpkix-jdk18on>1.80</version.bcpkix-jdk18on>
     <version.byte-buddy-agent>1.17.6</version.byte-buddy-agent>


### PR DESCRIPTION
This change to this issue : https://github.com/flyway/flyway/issues/4205

This change attempts to address CVE-2025-67735. Which was introduced by transient dependency of `com.amazonaws.secretsmanager` which has now been fixed in version 2.0.4 (Ref: https://github.com/aws/aws-secretsmanager-jdbc/releases)