### PR TITLE
Standardize jackson-core in Docker images to pinned versions from Maven Central

### DIFF
--- a/flyway-docker/dockerfiles/alpine/Dockerfile
+++ b/flyway-docker/dockerfiles/alpine/Dockerfile
@@ -1,7 +1,9 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
 ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V2_SHA256=1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0
 ARG JACKSON_CORE_V3=3.1.0
+ARG JACKSON_CORE_V3_SHA256=4dd383f96b51b9b9ac4b74bdf1c150df0100443e1da1fba480f57da09a2dcef7
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz .
 RUN apk add --no-cache wget \
@@ -12,8 +14,10 @@ RUN apk add --no-cache wget \
   && find /flyway -name 'jackson-core-*.jar' -delete \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
        "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && echo "${JACKSON_CORE_V2_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar" | sha256sum -c - \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
        "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
+  && echo "${JACKSON_CORE_V3_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar" | sha256sum -c - \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 

--- a/flyway-docker/dockerfiles/alpine/Dockerfile
+++ b/flyway-docker/dockerfiles/alpine/Dockerfile
@@ -1,11 +1,19 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
+ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V3=3.1.0
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz .
-RUN gzip -d flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz \
+RUN apk add --no-cache wget \
+  && gzip -d flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz \
   && tar -xf flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar \
   && rm -rf /flyway/jre \
+  && find /flyway -name 'jackson-core-*.jar' -delete \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
+       "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
+       "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 

--- a/flyway-docker/dockerfiles/azure/Dockerfile
+++ b/flyway-docker/dockerfiles/azure/Dockerfile
@@ -1,10 +1,18 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
+ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V3=3.1.0
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz .
-RUN gzip -d flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz \
+RUN apk add --no-cache wget \
+  && gzip -d flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz \
   && tar -xf flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar \
+  && find /flyway -name 'jackson-core-*.jar' -delete \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
+       "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
+       "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 

--- a/flyway-docker/dockerfiles/azure/Dockerfile
+++ b/flyway-docker/dockerfiles/azure/Dockerfile
@@ -1,7 +1,9 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
 ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V2_SHA256=1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0
 ARG JACKSON_CORE_V3=3.1.0
+ARG JACKSON_CORE_V3_SHA256=4dd383f96b51b9b9ac4b74bdf1c150df0100443e1da1fba480f57da09a2dcef7
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}-linux-alpine-x64.tar.gz .
 RUN apk add --no-cache wget \
@@ -11,8 +13,10 @@ RUN apk add --no-cache wget \
   && find /flyway -name 'jackson-core-*.jar' -delete \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
        "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && echo "${JACKSON_CORE_V2_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar" | sha256sum -c - \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
        "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
+  && echo "${JACKSON_CORE_V3_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar" | sha256sum -c - \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 

--- a/flyway-docker/dockerfiles/base/Dockerfile
+++ b/flyway-docker/dockerfiles/base/Dockerfile
@@ -1,10 +1,18 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
+ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V3=3.1.0
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}.tar.gz .
-RUN gzip -d flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+RUN apk add --no-cache wget \
+  && gzip -d flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && tar -xf flyway-commandline-${FLYWAY_VERSION}.tar --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}.tar \
+  && find /flyway -name 'jackson-core-*.jar' -delete \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
+       "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
+       "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 

--- a/flyway-docker/dockerfiles/base/Dockerfile
+++ b/flyway-docker/dockerfiles/base/Dockerfile
@@ -1,7 +1,9 @@
 FROM bash:5 AS untar
 ARG FLYWAY_VERSION
 ARG JACKSON_CORE_V2=2.21.1
+ARG JACKSON_CORE_V2_SHA256=1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0
 ARG JACKSON_CORE_V3=3.1.0
+ARG JACKSON_CORE_V3_SHA256=4dd383f96b51b9b9ac4b74bdf1c150df0100443e1da1fba480f57da09a2dcef7
 WORKDIR /flyway
 COPY flyway-commandline-${FLYWAY_VERSION}.tar.gz .
 RUN apk add --no-cache wget \
@@ -11,8 +13,10 @@ RUN apk add --no-cache wget \
   && find /flyway -name 'jackson-core-*.jar' -delete \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar \
        "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_CORE_V2}/jackson-core-${JACKSON_CORE_V2}.jar" \
+  && echo "${JACKSON_CORE_V2_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V2}.jar" | sha256sum -c - \
   && wget -q -O /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar \
        "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/${JACKSON_CORE_V3}/jackson-core-${JACKSON_CORE_V3}.jar" \
+  && echo "${JACKSON_CORE_V3_SHA256}  /flyway/lib/jackson-core-${JACKSON_CORE_V3}.jar" | sha256sum -c - \
   && chmod -R a+r /flyway \
   && chmod a+x /flyway/flyway
 


### PR DESCRIPTION
## Proposed changes

Flyway 12's Maven assembly bundles multiple jackson-core versions in `/flyway/lib/` because internal modules (`flyway-core`, `flyway-database-*`, `flyway-reports`) each resolve their own transitive jackson dependency. This triggers Trivy findings for the older versions.

## Changes

- **All three Dockerfile variants** (`base`, `alpine`, `azure`) that extract the flyway-commandline tarball now:
  - Delete all `jackson-core-*.jar` from the extracted distribution
  - Download the two required versions from Maven Central with SHA-256 verification
  - `com.fasterxml.jackson.core:jackson-core:2.21.1` (2.x API consumers)
  - `tools.jackson.core:jackson-core:3.1.0` (Flyway's own 3.x usage)

- **Versions and checksums are build ARGs** with defaults matching `pom.xml`, overridable at build time without code changes

```dockerfile
ARG JACKSON_CORE_V2=2.21.1
ARG JACKSON_CORE_V2_SHA256=1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0
ARG JACKSON_CORE_V3=3.1.0
ARG JACKSON_CORE_V3_SHA256=4dd383f96b51b9b9ac4b74bdf1c150df0100443e1da1fba480f57da09a2dcef7
```

Mono/oracle/redgate overlay Dockerfiles inherit from these base images — no changes needed there.