### PR TITLE
Automatically use session-level PostgreSQL advisory lock for non-transactional migrations

### DIFF
--- a/documentation/Reference/Configuration/Flyway Namespace/Flyway PostgreSQL Namespace/Flyway PostgreSQL Transactional Lock Setting.md
+++ b/documentation/Reference/Configuration/Flyway Namespace/Flyway PostgreSQL Namespace/Flyway PostgreSQL Transactional Lock Setting.md
@@ -10,6 +10,10 @@ If false, session-level locks will be used instead.
 
 This should be set to `false` for statements such as `CREATE INDEX CONCURRENTLY`.
 
+Flyway also switches to a session-level lock automatically, without this setting, for any single migration
+(or, with `group` enabled, any migration batch) that declares `executeInTransaction=false` in its script
+configuration. This setting remains available to force session-level locking for every migration.
+
 ## Type
 
 Boolean

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/command/DbMigrate.java
@@ -102,7 +102,7 @@ public class DbMigrate {
             count = configuration.isGroup() ?
                 // When group is active, start the transaction boundary early to
                 // ensure that all changes to the schema history table are either committed or rolled back atomically.
-                schemaHistory.lock(this::migrateAll) :
+                schemaHistory.lock(this::migrateAll, nextPendingMigrationsRequireSessionLock()) :
                 // For all regular cases, proceed with the migration as usual.
                 migrateAll();
 
@@ -152,7 +152,7 @@ public class DbMigrate {
                 // With group active a lock on the schema history table has already been acquired.
                 ? migrateGroup(firstRun)
                 // Otherwise acquire the lock now. The lock will be released at the end of each migration.
-                : schemaHistory.lock(() -> migrateGroup(firstRun));
+                : schemaHistory.lock(() -> migrateGroup(firstRun), nextPendingMigrationsRequireSessionLock());
 
             migrateResult.migrationsExecuted += count;
             total += count;
@@ -170,6 +170,34 @@ public class DbMigrate {
         }
 
         return total;
+    }
+
+    /**
+     * Determines, without acquiring the schema history lock, whether the migration(s) about to be locked for
+     * require a session-scoped lock rather than a transactional one. With {@code group} disabled, the lock is
+     * re-acquired for each individual migration, so only the next pending migration matters. With {@code group}
+     * enabled, all pending migrations are applied under a single lock acquisition, so any one of them requiring
+     * non-transactional execution means the whole batch does too.
+     */
+    private boolean nextPendingMigrationsRequireSessionLock() {
+        final MigrationInfoServiceImpl infoService = new MigrationInfoServiceImpl(migrationResolver,
+            schemaHistory,
+            database,
+            configuration,
+            configuration.getTarget(),
+            configuration.isOutOfOrder(),
+            ValidatePatternUtils.getIgnoreAllPattern());
+        infoService.refresh();
+
+        final MigrationInfoImpl[] pending = infoService.pending();
+        if (pending.length == 0) {
+            return false;
+        }
+
+        return configuration.isGroup()
+            ? Arrays.stream(pending)
+                .anyMatch(migration -> !migration.getResolvedMigration().getExecutor().canExecuteInTransaction())
+            : !pending[0].getResolvedMigration().getExecutor().canExecuteInTransaction();
     }
 
     /**

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/Connection.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/base/Connection.java
@@ -106,6 +106,17 @@ public abstract class Connection<D extends Database> implements Closeable {
             database).execute(callable);
     }
 
+    /**
+     * Locks this table and executes this callable.
+     *
+     * @param preferSessionLock Whether a session-scoped lock should be used instead of a transactional one, when the
+     * database implementation supports the distinction. Ignored by implementations that don't.
+     * @return The result of the callable.
+     */
+    public <T> T lock(final Table table, final Callable<T> callable, final boolean preferSessionLock) {
+        return lock(table, callable);
+    }
+
     public final JdbcTemplate getJdbcTemplate() {
         return jdbcTemplate;
     }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/JdbcTableSchemaHistory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/JdbcTableSchemaHistory.java
@@ -172,9 +172,14 @@ class JdbcTableSchemaHistory extends SchemaHistory {
 
     @Override
     public <T> T lock(final Callable<T> callable) {
+        return lock(callable, false);
+    }
+
+    @Override
+    public <T> T lock(final Callable<T> callable, final boolean preferSessionLock) {
         connection.restoreOriginalState();
 
-        return connection.lock(table, callable);
+        return connection.lock(table, callable, preferSessionLock);
     }
 
     @Override

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/SchemaHistory.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/schemahistory/SchemaHistory.java
@@ -60,6 +60,18 @@ public abstract class SchemaHistory {
     public abstract <T> T lock(Callable<T> callable);
 
     /**
+     * Acquires an exclusive read-write lock on the schema history table. This lock will be released automatically upon
+     * completion.
+     *
+     * @param preferSessionLock Whether a session-scoped lock should be used instead of a transactional one, when the
+     * database implementation supports the distinction. Ignored by implementations that don't.
+     * @return The result of the action.
+     */
+    public <T> T lock(final Callable<T> callable, final boolean preferSessionLock) {
+        return lock(callable);
+    }
+
+    /**
      * @return Whether the schema history table exists.
      */
     public abstract boolean exists();

--- a/flyway-database/flyway-database-postgresql/src/main/java/org/flywaydb/database/postgresql/PostgreSQLAdvisoryLockTemplate.java
+++ b/flyway-database/flyway-database-postgresql/src/main/java/org/flywaydb/database/postgresql/PostgreSQLAdvisoryLockTemplate.java
@@ -55,10 +55,21 @@ public class PostgreSQLAdvisoryLockTemplate {
     }
 
     public <T> T execute(final Callable<T> callable) {
+        return execute(callable, false);
+    }
+
+    /**
+     * @param preferSessionLock When {@code true}, uses PostgreSQL's session-level advisory lock instead of the
+     * transactional one, regardless of the {@code postgresql.transactional.lock} configuration setting. Intended for
+     * migrations that declare {@code executeInTransaction=false} (e.g. {@code CREATE INDEX CONCURRENTLY}), since the
+     * transactional lock otherwise holds this connection's transaction open for the duration of the migration,
+     * causing PostgreSQL to wait on it as part of the non-transactional statement's own visibility snapshot.
+     */
+    public <T> T execute(final Callable<T> callable, final boolean preferSessionLock) {
         final PostgreSQLConfigurationExtension configurationExtension = configuration.getPluginRegister()
             .getExact(PostgreSQLConfigurationExtension.class);
 
-        if (configurationExtension.isTransactionalLock()) {
+        if (configurationExtension.isTransactionalLock() && !preferSessionLock) {
             return new TransactionalExecutionTemplate(jdbcTemplate.getConnection(),
                 true).execute(() -> execute(callable, this::tryLockTransactional));
         } else {

--- a/flyway-database/flyway-database-postgresql/src/main/java/org/flywaydb/database/postgresql/PostgreSQLConnection.java
+++ b/flyway-database/flyway-database-postgresql/src/main/java/org/flywaydb/database/postgresql/PostgreSQLConnection.java
@@ -103,9 +103,14 @@ public class PostgreSQLConnection extends Connection<PostgreSQLDatabase> {
 
     @Override
     public <T> T lock(final Table table, final Callable<T> callable) {
+        return lock(table, callable, false);
+    }
+
+    @Override
+    public <T> T lock(final Table table, final Callable<T> callable, final boolean preferSessionLock) {
         return new PostgreSQLAdvisoryLockTemplate(database.getConfiguration(),
             jdbcTemplate,
-            table.toString().hashCode()).execute(callable);
+            table.toString().hashCode()).execute(callable, preferSessionLock);
     }
 
     private boolean rdsAdminExists() {


### PR DESCRIPTION
## Problem

Migrations that declare `executeInTransaction=false` (e.g. `CREATE INDEX CONCURRENTLY`) still acquire Flyway's default *transactional* advisory lock, which holds this connection's own transaction open for the duration of the migration. PostgreSQL then waits on that open transaction as part of the non-transactional statement's own visibility snapshot — Flyway deadlocks against itself.

The documented workaround is `postgresql.transactional.lock=false`, but that's a global setting — it changes locking behavior for *every* migration, not just the one that needs it. There is no way to scope it per migration via script configuration: `SqlScriptMetadata` only recognizes `executeInTransaction`, `encoding`, `placeholderReplacement`, and `shouldExecute`. Other users have hit exactly this and asked for finer scoping without a resolution: #3492, #3500.

## Fix

With `group` disabled (the default), `DbMigrate` already re-acquires the schema history lock separately for each individual migration in its loop — the lock's scope is already effectively per-migration at the call site. The only thing preventing scoping is that `PostgreSQLAdvisoryLockTemplate` decides lock strategy purely from the global config, without knowing which migration is about to run.

This threads a `preferSessionLock` hint through `Connection.lock`/`SchemaHistory.lock`, computed by peeking at the next pending migration's already-resolved `executeInTransaction` value *before* acquiring the lock (a read-only check, no lock needed). When that value is `false`, `PostgreSQLAdvisoryLockTemplate` uses the session-level advisory lock for that one acquisition, regardless of the global setting. With `group` enabled, the whole batch runs under a single lock acquisition, so the hint checks whether any migration in that batch requires it.

The existing `postgresql.transactional.lock=false` setting is untouched and still works for anyone who wants to force session-level locking for every migration.

## Compatibility

- Every other `Connection` implementation inherits a default no-op override of the new `lock(Table, Callable, boolean)` overload — this is source- and behavior-compatible for every database besides PostgreSQL.
- No change in behavior unless a migration declares `executeInTransaction=false`.
- Documentation for `flyway.postgresql.transactional.lock` updated to describe the new automatic behavior.

## Testing

I wasn't able to locate a test source tree in this public checkout (`flyway-core` and `flyway-database-postgresql` appear to ship without `src/test`), so I can't add or run a test within this repo structure. I did verify the fix's premise against a real production incident: forcing the transactional lock and running `CREATE INDEX CONCURRENTLY` reproduced the self-deadlock (confirmed via `pg_stat_activity`/`pg_locks` — the lock-holder connection sat `idle in transaction` while the index build waited on it), and disabling the transactional lock for that migration alone resolved it. `flyway-core` and `flyway-database-postgresql` compile cleanly against this change (`mvn -pl flyway-core,flyway-database/flyway-database-postgresql -am compile`).

Happy to add tests if pointed at the right harness, or to adjust the approach if there's a different mechanism you'd prefer for surfacing this hint.
