### PR TITLE
Add InsertRowLock#doLock method with lockStrategy predicate enabling alternative implementations for databases without primary key support

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/InsertRowLock.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/InsertRowLock.java
@@ -20,6 +20,7 @@
 package org.flywaydb.core.internal.database;
 
 import lombok.CustomLog;
+import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
 import org.flywaydb.core.internal.jdbc.Results;
 
@@ -33,7 +34,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
 
+/**
+ * Distributed locking mechanism using row insertion in the Flyway schema history table.
+ *
+ * <p>This class implements a database-based locking strategy to prevent multiple Flyway instances
+ * from simultaneously migrating the same database. The lock is implemented by inserting a special
+ * row into the schema history table with a fixed installed_rank value (-100). The primary key
+ * constraint on installed_rank ensures only one instance can hold the lock at a time.</p>
+ *
+ * <p>The lock is kept alive by a background thread that periodically updates the lock row's timestamp.
+ * Locks that haven't been updated within {@link #LOCK_TIMEOUT_MINS} are considered expired and can be
+ * cleaned up by other instances attempting to acquire the lock.</p>
+ */
 @CustomLog
 public class InsertRowLock {
     private static final Random random = new Random();
@@ -47,18 +61,79 @@ public class InsertRowLock {
     public static final int LOCK_TIMEOUT_MINS = 10;
     private final ScheduledExecutorService executor;
     private ScheduledFuture<?> scheduledFuture;
+    /**
+     * Description field value used in the lock row to identify it as a Flyway lock.
+     */
+    public static String FLYWAY_LOCK_STRING = "flyway-lock";
 
     public InsertRowLock(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
         this.executor = createScheduledExecutor();
     }
 
+    /**
+     * Gets the unique lock identifier for this Flyway instance.
+     *
+     * @return the unique lock identifier stored in the lock row's 'version' column
+     */
+    public String getLockId() {
+        return this.tableLockString;
+    }
+
+    /**
+     * Acquires a lock on the schema history table using primary key constraint.
+     *
+     * <p>This method assumes the database supports primary key constraints on 'installed_rank'.
+     * The lock is acquired by inserting a row with installed_rank = -100. If another instance
+     * already holds the lock, this method will retry every second until the lock becomes available.</p>
+     *
+     * @param insertStatementTemplate    template for INSERT statement with placeholders ({@link org.flywaydb.core.internal.database.base.Database#getInsertStatement(Table)})
+     * @param updateLockStatement        SQL statement to update the lock timestamp, takes a single '?' placeholder for the 'version' column that will be replaced with {@link #tableLockString}
+     * @param deleteExpiredLockStatement SQL statement to delete expired locks, takes a single '?' placeholder that will be replaced with a timestamp to remove locks older than the cutoff
+     * @param booleanTrue                database-specific representation of boolean true value
+     * @throws SQLException if a database error occurs
+     */
     public void doLock(String insertStatementTemplate, String updateLockStatement, String deleteExpiredLockStatement, String booleanTrue) throws SQLException {
+        doLock(insertStatementTemplate, updateLockStatement, deleteExpiredLockStatement, "0", booleanTrue, (jdbcTemplate, insertStatement) -> {
+            // Insert the locking row - the primary key-ness of 'installed_rank' will prevent us having two
+            Results results = jdbcTemplate.executeStatement(insertStatement);
+
+            // Succeed if there were no errors
+            return results.getException() == null;
+        });
+    }
+
+    /**
+     * Acquires a lock on the schema history table using a custom locking strategy.
+     *
+     * <p>This is the main locking method that supports different database-specific locking strategies
+     * through the lockStrategy predicate. The method will:</p>
+     * <ol>
+     *   <li>Delete any expired locks from previous instances</li>
+     *   <li>Attempt to insert a lock row using the provided strategy</li>
+     *   <li>If successful, start a background thread to keep the lock alive</li>
+     *   <li>If unsuccessful, retry every second (up to 50 retries with debug logging, then error logging)</li>
+     * </ol>
+     *
+     * @param insertStatementTemplate    template for INSERT statement with placeholders ({@link org.flywaydb.core.internal.database.base.Database#getInsertStatement(Table)})
+     * @param updateLockStatement        SQL statement to update the lock timestamp, takes a single '?' placeholder for the 'version' column that will be replaced with {@link #tableLockString}
+     * @param deleteExpiredLockStatement SQL statement to delete expired locks, takes a single '?' placeholder that will be replaced with a timestamp to remove locks older than the cutoff
+     * @param checksumValue              checksum value to use in the lock row
+     * @param booleanTrue                database-specific representation of boolean true value
+     * @param lockStrategy               predicate that attempts to acquire the lock and returns true on success. Takes (JdbcTemplate, String insertStatement) where the statement is the formatted INSERT for the lock row
+     * @throws SQLException if a database error occurs
+     */
+    public void doLock(String insertStatementTemplate,
+                       String updateLockStatement,
+                       String deleteExpiredLockStatement,
+                       String checksumValue,
+                       String booleanTrue,
+                       BiPredicate<JdbcTemplate, String> lockStrategy) throws SQLException {
         int retryCount = 0;
         while (true) {
             try {
                 jdbcTemplate.execute(generateDeleteExpiredLockStatement(deleteExpiredLockStatement));
-                if (insertLockingRow(insertStatementTemplate, booleanTrue)) {
+                if (insertLockingRow(insertStatementTemplate, checksumValue, booleanTrue, lockStrategy)) {
                     scheduledFuture = startLockWatchingThread(String.format(updateLockStatement.replace("?", "%s"), tableLockString));
                     return;
                 }
@@ -82,24 +157,19 @@ public class InsertRowLock {
         return String.format(deleteExpiredLockStatementTemplate.replace("?", "%s"), zonedDateTime.format(formatter));
     }
 
-    private boolean insertLockingRow(String insertStatementTemplate, String booleanTrue) {
+    private boolean insertLockingRow(String insertStatementTemplate, String checksumValue, String booleanTrue, BiPredicate<JdbcTemplate, String> lockStrategy) {
         String insertStatement = String.format(insertStatementTemplate.replace("?", "%s"),
                                                -100,
                                                "'" + tableLockString + "'",
-                                               "'flyway-lock'",
+                                               "'" + FLYWAY_LOCK_STRING + "'",
                                                "''",
                                                "''",
-                                               0,
+                                               checksumValue,
                                                "''",
                                                0,
                                                booleanTrue
-                                              );
-
-        // Insert the locking row - the primary key-ness of 'installed_rank' will prevent us having two
-        Results results = jdbcTemplate.executeStatement(insertStatement);
-
-        // Succeed if there were no errors
-        return results.getException() == null;
+        );
+        return lockStrategy.test(jdbcTemplate, insertStatement);
     }
 
     public void doUnlock(String deleteLockTemplate) throws SQLException {


### PR DESCRIPTION
https://github.com/flyway/flyway/issues/4164

RowLock currently assumes the db has a primary key on installed_rank, for clickhouse this doesn't work. Small refactor to open up another doLock method which takes a predicate to do the locking which clickhouse can implement an alternative for