### PR TITLE
#4233 - fix tablespace clause

### DIFF
--- a/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
+++ b/flyway-database/flyway-database-db2/src/main/java/org/flywaydb/database/db2/DB2Database.java
@@ -54,7 +54,7 @@ public class DB2Database extends Database<DB2Connection> {
     public String getRawCreateScript(final Table table, final boolean baseline) {
         final String tablespace = configuration.getTablespace() == null
             ? ""
-            : " IN \"" + configuration.getTablespace() + "\"";
+            : " IN \"" + configuration.getTablespace() + "\" INDEX IN \"" + configuration.getTablespace() + "\"";
 
         return "CREATE TABLE "
             + table
@@ -88,7 +88,6 @@ public class DB2Database extends Database<DB2Connection> {
             + "_s_idx\" ON "
             + table
             + " (\"success\") "
-            + tablespace
             + ";"
             + (baseline ? getBaselineStatement(table) + ";\n" : "");
     }


### PR DESCRIPTION
Tablespace for indices must be specified in the create-table statement.
See the[tablespace clauses](https://www.ibm.com/docs/en/db2/11.5.x?topic=statements-create-table#sdx-synid_tablespace-clauses) of the create-table syntax diagram.
