### PR TITLE
Fix for #4245 (slf4j-api jar is missing in /lib (flyway-commandline))

### DIFF
--- a/flyway-commandline/src/main/assembly/component.xml
+++ b/flyway-commandline/src/main/assembly/component.xml
@@ -149,6 +149,7 @@
         <include>tools.jackson.dataformat:jackson-dataformat-xml</include>
         <include>com.fasterxml.jackson.dataformat:jackson-dataformat-xml</include>
         <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+        <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-nop</include>
         <include>com.nimbusds:nimbus-jose-jwt</include>
         <include>com.nimbusds:oauth2-oidc-sdk</include>
@@ -178,6 +179,7 @@
         <exclude>com.nimbusds:content-type</exclude>
         <exclude>com.nimbusds:nimbus-jose-jwt</exclude>
         <exclude>com.nimbusds:oauth2-oidc-sdk</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>


### PR DESCRIPTION
Fix for #4245