### PR TITLE
Filter flyway env vars as part of Gradle Plugin

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/configuration/ConfigUtils.java
@@ -165,9 +165,13 @@ public class ConfigUtils {
      * @return The properties corresponding to the environment variables.
      */
     public static Map<String, String> environmentVariablesToPropertyMap() {
+        return environmentVariablesToPropertyMap(System.getenv());
+    }
+
+    public static Map<String, String> environmentVariablesToPropertyMap(Map<String, String> envVars) {
         final Map<String, String> result = new HashMap<>();
 
-        for (final Map.Entry<String, String> entry : System.getenv().entrySet()) {
+        for (final Map.Entry<String, String> entry : envVars.entrySet()) {
             final String convertedKey = convertKey(entry.getKey());
             if (convertedKey != null) {
                 // Known environment variable

--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/AbstractFlywayTask.java
@@ -44,6 +44,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
@@ -80,6 +81,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
     private final Map<String, String> flywayProjectProperties;
     private final String projectDirPath;
     private final FileCollection extraClasspath;
+    private final Provider<Map<String, String>> flywayEnvVars;
 
     /**
      * The fully qualified classname of the JDBC driver to use to connect to the database.
@@ -594,6 +596,9 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             }
         }
 
+        this.flywayEnvVars = project.getProviders().of(FlywayEnvVarsValueSource.class,
+            spec -> {});
+
         final ConfigurableFileCollection classpathFiles = project.getObjects().fileCollection();
 
         if (javaProject) {
@@ -605,7 +610,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
         }
 
         classpathFiles.from(project.provider(() -> {
-            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap();
+            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap(flywayEnvVars.get());
             final String[] configs = determineConfigurations(envVars);
             final List<FileCollection> result = new ArrayList<>();
             for (final String config : configs) {
@@ -628,7 +633,7 @@ public abstract class AbstractFlywayTask extends DefaultTask {
             final ClassLoader classLoader = new URLClassLoader(extraURLs.toArray(URL[]::new),
                 getClass().getClassLoader());
 
-            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap();
+            final Map<String, String> envVars = ConfigUtils.environmentVariablesToPropertyMap(flywayEnvVars.get());
             final Map<String, String> config = createFlywayConfig(envVars);
             ConfigUtils.dumpConfigurationMap(config, "Using configuration:");
 

--- a/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayEnvVarsValueSource.java
+++ b/flyway-plugins/flyway-gradle-plugin/src/main/java/org/flywaydb/gradle/task/FlywayEnvVarsValueSource.java
@@ -1,0 +1,44 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-gradle-plugin
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.gradle.task;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+/**
+ * A Gradle {@link ValueSource} that retrieves environment variables whose keys start with {@code FLYWAY_}.
+ * <p>
+ * Using a {@code ValueSource} to access environment variables makes the plugin compatible with Gradle's
+ * configuration cache, since direct calls to {@link System#getenv()} at configuration time are not allowed.
+ */
+public abstract class FlywayEnvVarsValueSource
+    implements ValueSource<Map<String, String>, ValueSourceParameters.None> {
+
+    private static final String FLYWAY_ENV_PREFIX = "FLYWAY_";
+
+    @Override
+    public Map<String, String> obtain() {
+        return System.getenv().entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(FLYWAY_ENV_PREFIX))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}


### PR DESCRIPTION
Currently the gradle plugin is iterating over all env vars to read the config. As part of configuration caching Gradle detects this and associates all read environment variables with the flyway plugin. The result is that a change to any environment variable (even ones that flyway is not interested in) will trigger the cache to be invalidated. This is a huge problem for CI environments where CI variables are provided.

> Some access patterns that potentially enumerate all environment variables or system properties (for example, calling System.getenv().forEach() or using the iterator of its keySet()) are discouraged. In this case, Gradle cannot find out what properties are actual build configuration inputs, so every available property becomes one. Even adding a new property will invalidate the cache if this pattern is used.

[Source](https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:requirements:reading_sys_props_and_env_vars)

This can generally be worked around by using the `providers.environmentVariablesPrefixedBy()` provider, but it is not available in the Gradle version targeted by the current build.

To avoid upgrading the gradle api version in this PR I propose the use of a custom `ValueSource` provider to filter the environment variables using the `FLYWAY_` prefix before pushing them through an overridden variant of `ConfigUtils.environmentVariablesToPropertyMap()`