### PR TITLE
Make mongosh shell command and URL configurable for MongoDB .js migrations

### DIFF
--- a/flyway-database/flyway-database-nc-mongodb/pom.xml
+++ b/flyway-database/flyway-database-nc-mongodb/pom.xml
@@ -40,10 +40,12 @@
       <version>${project.parent.version}</version>
       <scope>compile</scope>
     </dependency>
-
-
-
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
 
 
 
@@ -57,6 +59,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>

--- a/flyway-database/flyway-database-nc-mongodb/src/main/java/org/flywaydb/database/nc/mongodb/MongoDBConfigurationExtension.java
+++ b/flyway-database/flyway-database-nc-mongodb/src/main/java/org/flywaydb/database/nc/mongodb/MongoDBConfigurationExtension.java
@@ -1,0 +1,61 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-nc-mongodb
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.database.nc.mongodb;
+
+import java.util.List;
+import lombok.Data;
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+
+@Data
+public class MongoDBConfigurationExtension implements ConfigurationExtension {
+    private static final String MONGODB_SHELL_COMMAND = "flyway.mongodb.shellCommand";
+    private static final String MONGODB_SHELL_URL = "flyway.mongodb.shellUrl";
+
+    /**
+     * Command prefix used to invoke {@code mongosh} for {@code .js} migrations. Each element is
+     * passed as a discrete process argument, so the invocation can be routed through a wrapper such
+     * as {@code ["docker", "exec", "-i", "<container>", "mongosh"]}. Defaults to {@code ["mongosh"]}.
+     */
+    private List<String> shellCommand = List.of("mongosh");
+
+    /**
+     * Connection URL passed to {@code mongosh} for {@code .js} migrations. Defaults to {@code null},
+     * meaning {@code flyway.url} is used. Override only when {@code mongosh} reaches the database
+     * through a different URL than the JVM driver does (e.g. a container with a different port).
+     */
+    private String shellUrl = null;
+
+    @Override
+    public String getNamespace() {
+        return "mongodb";
+    }
+
+    @Override
+    public String getConfigurationParameterFromEnvironmentVariable(final String environmentVariable) {
+        switch (environmentVariable) {
+            case "FLYWAY_MONGODB_SHELL_COMMAND":
+                return MONGODB_SHELL_COMMAND;
+            case "FLYWAY_MONGODB_SHELL_URL":
+                return MONGODB_SHELL_URL;
+            default:
+                return null;
+        }
+    }
+}

--- a/flyway-database/flyway-database-nc-mongodb/src/main/java/org/flywaydb/database/nc/mongodb/MongoDBDatabase.java
+++ b/flyway-database/flyway-database-nc-mongodb/src/main/java/org/flywaydb/database/nc/mongodb/MongoDBDatabase.java
@@ -78,6 +78,7 @@ public class MongoDBDatabase extends NativeConnectorsNonJdbc {
     private ClientSession clientSession;
     private Boolean doesSchemaHistoryTableExist;
     private ConnectionString connectionString;
+    private List<String> shellCommand = List.of("mongosh");
 
     @Override
     public DatabaseSupport supportsUrl(final String url) {
@@ -111,8 +112,15 @@ public class MongoDBDatabase extends NativeConnectorsNonJdbc {
         }
 
         if (connectionType == ConnectionType.EXECUTABLE) {
+            final MongoDBConfigurationExtension configurationExtension =
+                configuration.getPluginRegister().getExact(MongoDBConfigurationExtension.class);
+            shellCommand = resolveShellCommand(configurationExtension);
+            final String shellUrl = configurationExtension != null
+                && StringUtils.hasText(configurationExtension.getShellUrl())
+                ? configurationExtension.getShellUrl()
+                : environment.getUrl();
             checkMongoshInstalled();
-            mongoshCredential = new MongoshCredential(environment.getUrl(),
+            mongoshCredential = new MongoshCredential(shellUrl,
                 environment.getUser(),
                 environment.getPassword());
             checkMongoshConnectivity();
@@ -435,7 +443,8 @@ public class MongoDBDatabase extends NativeConnectorsNonJdbc {
     }
 
     private void checkMongoshInstalled() {
-        final List<String> commands = Arrays.asList("mongosh", "--version");
+        final List<String> commands = new ArrayList<>(shellCommand);
+        commands.add("--version");
         final NativeConnectorsProcessRunner processRunner = new NativeConnectorsProcessRunner(commands, "Mongosh");
         final String errorMessage = "Mongosh is required for .js migrations and is not currently installed. "
             + "Information on how to install Mongosh can be found here: "
@@ -480,7 +489,13 @@ public class MongoDBDatabase extends NativeConnectorsNonJdbc {
     }
 
     private List<String> getMongoshConnectCommands() {
-        List<String> commands = new ArrayList<>(List.of("mongosh", mongoshCredential.url()));
+        return buildMongoshConnectCommands(shellCommand, mongoshCredential);
+    }
+
+    static List<String> buildMongoshConnectCommands(final List<String> shellCommand,
+        final MongoshCredential mongoshCredential) {
+        final List<String> commands = new ArrayList<>(shellCommand);
+        commands.add(mongoshCredential.url());
         if (mongoshCredential.username() != null) {
             commands.addAll(List.of("--username", mongoshCredential.username()));
         }
@@ -488,5 +503,14 @@ public class MongoDBDatabase extends NativeConnectorsNonJdbc {
             commands.addAll(List.of("--password", mongoshCredential.password()));
         }
         return commands;
+    }
+
+    private static List<String> resolveShellCommand(final MongoDBConfigurationExtension configurationExtension) {
+        if (configurationExtension == null
+            || configurationExtension.getShellCommand() == null
+            || configurationExtension.getShellCommand().isEmpty()) {
+            return List.of("mongosh");
+        }
+        return configurationExtension.getShellCommand();
     }
 }

--- a/flyway-database/flyway-database-nc-mongodb/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/flyway-database/flyway-database-nc-mongodb/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,1 +1,2 @@
 org.flywaydb.database.nc.mongodb.MongoDBDatabase
+org.flywaydb.database.nc.mongodb.MongoDBConfigurationExtension

--- a/flyway-database/flyway-database-nc-mongodb/src/test/java/org/flywaydb/database/nc/mongodb/MongoDBShellCommandTest.java
+++ b/flyway-database/flyway-database-nc-mongodb/src/test/java/org/flywaydb/database/nc/mongodb/MongoDBShellCommandTest.java
@@ -1,0 +1,97 @@
+/*-
+ * ========================LICENSE_START=================================
+ * flyway-database-nc-mongodb
+ * ========================================================================
+ * Copyright (C) 2010 - 2026 Red Gate Software Ltd
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.flywaydb.database.nc.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the configurable {@code mongosh} shell command / URL introduced for
+ * <a href="https://github.com/flyway/flyway/issues/4242">flyway/flyway#4242</a>.
+ */
+class MongoDBShellCommandTest {
+
+    @Test
+    void extensionDefaultsPreserveLegacyBehaviour() {
+        final MongoDBConfigurationExtension extension = new MongoDBConfigurationExtension();
+
+        assertEquals(List.of("mongosh"), extension.getShellCommand(),
+            "shellCommand must default to [\"mongosh\"] to keep host-PATH resolution working");
+        assertNull(extension.getShellUrl(),
+            "shellUrl must default to null so flyway.url is used unchanged");
+        assertEquals("mongodb", extension.getNamespace());
+    }
+
+    @Test
+    void environmentVariablesMapToNamespacedProperties() {
+        final MongoDBConfigurationExtension extension = new MongoDBConfigurationExtension();
+
+        assertEquals("flyway.mongodb.shellCommand",
+            extension.getConfigurationParameterFromEnvironmentVariable("FLYWAY_MONGODB_SHELL_COMMAND"));
+        assertEquals("flyway.mongodb.shellUrl",
+            extension.getConfigurationParameterFromEnvironmentVariable("FLYWAY_MONGODB_SHELL_URL"));
+        assertNull(extension.getConfigurationParameterFromEnvironmentVariable("FLYWAY_SOMETHING_ELSE"));
+    }
+
+    @Test
+    void defaultShellCommandProducesBareMongoshInvocation() {
+        final MongoshCredential credential =
+            new MongoshCredential("mongodb://localhost:27017/test", null, null);
+
+        final List<String> commands =
+            MongoDBDatabase.buildMongoshConnectCommands(List.of("mongosh"), credential);
+
+        assertEquals(List.of("mongosh", "mongodb://localhost:27017/test"), commands);
+    }
+
+    @Test
+    void shellCommandPrefixAndShellUrlReachTheProcessBuilder() {
+        final List<String> shellCommand =
+            List.of("docker", "exec", "-i", "my-mongo-container", "mongosh");
+        final MongoshCredential credential =
+            new MongoshCredential("mongodb://localhost:27017/test", "user", "secret");
+
+        final List<String> commands =
+            MongoDBDatabase.buildMongoshConnectCommands(shellCommand, credential);
+
+        assertEquals(List.of(
+            "docker", "exec", "-i", "my-mongo-container", "mongosh",
+            "mongodb://localhost:27017/test",
+            "--username", "user",
+            "--password", "secret"), commands);
+    }
+
+    @Test
+    void credentialsAreOmittedWhenNotProvided() {
+        final MongoshCredential credential =
+            new MongoshCredential("mongodb://localhost:27017/test", "user", null);
+
+        final List<String> commands = MongoDBDatabase.buildMongoshConnectCommands(
+            List.of("kubectl", "exec", "-i", "mongo-0", "--", "mongosh"), credential);
+
+        assertEquals(List.of(
+            "kubectl", "exec", "-i", "mongo-0", "--", "mongosh",
+            "mongodb://localhost:27017/test",
+            "--username", "user"), commands);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4242.

MongoDB Native Connectors run `.js` migrations by shelling out to a hard-coded, bare `mongosh` resolved on the host `PATH`. There's no way to point Flyway at a `mongosh` located elsewhere — so when MongoDB runs in a container or on a remote host (Docker, Kubernetes, Dev Services), `mongosh` must *also* be installed on the Flyway host.

This adds a `mongodb` `ConfigurationExtension` with two options:

| Option | Type | Default | Purpose |
|---|---|---|---|
| `flyway.mongodb.shellCommand` | `List<String>` | `["mongosh"]` | The `mongosh` invocation as a command *prefix*, so it can be routed through a wrapper. |
| `flyway.mongodb.shellUrl` | `String` | `flyway.url` | URL passed to `mongosh` when it reaches MongoDB differently than the in-process driver (e.g. container vs. host port). |

Both are also exposed as env vars: `FLYWAY_MONGODB_SHELL_COMMAND`, `FLYWAY_MONGODB_SHELL_URL`.

### Example — `mongosh` inside a Docker container

```properties
flyway.mongodb.shellCommand=docker,exec,-i,my-mongo,mongosh
flyway.mongodb.shellUrl=mongodb://localhost:27017/mydb
```

(or `kubectl,exec,-i,mongo-0,--,mongosh` for Kubernetes).

### Backward compatibility

The defaults reproduce the exact current argv (`mongosh <url> [--username …] [--password …]`). Behavior is unchanged unless these options are set.

### Testing

- Unit tests in `MongoDBShellCommandTest` — defaults, env-var mapping, and command/URL assembly (including the `docker exec` / `kubectl exec` prefixes).
- Validated end-to-end downstream in the Quarkus `flyway-mongodb` extension: the full `.js` migration suite runs against a `mongo:7` container using the container's bundled `mongosh` via `docker exec`, with **no host `mongosh`** — [commit](https://github.com/quarkusio/quarkus/commit/57e35e72a7c2803fc92562d77e8cf27d207babf2), [branch](https://github.com/ozgliderpilot/quarkus/tree/ozgliderpilot/flyway-mongodb-testcontainers-tests).

### Note for review

`.js` migrations are executed as `mongosh --file <tmp>`, where `<tmp>` is written to the host temp dir. When `mongosh` runs in a container, that path must also be reachable inside it (the downstream tests bind-mount the temp dir). I'm happy to pipe the script via stdin instead if you'd prefer not to rely on a shared filesystem.

### Docs

Happy to add documentation for the new options — point me at the page(s) you'd like them on.
