### PR TITLE
Fix index creation statement in DB2Database

### DIFF
--- a/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
+++ b/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
@@ -69,7 +69,7 @@ public class DB2Database extends Database<DB2Connection> {
                 ")" + (getVersion().isAtLeast("10.5") ? "" : " ORGANIZE BY ROW")
                 + tablespace + ";\n" +
                 "ALTER TABLE " + table + " ADD CONSTRAINT \"" + table.getName() + "_pk\" PRIMARY KEY (\"installed_rank\");\n" +
-                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\") " + tablespace + ";" +
+                "CREATE INDEX \"" + table.getSchema().getName() + "\".\"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "");
     }
 


### PR DESCRIPTION
Revert https://github.com/flyway/flyway/pull/4156/changes/843a2966193bf3fee537a01ccb1fb381df34aeb4 . It causes invalid syntax for create index statement in db2 luw