### PR TITLE
fix(oracle): handle IF [NOT] EXISTS in DDL statements #4231

### DIFF
--- a/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
+++ b/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
@@ -492,6 +492,8 @@ public class OracleParser extends Parser {
 
     private static final Pattern CREATE_IF_NOT_EXISTS = Pattern.compile(
             ".*CREATE\\s([^\\s]+\\s){0,2}IF\\sNOT\\sEXISTS");
+    private static final Pattern DROP_IF_EXISTS = Pattern.compile(
+            ".*DROP\\s([^\\s]+\\s){0,2}IF\\sEXISTS");
 
     @Override
     protected void adjustBlockDepth(ParserContext context, List<Token> tokens, Token keyword, PeekingReader reader) {
@@ -543,7 +545,8 @@ public class OracleParser extends Parser {
         ) {
             context.increaseBlockDepth(keywordText);
         } else if ("END".equals(keywordText)
-                || doTokensMatchPattern(tokens, keyword, CREATE_IF_NOT_EXISTS)) {
+                || doTokensMatchPattern(tokens, keyword, CREATE_IF_NOT_EXISTS)
+                || doTokensMatchPattern(tokens, keyword, DROP_IF_EXISTS)) {
             context.decreaseBlockDepth();
         }
 

--- a/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
+++ b/flyway-database/flyway-database-oracle/src/main/java/org/flywaydb/database/oracle/OracleParser.java
@@ -490,6 +490,9 @@ public class OracleParser extends Parser {
     // These words increase the block depth - unless preceded by END (in which case the END will decrease the block depth)
     private static final List<String> CONTROL_FLOW_KEYWORDS = Arrays.asList("IF", "LOOP", "CASE");
 
+    private static final Pattern CREATE_IF_NOT_EXISTS = Pattern.compile(
+            ".*CREATE\\s([^\\s]+\\s){0,2}IF\\sNOT\\sEXISTS");
+
     @Override
     protected void adjustBlockDepth(ParserContext context, List<Token> tokens, Token keyword, PeekingReader reader) {
         TokenType tokenType = keyword.getType();
@@ -539,7 +542,8 @@ public class OracleParser extends Parser {
                         doTokensMatchPattern(tokens, keyword, PLSQL_TYPE_BODY_REGEX)))
         ) {
             context.increaseBlockDepth(keywordText);
-        } else if ("END".equals(keywordText)) {
+        } else if ("END".equals(keywordText)
+                || doTokensMatchPattern(tokens, keyword, CREATE_IF_NOT_EXISTS)) {
             context.decreaseBlockDepth();
         }
 


### PR DESCRIPTION
The Oracle parser increments block depth on any IF keyword, treating CREATE INDEX IF NOT EXISTS as an unclosed PL/SQL block. Add a pattern that matches CREATE ... IF NOT EXISTS and immediately decrements block depth again, so the statement is parsed correctly.

Inspired by approach in https://github.com/flyway/flyway/commit/0904b0c7a8ae6558a0c4fa2d32c4b843e9de1541 

closes #4231