### PR TITLE
Avoid NullPointerException in ClasspathSqlMigrationScanner when getResource(".") returns null

### DIFF
--- a/flyway-nc/flyway-nc-scanners/src/main/java/org/flywaydb/scanners/ClasspathSqlMigrationScanner.java
+++ b/flyway-nc/flyway-nc-scanners/src/main/java/org/flywaydb/scanners/ClasspathSqlMigrationScanner.java
@@ -109,12 +109,23 @@ public class ClasspathSqlMigrationScanner extends BaseSqlMigrationScanner {
 
     @Override
     boolean matchesPath(final String path, final Location location) {
-        final String rootPath = new File(Thread.currentThread()
-            .getContextClassLoader()
-            .getResource(".")
-            .getPath()).getAbsolutePath();
-        final String remainingPath = path.replace("\\", "/").substring(rootPath.length() + 1);
+        if (location.getPathRegex() == null) {
+            // Without wildcard restrictions the path is irrelevant. Returning early also avoids
+            // resolving the classpath root, which is not possible under every class loader.
+            return true;
+        }
 
+        final String normalizedPath = path.replace("\\", "/");
+        final URL rootUrl = Thread.currentThread().getContextClassLoader().getResource(".");
+        if (rootUrl == null) {
+            // Some class loaders (e.g. Quarkus) return null for getResource("."), so the classpath
+            // root cannot be determined this way. Fall back to matching the full path instead of
+            // failing with a NullPointerException.
+            return matchesAnyWildcardRestrictions(location, normalizedPath);
+        }
+
+        final String rootPath = new File(rootUrl.getPath()).getAbsolutePath();
+        final String remainingPath = normalizedPath.substring(rootPath.length() + 1);
         return matchesAnyWildcardRestrictions(location, remainingPath);
     }
 


### PR DESCRIPTION
Fixes #4241

### Root cause
`ClasspathSqlMigrationScanner.matchesPath` resolved the classpath root with
`Thread.currentThread().getContextClassLoader().getResource(".").getPath()`. Some class
loaders — notably Quarkus' runtime class loader — return `null` for `getResource(".")`, so
`.getPath()` threw a `NullPointerException`, which Flyway surfaced as
`FlywayException: Cannot invoke "java.net.URL.getPath()" because the return value of "java.lang.ClassLoader.getResource(String)" is null`
and aborted application startup.

### Change
The resolved root path is only used to strip the classpath prefix from a discovered
resource before applying a location's wildcard restrictions. Therefore:

- When the location has no path regex (the common case, e.g. `classpath:db/migration`),
  `matchesAnyWildcardRestrictions` returns `true` regardless of the path, so the scanner now
  returns early without resolving the root at all. This mirrors the sibling
  `FileSystemSqlMigrationScanner.matchesPath`.
- When a path regex is present but the classpath root cannot be resolved (`getResource(".")`
  is `null`), it falls back to matching the full normalized path instead of throwing.

Behaviour is unchanged whenever `getResource(".")` resolves normally.

### Verification done
- Verification 1/3/4: confirmed on `main` that `matchesPath` dereferences `getResource(".")`
  unconditionally and that the symptom reproduces; the fix is confined to one `.java` file.
- `./mvnw -pl flyway-nc/flyway-nc-scanners -am compile` succeeds.
- Reproduced and fixed with a standalone harness using a class loader whose `getResource`
  returns `null`: the previous logic throws the exact NPE above, while the patched
  `matchesPath` returns `true` for a plain `classpath:db/migration` location and no longer
  throws for a wildcard-restricted location.

Note: the public repository does not contain a `src/test/java` tree for any module (verified:
no test sources under `flyway-nc/*`), so I could not add an in-repo regression test without
introducing test scaffolding to a module that has none. Happy to add one if you can point me
at where scanner tests live, or adjust the approach for the wildcard-restricted fallback.
