### PR TITLE
Make Flyway Gradle tasks compatible with configuration cache

### DIFF
--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,9 +24,6 @@ import static org.flywaydb.core.internal.configuration.ConfigUtils.putIfSet;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -46,12 +43,11 @@ import org.flywaydb.core.internal.jdbc.DriverDataSource;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.flywaydb.gradle.FlywayExtension;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -77,6 +73,15 @@ public abstract class AbstractFlywayTask extends DefaultTask {
      * The flyway {} block in the build script.
      */
     protected FlywayExtension extension;
+
+    /**
+     * Values captured at configuration time for configuration cache compatibility.
+     */
+    private final String gradleVersion;
+    private final boolean javaProject;
+    private final Map<String, String> flywayProjectProperties;
+    private final String projectDirPath;
+    private final FileCollection extraClasspath;
 
     /**
      * The fully qualified classname of the JDBC driver to use to connect to the database.
@@ -577,24 +582,56 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     protected AbstractFlywayTask() {
         super();
         setGroup("Flyway");
-        extension = (FlywayExtension) getProject().getExtensions().getByName("flyway");
+
+        final Project project = getProject();
+        extension = (FlywayExtension) project.getExtensions().getByName("flyway");
+
+        this.gradleVersion = project.getGradle().getGradleVersion();
+        this.javaProject = project.getPluginManager().hasPlugin("java");
+        this.projectDirPath = project.getProjectDir().getAbsolutePath();
+
+        this.flywayProjectProperties = new HashMap<>();
+        for (final Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
+            if (entry.getKey().startsWith("flyway.") && entry.getValue() != null) {
+                flywayProjectProperties.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+
+        final ConfigurableFileCollection classpathFiles = project.getObjects().fileCollection();
+
+        if (javaProject) {
+            final SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+            for (final SourceSet sourceSet : sourceSets) {
+                classpathFiles.from(sourceSet.getOutput().getClassesDirs());
+                classpathFiles.from(sourceSet.getOutput().getResourcesDir());
+            }
+        }
+
+        classpathFiles.from(project.provider(() -> {
+            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap();
+            final String[] configs = determineConfigurations(envVars);
+            final List<FileCollection> result = new ArrayList<>();
+            for (final String config : configs) {
+                result.add(project.getConfigurations().getByName(config));
+            }
+            return result;
+        }));
+
+        this.extraClasspath = classpathFiles;
     }
 
     @TaskAction
     public Object runTask() {
         try {
-            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap();
-
             final Set<URL> extraURLs = new HashSet<>();
-            if (isJavaProject()) {
-                addClassesAndResourcesDirs(extraURLs);
+            for (final File file : extraClasspath.getFiles()) {
+                extraURLs.add(file.toURI().toURL());
             }
 
-            addConfigurationArtifacts(determineConfigurations(envVars), extraURLs);
-
             final ClassLoader classLoader = new URLClassLoader(extraURLs.toArray(URL[]::new),
-                getProject().getBuildscript().getClassLoader());
+                getClass().getClassLoader());
 
+            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap();
             final Map<String, String> config = createFlywayConfig(envVars);
             ConfigUtils.dumpConfigurationMap(config, "Using configuration:");
 
@@ -604,53 +641,6 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             return result;
         } catch (final Exception e) {
             throw new FlywayException(collectMessages(e, "Error occurred while executing " + getName()), e);
-        }
-    }
-
-    private void addClassesAndResourcesDirs(final Collection<? super URL> extraURLs)
-        throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        final SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
-
-        for (final SourceSet sourceSet : sourceSets) {
-            try {
-                final FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
-                for (final File directory : classesDirs.getFiles()) {
-                    final URL classesUrl = directory.toURI().toURL();
-                    getLogger().debug("Adding directory to Classpath: " + classesUrl);
-                    extraURLs.add(classesUrl);
-                }
-            } catch (final NoSuchMethodError ex) {
-                getLogger().debug("Falling back to legacy getClassesDir method");
-
-                // try legacy gradle 3.0 method instead
-                @SuppressWarnings("JavaReflectionMemberAccess") final Method getClassesDir = SourceSetOutput.class.getMethod(
-                    "getClassesDir");
-
-                final File classesDir = (File) getClassesDir.invoke(sourceSet.getOutput());
-                final URL classesUrl = classesDir.toURI().toURL();
-
-                getLogger().debug("Adding directory to Classpath: " + classesUrl);
-                extraURLs.add(classesUrl);
-            }
-
-            final URL resourcesUrl = sourceSet.getOutput().getResourcesDir().toURI().toURL();
-            getLogger().debug("Adding directory to Classpath: " + resourcesUrl);
-            extraURLs.add(resourcesUrl);
-        }
-    }
-
-    private void addConfigurationArtifacts(final String[] configurations, final Collection<? super URL> urls)
-        throws IOException {
-        for (final String configuration : configurations) {
-            getLogger().debug("Adding configuration to classpath: " + configuration);
-            final ResolvedConfiguration resolvedConfiguration = getProject().getConfigurations()
-                .getByName(configuration)
-                .getResolvedConfiguration();
-            for (final ResolvedArtifact artifact : resolvedConfiguration.getResolvedArtifacts()) {
-                final URL artifactUrl = artifact.getFile().toURI().toURL();
-                getLogger().debug("Adding artifact to classpath: " + artifactUrl);
-                urls.add(artifactUrl);
-            }
         }
     }
 
@@ -668,8 +658,8 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         if (extension.configurations != null) {
             return extension.configurations;
         }
-        if (isJavaProject()) {
-            if (getProject().getGradle().getGradleVersion().startsWith("3")) {
+        if (javaProject) {
+            if (gradleVersion.startsWith("3")) {
                 return DEFAULT_CONFIGURATIONS_GRADLE3;
             }
             return DEFAULT_CONFIGURATIONS_GRADLE45;
@@ -810,7 +800,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
 
         conf.putAll(getPluginConfiguration(pluginConfiguration, extension.pluginConfiguration));
 
-        addConfigFromProperties(conf, getProject().getProperties());
+        addConfigFromProperties(conf, flywayProjectProperties);
         addConfigFromProperties(conf, loadConfigurationFromConfigFiles(getWorkingDirectory(), envVars));
         addConfigFromProperties(conf, envVars);
         addConfigFromProperties(conf, System.getProperties());
@@ -907,7 +897,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             return new File(workingDirectory);
         }
 
-        return new File(getProject().getProjectDir().getAbsolutePath());
+        return new File(projectDirPath);
     }
 
     /**
@@ -993,9 +983,9 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             return configFiles;
         }
 
-        if (getProject().getProperties().containsKey(ConfigUtils.CONFIG_FILES)) {
-            for (final String file : StringUtils.tokenizeToStringArray(String.valueOf(getProject().getProperties()
-                .get(ConfigUtils.CONFIG_FILES)), ",")) {
+        if (flywayProjectProperties.containsKey(ConfigUtils.CONFIG_FILES)) {
+            for (final String file : StringUtils.tokenizeToStringArray(
+                flywayProjectProperties.get(ConfigUtils.CONFIG_FILES), ",")) {
                 configFiles.add(toFile(workingDirectory, file));
             }
             return configFiles;
@@ -1077,9 +1067,5 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             return collectMessages(throwable.getCause(), message);
         }
         return message;
-    }
-
-    private boolean isJavaProject() {
-        return getProject().getPluginManager().hasPlugin("java");
     }
 }


### PR DESCRIPTION
Move all Task.getProject() calls from execution time to configuration time in AbstractFlywayTask to fix "Invocation of Task.project at execution time is unsupported" error when running with --configuration-cache.

closes #4107 